### PR TITLE
Fix Y range calculation when switching presets

### DIFF
--- a/crates/config-system/src/presets/candle_presets.rs
+++ b/crates/config-system/src/presets/candle_presets.rs
@@ -13,15 +13,11 @@ pub fn create_candle_presets() -> ChartPreset {
 fn candlestick_preset() -> ChartPreset {
     ChartPreset {
         name: "Candlestick".to_string(),
-        description: "Standard OHLC candlestick chart".to_string(),
+        description: "OHLC candlestick chart aggregated from trades".to_string(),
         chart_types: vec![RenderPreset {
             render_type: RenderType::Candlestick,
-            data_columns: vec![
-                ("ohlc".to_string(), "open".to_string()),
-                ("ohlc".to_string(), "high".to_string()),
-                ("ohlc".to_string(), "low".to_string()),
-                ("ohlc".to_string(), "close".to_string()),
-            ],
+            // The candlestick renderer will aggregate trades data into OHLC
+            data_columns: vec![("TRADES".to_string(), "price".to_string())],
             additional_data_columns: None,
             visible: true,
             label: "OHLC".to_string(),
@@ -30,7 +26,7 @@ fn candlestick_preset() -> ChartPreset {
                 color_options: None,
                 size: 0.8, // Body width relative to time interval
             },
-            compute_op: None,
+            compute_op: None, // OHLC aggregation is done by the renderer itself
         }],
     }
 }
@@ -50,6 +46,6 @@ mod tests {
         let preset = candlestick_preset();
         assert_eq!(preset.chart_types.len(), 1);
         assert_eq!(preset.chart_types[0].render_type, RenderType::Candlestick);
-        assert_eq!(preset.chart_types[0].data_columns.len(), 4); // OHLC
+        assert_eq!(preset.chart_types[0].data_columns.len(), 1); // price from TRADES
     }
 }

--- a/crates/data-manager/src/data_store.rs
+++ b/crates/data-manager/src/data_store.rs
@@ -105,12 +105,13 @@ impl DataStore {
 
     pub fn add_data_group(&mut self, x_series: (ArrayBuffer, Vec<Buffer>), set_as_active: bool) {
         let f: Uint32Array = Uint32Array::new(&x_series.0);
+        let length = f.length();
 
         self.data_groups.push(DataSeries {
             x_buffers: x_series.1,
             x_raw: x_series.0,
             metrics: Vec::new(),
-            length: f.length(),
+            length,
         });
 
         if set_as_active {
@@ -132,10 +133,21 @@ impl DataStore {
         color: [f32; 3],
         name: String,
     ) {
+        self.add_metric_to_group_with_visibility(group_index, y_series, color, name, true);
+    }
+    
+    pub fn add_metric_to_group_with_visibility(
+        &mut self,
+        group_index: usize,
+        y_series: (ArrayBuffer, Vec<Buffer>),
+        color: [f32; 3],
+        name: String,
+        visible: bool,
+    ) {
         if let Some(data_group) = self.data_groups.get_mut(group_index) {
-            data_group
-                .metrics
-                .push(MetricSeries::new(y_series.1, y_series.0, color, name));
+            let mut metric = MetricSeries::new(y_series.1, y_series.0, color, name);
+            metric.visible = visible;
+            data_group.metrics.push(metric);
         }
 
         self.mark_dirty();
@@ -150,13 +162,35 @@ impl DataStore {
         compute_type: ComputeOp,
         dependencies: Vec<MetricRef>,
     ) {
+        self.add_computed_metric_to_group_with_visibility(
+            group_index,
+            name,
+            color,
+            compute_type,
+            dependencies,
+            true,
+        );
+    }
+    
+    /// Add a computed metric to a data group with visibility
+    pub fn add_computed_metric_to_group_with_visibility(
+        &mut self,
+        group_index: usize,
+        name: String,
+        color: [f32; 3],
+        compute_type: ComputeOp,
+        dependencies: Vec<MetricRef>,
+        visible: bool,
+    ) {
         if let Some(data_group) = self.data_groups.get_mut(group_index) {
-            data_group.metrics.push(MetricSeries::new_computed(
+            let mut metric = MetricSeries::new_computed(
                 name,
                 color,
                 compute_type,
                 dependencies,
-            ));
+            );
+            metric.visible = visible;
+            data_group.metrics.push(metric);
         }
 
         self.mark_dirty();
@@ -174,11 +208,13 @@ impl DataStore {
     }
 
     pub fn get_data_len(&self) -> u32 {
-        self.get_active_data_groups()
+        let active_groups = self.get_active_data_groups();
+        let result = active_groups
             .iter()
             .map(|group| group.length)
             .max()
-            .unwrap_or(0)
+            .unwrap_or(0);
+        result
     }
 
     pub fn get_all_visible_metrics(&self) -> Vec<(&DataSeries, &MetricSeries)> {
@@ -536,12 +572,26 @@ impl DataStore {
         preset: Option<&ChartPreset>,
         symbol_name: Option<String>,
     ) {
+        // Check if preset is changing
+        let preset_changed = match (&self.preset, preset) {
+            (Some(current), Some(new)) => current.name != new.name,
+            (None, Some(_)) | (Some(_), None) => true,
+            (None, None) => false,
+        };
+        
         if let Some(p) = preset {
             self.preset = Some(p.clone());
         } else {
             self.preset = None;
         }
         self.symbol = symbol_name.clone();
+        
+        // Clear all data if preset changed to avoid mixing data from different presets
+        if preset_changed {
+            self.data_groups.clear();
+            self.active_data_group_indices.clear();
+            self.clear_gpu_bounds();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Fixed Y range calculation to only include visible metrics from the current preset
- Resolved issue where candlestick view was using incorrect Y range due to metrics from previous presets
- Improved preset switching behavior to clear old data and prevent data mixing

## Problem
When switching between Market Data and Candlestick presets, the Y range was being calculated incorrectly because:
1. All metrics were being created with `visible=true` regardless of preset settings
2. Data from previous presets was not cleared when switching
3. The Y range calculation included all visible metrics from all data groups

## Solution
1. **Respect preset visibility**: Added methods to create metrics with specified visibility based on preset configuration
2. **Clear data on preset change**: Modified `set_preset_and_symbol` to detect preset changes and clear all data groups
3. **Fix candlestick data**: Updated candlestick preset to use TRADES data instead of non-existent OHLC columns
4. **Automatic timeframe selection**: Implemented smart candlestick timeframe selection (target 300 candles)

## Changes
- Added `add_metric_to_group_with_visibility()` and `add_computed_metric_to_group_with_visibility()` methods
- Updated data loading to respect visibility settings from presets
- Clear GPU bounds and pending operations when switching presets
- Fixed candlestick preset configuration
- Cleaned up debug logging

## Test Plan
✅ Start with Market Data preset - verify only Mid price line is visible
✅ Switch to Candlestick preset - verify Y range adjusts to price data only
✅ Switch back to Market Data - verify Y range returns to Mid price range
✅ Candlesticks automatically select appropriate timeframe based on zoom level

🤖 Generated with [Claude Code](https://claude.ai/code)