### PR TITLE
fix: Only create data groups for visible chart types in comparison mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,6 +3491,7 @@ dependencies = [
  "tokio-test",
  "toml",
  "url",
+ "urlencoding",
 ]
 
 [[package]]

--- a/crates/data-manager/src/lib.rs
+++ b/crates/data-manager/src/lib.rs
@@ -71,14 +71,23 @@ impl DataManager {
             return Ok(handle);
         }
 
+        // Parse exchange from symbol if present (format: "exchange:SYMBOL" or just "SYMBOL")
+        let (exchange, base_symbol) = if symbol.contains(':') {
+            let parts: Vec<&str> = symbol.splitn(2, ':').collect();
+            (parts[0], parts[1])
+        } else {
+            ("coinbase", symbol) // Default to coinbase for backward compatibility
+        };
+        
         // Build the API URL with proper encoding
         let columns_str = columns.join(",");
-        let encoded_symbol = urlencoding::encode(symbol);
+        let encoded_symbol = urlencoding::encode(base_symbol);
         let encoded_columns = urlencoding::encode(&columns_str);
+        let encoded_exchange = urlencoding::encode(exchange);
 
         let url = format!(
-            "{}/api/data?symbol={}&type={}&start={}&end={}&columns={}&exchange=coinbase",
-            self.base_url, encoded_symbol, data_type, start_time, end_time, encoded_columns
+            "{}/api/data?symbol={}&type={}&start={}&end={}&columns={}&exchange={}",
+            self.base_url, encoded_symbol, data_type, start_time, end_time, encoded_columns, encoded_exchange
         );
 
         // Fetch from server

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,6 +24,7 @@ chrono = "0.4.41"
 tokio-stream ={ version = "0.1.17", features = ["fs"] }
 lru = "0.12"
 once_cell = "1.20"
+urlencoding = "2.1"
 
 [build-dependencies]
 toml = "0.8"

--- a/server/deploy-configs.sh
+++ b/server/deploy-configs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Deploy symbol configuration files to production server
+
+echo "Deploying symbol configuration files..."
+
+# Create config directory in Docker container if needed
+docker exec gpu-charts-server mkdir -p /opt/gpu-charts/configs 2>/dev/null || true
+
+# Copy config files to the container
+for config in server/src/symbols/configs/*.json; do
+    if [ -f "$config" ]; then
+        filename=$(basename "$config")
+        echo "Copying $filename..."
+        docker cp "$config" gpu-charts-server:/opt/gpu-charts/configs/
+    fi
+done
+
+echo "Configuration files deployed successfully!"
+echo ""
+echo "Testing symbol search endpoint..."
+curl -s "https://api.rednax.io/api/symbol-search?q=btc" | python3 -m json.tool | head -20 || echo "Test failed"

--- a/server/scripts/generate_symbol_configs.py
+++ b/server/scripts/generate_symbol_configs.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""
+Generate symbol configuration files for each exchange based on actual data directories.
+This script scans /mnt/md/data/{exchange}/ directories and creates JSON configs.
+"""
+
+import os
+import json
+import re
+from pathlib import Path
+
+# Base data directory
+DATA_DIR = "/mnt/md/data"
+CONFIG_DIR = "/home/xander/projects/gpu-charts/server/src/symbols/configs"
+
+def parse_symbol_parts(symbol, exchange):
+    """Parse symbol into base and quote currencies based on exchange format."""
+    
+    if exchange == "binance":
+        # Binance uses concatenated format like BTCUSDT, ETHUSDT
+        # Common quote currencies: USDT, USDC, BTC, ETH, BNB, BUSD, FDUSD, TRY, EUR, BRL, JPY
+        patterns = [
+            (r'^(.+)(USDT|USDC|BUSD|FDUSD)$', lambda m: (m.group(1), 'USD')),
+            (r'^(.+)(BTC|ETH|BNB)$', lambda m: (m.group(1), m.group(2))),
+            (r'^(.+)(EUR|GBP|AUD|CAD|JPY|TRY|BRL)$', lambda m: (m.group(1), m.group(2))),
+        ]
+        
+    elif exchange == "coinbase":
+        # Coinbase uses hyphenated format like BTC-USD, ETH-USD
+        if '-' in symbol:
+            parts = symbol.split('-')
+            if len(parts) == 2:
+                base, quote = parts
+                # Normalize USDT/USDC to USD for display
+                if quote in ['USDT', 'USDC']:
+                    return base, 'USD'
+                return base, quote
+                
+    elif exchange == "bitfinex":
+        # Bitfinex uses format like tBTCUSD, tETHUSD
+        if symbol.startswith('t'):
+            symbol = symbol[1:]  # Remove 't' prefix
+            # Handle special cases with colons
+            if ':' in symbol:
+                parts = symbol.split(':')
+                if len(parts) == 2:
+                    base = parts[0]
+                    quote = 'USD' if parts[1] in ['USD', 'UST'] else parts[1]
+                    return base, quote
+            # Standard format
+            patterns = [
+                (r'^(.+)(USD|UST|EUR|GBP|JPY|BTC|ETH)$', lambda m: (m.group(1), 'USD' if m.group(2) in ['USD', 'UST'] else m.group(2))),
+            ]
+            
+    elif exchange == "kraken":
+        # Kraken uses underscore format like XBT_USD, ETH_USD
+        if '_' in symbol:
+            parts = symbol.split('_')
+            if len(parts) == 2:
+                base, quote = parts
+                # Convert XBT to BTC for normalization
+                if base == 'XBT':
+                    base = 'BTC'
+                # Normalize USDT/USDC to USD
+                if quote in ['USDT', 'USDC']:
+                    return base, 'USD'
+                return base, quote
+                
+    elif exchange == "okx":
+        # OKX uses hyphenated format like BTC-USDT, ETH-USDT
+        if '-' in symbol:
+            parts = symbol.split('-')
+            if len(parts) == 2:
+                base, quote = parts
+                # Normalize USDT/USDC to USD
+                if quote in ['USDT', 'USDC']:
+                    return base, 'USD'
+                return base, quote
+    
+    # Try to match patterns for exchanges that use them
+    if exchange in ["binance", "bitfinex"]:
+        for pattern, extractor in patterns:
+            match = re.match(pattern, symbol, re.IGNORECASE)
+            if match:
+                return extractor(match)
+    
+    # Fallback: return as-is
+    return symbol, "UNKNOWN"
+
+def get_currency_name(symbol):
+    """Get full name for a currency symbol."""
+    names = {
+        'BTC': 'Bitcoin',
+        'ETH': 'Ethereum',
+        'BNB': 'Binance Coin',
+        'SOL': 'Solana',
+        'XRP': 'Ripple',
+        'ADA': 'Cardano',
+        'AVAX': 'Avalanche',
+        'DOGE': 'Dogecoin',
+        'DOT': 'Polkadot',
+        'MATIC': 'Polygon',
+        'LINK': 'Chainlink',
+        'UNI': 'Uniswap',
+        'LTC': 'Litecoin',
+        'BCH': 'Bitcoin Cash',
+        'ATOM': 'Cosmos',
+        'FIL': 'Filecoin',
+        'APT': 'Aptos',
+        'ARB': 'Arbitrum',
+        'OP': 'Optimism',
+        'NEAR': 'NEAR Protocol',
+        'ALGO': 'Algorand',
+        'ICP': 'Internet Computer',
+        'FTM': 'Fantom',
+        'XLM': 'Stellar',
+        'VET': 'VeChain',
+        'SAND': 'The Sandbox',
+        'MANA': 'Decentraland',
+        'AAVE': 'Aave',
+        'CRV': 'Curve',
+        'MKR': 'Maker',
+        'SNX': 'Synthetix',
+        'COMP': 'Compound',
+        'ENJ': 'Enjin',
+        'ZRX': '0x',
+        'BAT': 'Basic Attention Token',
+        'CHZ': 'Chiliz',
+        'GALA': 'Gala',
+        'AXS': 'Axie Infinity',
+        'FLOW': 'Flow',
+        'THETA': 'Theta',
+        'EOS': 'EOS',
+        'XTZ': 'Tezos',
+        'HBAR': 'Hedera',
+        'EGLD': 'MultiversX',
+        'QNT': 'Quant',
+        'TRX': 'TRON',
+        'TON': 'Toncoin',
+        'SUI': 'Sui',
+        'SEI': 'Sei',
+        'INJ': 'Injective',
+        'TIA': 'Celestia',
+        'JUP': 'Jupiter',
+        'PYTH': 'Pyth Network',
+        'BONK': 'Bonk',
+        'WIF': 'dogwifhat',
+        'PEPE': 'Pepe',
+        'SHIB': 'Shiba Inu',
+        'FLOKI': 'Floki',
+        # Quote currencies
+        'USD': 'US Dollar',
+        'EUR': 'Euro',
+        'GBP': 'British Pound',
+        'JPY': 'Japanese Yen',
+        'AUD': 'Australian Dollar',
+        'CAD': 'Canadian Dollar',
+        'CHF': 'Swiss Franc',
+        'TRY': 'Turkish Lira',
+        'BRL': 'Brazilian Real',
+        'USDT': 'Tether',
+        'USDC': 'USD Coin',
+        'BUSD': 'Binance USD',
+        'DAI': 'Dai',
+    }
+    return names.get(symbol.upper(), symbol)
+
+def get_tags_for_symbol(base, quote):
+    """Generate relevant tags for a trading pair."""
+    tags = []
+    
+    # Add base currency tags
+    base_lower = base.lower()
+    tags.append(base_lower)
+    
+    # Add full name as tag
+    base_name = get_currency_name(base)
+    if base_name != base:
+        tags.append(base_name.lower())
+    
+    # Category tags based on the asset
+    categories = {
+        'major': ['BTC', 'ETH', 'BNB'],
+        'defi': ['UNI', 'AAVE', 'CRV', 'MKR', 'SNX', 'COMP', 'SUSHI', 'YFI'],
+        'layer2': ['ARB', 'OP', 'MATIC', 'IMX', 'STRK'],
+        'layer1': ['SOL', 'AVAX', 'DOT', 'NEAR', 'ATOM', 'FTM', 'ALGO', 'HBAR'],
+        'meme': ['DOGE', 'SHIB', 'PEPE', 'FLOKI', 'BONK', 'WIF'],
+        'gaming': ['SAND', 'MANA', 'AXS', 'GALA', 'ENJ', 'IMX'],
+        'oracle': ['LINK', 'PYTH', 'API3', 'BAND'],
+        'storage': ['FIL', 'AR', 'STORJ'],
+        'privacy': ['XMR', 'ZEC', 'DASH'],
+        'exchange': ['BNB', 'FTT', 'OKB', 'CRO', 'KCS'],
+    }
+    
+    for category, symbols in categories.items():
+        if base.upper() in symbols:
+            tags.append(category)
+    
+    # Add quote currency tags
+    quote_lower = quote.lower()
+    tags.append(quote_lower)
+    
+    if quote in ['USD', 'USDT', 'USDC', 'BUSD', 'FDUSD']:
+        tags.append('usd')
+        if quote != 'USD':
+            tags.append('stablecoin')
+            tags.append('tether' if quote == 'USDT' else quote_lower)
+    elif quote in ['EUR', 'GBP', 'JPY', 'AUD', 'CAD']:
+        tags.append('fiat')
+        tags.append(get_currency_name(quote).lower())
+    
+    # Remove duplicates while preserving order
+    seen = set()
+    unique_tags = []
+    for tag in tags:
+        if tag not in seen:
+            seen.add(tag)
+            unique_tags.append(tag)
+    
+    return unique_tags
+
+def determine_category(base):
+    """Determine the category for an asset."""
+    # Most assets are crypto
+    fiat = ['USD', 'EUR', 'GBP', 'JPY', 'AUD', 'CAD', 'CHF', 'TRY', 'BRL']
+    commodities = ['XAU', 'XAG', 'OIL']
+    
+    if base.upper() in fiat:
+        return 'forex'
+    elif base.upper() in commodities:
+        return 'commodity'
+    else:
+        return 'crypto'
+
+def generate_config_for_exchange(exchange):
+    """Generate configuration for a specific exchange."""
+    exchange_dir = Path(DATA_DIR) / exchange
+    
+    if not exchange_dir.exists():
+        print(f"Directory {exchange_dir} does not exist")
+        return {}
+    
+    config = {}
+    symbols = sorted([d.name for d in exchange_dir.iterdir() if d.is_dir()])
+    
+    print(f"\nProcessing {exchange}: {len(symbols)} symbols")
+    
+    for symbol in symbols:
+        base, quote = parse_symbol_parts(symbol, exchange)
+        
+        if quote == "UNKNOWN":
+            print(f"  Warning: Could not parse {symbol}")
+            continue
+        
+        # Create normalized ID
+        normalized_id = f"{base}/{quote}"
+        
+        # Get display names
+        base_name = get_currency_name(base)
+        quote_name = get_currency_name(quote)
+        
+        # Generate metadata
+        config[symbol] = {
+            "normalized_id": normalized_id,
+            "base": base,
+            "quote": quote,
+            "display_name": f"{base_name} / {quote_name}",
+            "description": f"{base_name} to {quote_name} {'spot' if determine_category(base) == 'crypto' else ''} trading pair".strip(),
+            "tags": get_tags_for_symbol(base, quote),
+            "category": determine_category(base)
+        }
+    
+    return config
+
+def main():
+    """Main function to generate all exchange configs."""
+    exchanges = ['binance', 'coinbase', 'bitfinex', 'kraken', 'okx']
+    
+    # Create config directory if it doesn't exist
+    Path(CONFIG_DIR).mkdir(parents=True, exist_ok=True)
+    
+    for exchange in exchanges:
+        print(f"\n{'='*50}")
+        print(f"Generating config for {exchange}")
+        print(f"{'='*50}")
+        
+        config = generate_config_for_exchange(exchange)
+        
+        if config:
+            output_file = Path(CONFIG_DIR) / f"{exchange}.json"
+            with open(output_file, 'w') as f:
+                json.dump(config, f, indent=2)
+            print(f"✓ Saved {len(config)} symbols to {output_file}")
+        else:
+            print(f"✗ No symbols found for {exchange}")
+    
+    print(f"\n{'='*50}")
+    print("Configuration generation complete!")
+    print(f"{'='*50}")
+
+if __name__ == "__main__":
+    main()

--- a/server/src/symbols/configs/binance.json
+++ b/server/src/symbols/configs/binance.json
@@ -1,0 +1,17946 @@
+{
+  "1000CATBNB": {
+    "normalized_id": "1000CAT/BNB",
+    "base": "1000CAT",
+    "quote": "BNB",
+    "display_name": "1000CAT / Binance Coin",
+    "description": "1000CAT to Binance Coin spot trading pair",
+    "tags": [
+      "1000cat",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "1000CATFDUSD": {
+    "normalized_id": "1000CAT/USD",
+    "base": "1000CAT",
+    "quote": "USD",
+    "display_name": "1000CAT / US Dollar",
+    "description": "1000CAT to US Dollar spot trading pair",
+    "tags": [
+      "1000cat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "1000CATTRY": {
+    "normalized_id": "1000CAT/TRY",
+    "base": "1000CAT",
+    "quote": "TRY",
+    "display_name": "1000CAT / Turkish Lira",
+    "description": "1000CAT to Turkish Lira spot trading pair",
+    "tags": [
+      "1000cat",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "1000CATUSDC": {
+    "normalized_id": "1000CAT/USD",
+    "base": "1000CAT",
+    "quote": "USD",
+    "display_name": "1000CAT / US Dollar",
+    "description": "1000CAT to US Dollar spot trading pair",
+    "tags": [
+      "1000cat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "1000CATUSDT": {
+    "normalized_id": "1000CAT/USD",
+    "base": "1000CAT",
+    "quote": "USD",
+    "display_name": "1000CAT / US Dollar",
+    "description": "1000CAT to US Dollar spot trading pair",
+    "tags": [
+      "1000cat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "1000CHEEMSUSDC": {
+    "normalized_id": "1000CHEEMS/USD",
+    "base": "1000CHEEMS",
+    "quote": "USD",
+    "display_name": "1000CHEEMS / US Dollar",
+    "description": "1000CHEEMS to US Dollar spot trading pair",
+    "tags": [
+      "1000cheems",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "1000CHEEMSUSDT": {
+    "normalized_id": "1000CHEEMS/USD",
+    "base": "1000CHEEMS",
+    "quote": "USD",
+    "display_name": "1000CHEEMS / US Dollar",
+    "description": "1000CHEEMS to US Dollar spot trading pair",
+    "tags": [
+      "1000cheems",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "1000SATSFDUSD": {
+    "normalized_id": "1000SATS/USD",
+    "base": "1000SATS",
+    "quote": "USD",
+    "display_name": "1000SATS / US Dollar",
+    "description": "1000SATS to US Dollar spot trading pair",
+    "tags": [
+      "1000sats",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "1000SATSTRY": {
+    "normalized_id": "1000SATS/TRY",
+    "base": "1000SATS",
+    "quote": "TRY",
+    "display_name": "1000SATS / Turkish Lira",
+    "description": "1000SATS to Turkish Lira spot trading pair",
+    "tags": [
+      "1000sats",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "1000SATSUSDC": {
+    "normalized_id": "1000SATS/USD",
+    "base": "1000SATS",
+    "quote": "USD",
+    "display_name": "1000SATS / US Dollar",
+    "description": "1000SATS to US Dollar spot trading pair",
+    "tags": [
+      "1000sats",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "1000SATSUSDT": {
+    "normalized_id": "1000SATS/USD",
+    "base": "1000SATS",
+    "quote": "USD",
+    "display_name": "1000SATS / US Dollar",
+    "description": "1000SATS to US Dollar spot trading pair",
+    "tags": [
+      "1000sats",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "1INCHBTC": {
+    "normalized_id": "1INCH/BTC",
+    "base": "1INCH",
+    "quote": "BTC",
+    "display_name": "1INCH / Bitcoin",
+    "description": "1INCH to Bitcoin spot trading pair",
+    "tags": [
+      "1inch",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "1INCHUSDT": {
+    "normalized_id": "1INCH/USD",
+    "base": "1INCH",
+    "quote": "USD",
+    "display_name": "1INCH / US Dollar",
+    "description": "1INCH to US Dollar spot trading pair",
+    "tags": [
+      "1inch",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "1MBABYDOGEFDUSD": {
+    "normalized_id": "1MBABYDOGE/USD",
+    "base": "1MBABYDOGE",
+    "quote": "USD",
+    "display_name": "1MBABYDOGE / US Dollar",
+    "description": "1MBABYDOGE to US Dollar spot trading pair",
+    "tags": [
+      "1mbabydoge",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "1MBABYDOGETRY": {
+    "normalized_id": "1MBABYDOGE/TRY",
+    "base": "1MBABYDOGE",
+    "quote": "TRY",
+    "display_name": "1MBABYDOGE / Turkish Lira",
+    "description": "1MBABYDOGE to Turkish Lira spot trading pair",
+    "tags": [
+      "1mbabydoge",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "1MBABYDOGEUSDC": {
+    "normalized_id": "1MBABYDOGE/USD",
+    "base": "1MBABYDOGE",
+    "quote": "USD",
+    "display_name": "1MBABYDOGE / US Dollar",
+    "description": "1MBABYDOGE to US Dollar spot trading pair",
+    "tags": [
+      "1mbabydoge",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "1MBABYDOGEUSDT": {
+    "normalized_id": "1MBABYDOGE/USD",
+    "base": "1MBABYDOGE",
+    "quote": "USD",
+    "display_name": "1MBABYDOGE / US Dollar",
+    "description": "1MBABYDOGE to US Dollar spot trading pair",
+    "tags": [
+      "1mbabydoge",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "A2ZUSDT": {
+    "normalized_id": "A2Z/USD",
+    "base": "A2Z",
+    "quote": "USD",
+    "display_name": "A2Z / US Dollar",
+    "description": "A2Z to US Dollar spot trading pair",
+    "tags": [
+      "a2z",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AAVEBTC": {
+    "normalized_id": "AAVE/BTC",
+    "base": "AAVE",
+    "quote": "BTC",
+    "display_name": "Aave / Bitcoin",
+    "description": "Aave to Bitcoin spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "AAVEETH": {
+    "normalized_id": "AAVE/ETH",
+    "base": "AAVE",
+    "quote": "ETH",
+    "display_name": "Aave / Ethereum",
+    "description": "Aave to Ethereum spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "AAVEFDUSD": {
+    "normalized_id": "AAVE/USD",
+    "base": "AAVE",
+    "quote": "USD",
+    "display_name": "Aave / US Dollar",
+    "description": "Aave to US Dollar spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AAVETRY": {
+    "normalized_id": "AAVE/TRY",
+    "base": "AAVE",
+    "quote": "TRY",
+    "display_name": "Aave / Turkish Lira",
+    "description": "Aave to Turkish Lira spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "AAVEUSDC": {
+    "normalized_id": "AAVE/USD",
+    "base": "AAVE",
+    "quote": "USD",
+    "display_name": "Aave / US Dollar",
+    "description": "Aave to US Dollar spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AAVEUSDT": {
+    "normalized_id": "AAVE/USD",
+    "base": "AAVE",
+    "quote": "USD",
+    "display_name": "Aave / US Dollar",
+    "description": "Aave to US Dollar spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ABTC": {
+    "normalized_id": "A/BTC",
+    "base": "A",
+    "quote": "BTC",
+    "display_name": "A / Bitcoin",
+    "description": "A to Bitcoin spot trading pair",
+    "tags": [
+      "a",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ACATRY": {
+    "normalized_id": "ACA/TRY",
+    "base": "ACA",
+    "quote": "TRY",
+    "display_name": "ACA / Turkish Lira",
+    "description": "ACA to Turkish Lira spot trading pair",
+    "tags": [
+      "aca",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ACAUSDT": {
+    "normalized_id": "ACA/USD",
+    "base": "ACA",
+    "quote": "USD",
+    "display_name": "ACA / US Dollar",
+    "description": "ACA to US Dollar spot trading pair",
+    "tags": [
+      "aca",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACETRY": {
+    "normalized_id": "ACE/TRY",
+    "base": "ACE",
+    "quote": "TRY",
+    "display_name": "ACE / Turkish Lira",
+    "description": "ACE to Turkish Lira spot trading pair",
+    "tags": [
+      "ace",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ACEUSDT": {
+    "normalized_id": "ACE/USD",
+    "base": "ACE",
+    "quote": "USD",
+    "display_name": "ACE / US Dollar",
+    "description": "ACE to US Dollar spot trading pair",
+    "tags": [
+      "ace",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACHTRY": {
+    "normalized_id": "ACH/TRY",
+    "base": "ACH",
+    "quote": "TRY",
+    "display_name": "ACH / Turkish Lira",
+    "description": "ACH to Turkish Lira spot trading pair",
+    "tags": [
+      "ach",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ACHUSDC": {
+    "normalized_id": "ACH/USD",
+    "base": "ACH",
+    "quote": "USD",
+    "display_name": "ACH / US Dollar",
+    "description": "ACH to US Dollar spot trading pair",
+    "tags": [
+      "ach",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACHUSDT": {
+    "normalized_id": "ACH/USD",
+    "base": "ACH",
+    "quote": "USD",
+    "display_name": "ACH / US Dollar",
+    "description": "ACH to US Dollar spot trading pair",
+    "tags": [
+      "ach",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACMUSDT": {
+    "normalized_id": "ACM/USD",
+    "base": "ACM",
+    "quote": "USD",
+    "display_name": "ACM / US Dollar",
+    "description": "ACM to US Dollar spot trading pair",
+    "tags": [
+      "acm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACTFDUSD": {
+    "normalized_id": "ACT/USD",
+    "base": "ACT",
+    "quote": "USD",
+    "display_name": "ACT / US Dollar",
+    "description": "ACT to US Dollar spot trading pair",
+    "tags": [
+      "act",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACTTRY": {
+    "normalized_id": "ACT/TRY",
+    "base": "ACT",
+    "quote": "TRY",
+    "display_name": "ACT / Turkish Lira",
+    "description": "ACT to Turkish Lira spot trading pair",
+    "tags": [
+      "act",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ACTUSDC": {
+    "normalized_id": "ACT/USD",
+    "base": "ACT",
+    "quote": "USD",
+    "display_name": "ACT / US Dollar",
+    "description": "ACT to US Dollar spot trading pair",
+    "tags": [
+      "act",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACTUSDT": {
+    "normalized_id": "ACT/USD",
+    "base": "ACT",
+    "quote": "USD",
+    "display_name": "ACT / US Dollar",
+    "description": "ACT to US Dollar spot trading pair",
+    "tags": [
+      "act",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACXTRY": {
+    "normalized_id": "ACX/TRY",
+    "base": "ACX",
+    "quote": "TRY",
+    "display_name": "ACX / Turkish Lira",
+    "description": "ACX to Turkish Lira spot trading pair",
+    "tags": [
+      "acx",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ACXUSDC": {
+    "normalized_id": "ACX/USD",
+    "base": "ACX",
+    "quote": "USD",
+    "display_name": "ACX / US Dollar",
+    "description": "ACX to US Dollar spot trading pair",
+    "tags": [
+      "acx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACXUSDT": {
+    "normalized_id": "ACX/USD",
+    "base": "ACX",
+    "quote": "USD",
+    "display_name": "ACX / US Dollar",
+    "description": "ACX to US Dollar spot trading pair",
+    "tags": [
+      "acx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ADABNB": {
+    "normalized_id": "ADA/BNB",
+    "base": "ADA",
+    "quote": "BNB",
+    "display_name": "Cardano / Binance Coin",
+    "description": "Cardano to Binance Coin spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "ADABRL": {
+    "normalized_id": "ADA/BRL",
+    "base": "ADA",
+    "quote": "BRL",
+    "display_name": "Cardano / Brazilian Real",
+    "description": "Cardano to Brazilian Real spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "ADABTC": {
+    "normalized_id": "ADA/BTC",
+    "base": "ADA",
+    "quote": "BTC",
+    "display_name": "Cardano / Bitcoin",
+    "description": "Cardano to Bitcoin spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ADAETH": {
+    "normalized_id": "ADA/ETH",
+    "base": "ADA",
+    "quote": "ETH",
+    "display_name": "Cardano / Ethereum",
+    "description": "Cardano to Ethereum spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "ADAEUR": {
+    "normalized_id": "ADA/EUR",
+    "base": "ADA",
+    "quote": "EUR",
+    "display_name": "Cardano / Euro",
+    "description": "Cardano to Euro spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ADAFDUSD": {
+    "normalized_id": "ADA/USD",
+    "base": "ADA",
+    "quote": "USD",
+    "display_name": "Cardano / US Dollar",
+    "description": "Cardano to US Dollar spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ADAJPY": {
+    "normalized_id": "ADA/JPY",
+    "base": "ADA",
+    "quote": "JPY",
+    "display_name": "Cardano / Japanese Yen",
+    "description": "Cardano to Japanese Yen spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "ADATRY": {
+    "normalized_id": "ADA/TRY",
+    "base": "ADA",
+    "quote": "TRY",
+    "display_name": "Cardano / Turkish Lira",
+    "description": "Cardano to Turkish Lira spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ADAUSDC": {
+    "normalized_id": "ADA/USD",
+    "base": "ADA",
+    "quote": "USD",
+    "display_name": "Cardano / US Dollar",
+    "description": "Cardano to US Dollar spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ADAUSDT": {
+    "normalized_id": "ADA/USD",
+    "base": "ADA",
+    "quote": "USD",
+    "display_name": "Cardano / US Dollar",
+    "description": "Cardano to US Dollar spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ADXBTC": {
+    "normalized_id": "ADX/BTC",
+    "base": "ADX",
+    "quote": "BTC",
+    "display_name": "ADX / Bitcoin",
+    "description": "ADX to Bitcoin spot trading pair",
+    "tags": [
+      "adx",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ADXETH": {
+    "normalized_id": "ADX/ETH",
+    "base": "ADX",
+    "quote": "ETH",
+    "display_name": "ADX / Ethereum",
+    "description": "ADX to Ethereum spot trading pair",
+    "tags": [
+      "adx",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "ADXUSDT": {
+    "normalized_id": "ADX/USD",
+    "base": "ADX",
+    "quote": "USD",
+    "display_name": "ADX / US Dollar",
+    "description": "ADX to US Dollar spot trading pair",
+    "tags": [
+      "adx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AETH": {
+    "normalized_id": "A/ETH",
+    "base": "A",
+    "quote": "ETH",
+    "display_name": "A / Ethereum",
+    "description": "A to Ethereum spot trading pair",
+    "tags": [
+      "a",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "AEURUSDT": {
+    "normalized_id": "AEUR/USD",
+    "base": "AEUR",
+    "quote": "USD",
+    "display_name": "AEUR / US Dollar",
+    "description": "AEUR to US Dollar spot trading pair",
+    "tags": [
+      "aeur",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AEVOBTC": {
+    "normalized_id": "AEVO/BTC",
+    "base": "AEVO",
+    "quote": "BTC",
+    "display_name": "AEVO / Bitcoin",
+    "description": "AEVO to Bitcoin spot trading pair",
+    "tags": [
+      "aevo",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "AEVOFDUSD": {
+    "normalized_id": "AEVO/USD",
+    "base": "AEVO",
+    "quote": "USD",
+    "display_name": "AEVO / US Dollar",
+    "description": "AEVO to US Dollar spot trading pair",
+    "tags": [
+      "aevo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AEVOTRY": {
+    "normalized_id": "AEVO/TRY",
+    "base": "AEVO",
+    "quote": "TRY",
+    "display_name": "AEVO / Turkish Lira",
+    "description": "AEVO to Turkish Lira spot trading pair",
+    "tags": [
+      "aevo",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "AEVOUSDT": {
+    "normalized_id": "AEVO/USD",
+    "base": "AEVO",
+    "quote": "USD",
+    "display_name": "AEVO / US Dollar",
+    "description": "AEVO to US Dollar spot trading pair",
+    "tags": [
+      "aevo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AFDUSD": {
+    "normalized_id": "A/USD",
+    "base": "A",
+    "quote": "USD",
+    "display_name": "A / US Dollar",
+    "description": "A to US Dollar spot trading pair",
+    "tags": [
+      "a",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AGLDBTC": {
+    "normalized_id": "AGLD/BTC",
+    "base": "AGLD",
+    "quote": "BTC",
+    "display_name": "AGLD / Bitcoin",
+    "description": "AGLD to Bitcoin spot trading pair",
+    "tags": [
+      "agld",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "AGLDUSDT": {
+    "normalized_id": "AGLD/USD",
+    "base": "AGLD",
+    "quote": "USD",
+    "display_name": "AGLD / US Dollar",
+    "description": "AGLD to US Dollar spot trading pair",
+    "tags": [
+      "agld",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AIBNB": {
+    "normalized_id": "AI/BNB",
+    "base": "AI",
+    "quote": "BNB",
+    "display_name": "AI / Binance Coin",
+    "description": "AI to Binance Coin spot trading pair",
+    "tags": [
+      "ai",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "AIBTC": {
+    "normalized_id": "AI/BTC",
+    "base": "AI",
+    "quote": "BTC",
+    "display_name": "AI / Bitcoin",
+    "description": "AI to Bitcoin spot trading pair",
+    "tags": [
+      "ai",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "AIFDUSD": {
+    "normalized_id": "AI/USD",
+    "base": "AI",
+    "quote": "USD",
+    "display_name": "AI / US Dollar",
+    "description": "AI to US Dollar spot trading pair",
+    "tags": [
+      "ai",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AITRY": {
+    "normalized_id": "AI/TRY",
+    "base": "AI",
+    "quote": "TRY",
+    "display_name": "AI / Turkish Lira",
+    "description": "AI to Turkish Lira spot trading pair",
+    "tags": [
+      "ai",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "AIUSDT": {
+    "normalized_id": "AI/USD",
+    "base": "AI",
+    "quote": "USD",
+    "display_name": "AI / US Dollar",
+    "description": "AI to US Dollar spot trading pair",
+    "tags": [
+      "ai",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AIXBTTRY": {
+    "normalized_id": "AIXBT/TRY",
+    "base": "AIXBT",
+    "quote": "TRY",
+    "display_name": "AIXBT / Turkish Lira",
+    "description": "AIXBT to Turkish Lira spot trading pair",
+    "tags": [
+      "aixbt",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "AIXBTUSDC": {
+    "normalized_id": "AIXBT/USD",
+    "base": "AIXBT",
+    "quote": "USD",
+    "display_name": "AIXBT / US Dollar",
+    "description": "AIXBT to US Dollar spot trading pair",
+    "tags": [
+      "aixbt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AIXBTUSDT": {
+    "normalized_id": "AIXBT/USD",
+    "base": "AIXBT",
+    "quote": "USD",
+    "display_name": "AIXBT / US Dollar",
+    "description": "AIXBT to US Dollar spot trading pair",
+    "tags": [
+      "aixbt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALCXUSDT": {
+    "normalized_id": "ALCX/USD",
+    "base": "ALCX",
+    "quote": "USD",
+    "display_name": "ALCX / US Dollar",
+    "description": "ALCX to US Dollar spot trading pair",
+    "tags": [
+      "alcx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALGOBTC": {
+    "normalized_id": "ALGO/BTC",
+    "base": "ALGO",
+    "quote": "BTC",
+    "display_name": "Algorand / Bitcoin",
+    "description": "Algorand to Bitcoin spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ALGOTRY": {
+    "normalized_id": "ALGO/TRY",
+    "base": "ALGO",
+    "quote": "TRY",
+    "display_name": "Algorand / Turkish Lira",
+    "description": "Algorand to Turkish Lira spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ALGOUSDC": {
+    "normalized_id": "ALGO/USD",
+    "base": "ALGO",
+    "quote": "USD",
+    "display_name": "Algorand / US Dollar",
+    "description": "Algorand to US Dollar spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALGOUSDT": {
+    "normalized_id": "ALGO/USD",
+    "base": "ALGO",
+    "quote": "USD",
+    "display_name": "Algorand / US Dollar",
+    "description": "Algorand to US Dollar spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALICETRY": {
+    "normalized_id": "ALICE/TRY",
+    "base": "ALICE",
+    "quote": "TRY",
+    "display_name": "ALICE / Turkish Lira",
+    "description": "ALICE to Turkish Lira spot trading pair",
+    "tags": [
+      "alice",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ALICEUSDT": {
+    "normalized_id": "ALICE/USD",
+    "base": "ALICE",
+    "quote": "USD",
+    "display_name": "ALICE / US Dollar",
+    "description": "ALICE to US Dollar spot trading pair",
+    "tags": [
+      "alice",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALPINETRY": {
+    "normalized_id": "ALPINE/TRY",
+    "base": "ALPINE",
+    "quote": "TRY",
+    "display_name": "ALPINE / Turkish Lira",
+    "description": "ALPINE to Turkish Lira spot trading pair",
+    "tags": [
+      "alpine",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ALPINEUSDT": {
+    "normalized_id": "ALPINE/USD",
+    "base": "ALPINE",
+    "quote": "USD",
+    "display_name": "ALPINE / US Dollar",
+    "description": "ALPINE to US Dollar spot trading pair",
+    "tags": [
+      "alpine",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALTBNB": {
+    "normalized_id": "ALT/BNB",
+    "base": "ALT",
+    "quote": "BNB",
+    "display_name": "ALT / Binance Coin",
+    "description": "ALT to Binance Coin spot trading pair",
+    "tags": [
+      "alt",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "ALTBTC": {
+    "normalized_id": "ALT/BTC",
+    "base": "ALT",
+    "quote": "BTC",
+    "display_name": "ALT / Bitcoin",
+    "description": "ALT to Bitcoin spot trading pair",
+    "tags": [
+      "alt",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ALTFDUSD": {
+    "normalized_id": "ALT/USD",
+    "base": "ALT",
+    "quote": "USD",
+    "display_name": "ALT / US Dollar",
+    "description": "ALT to US Dollar spot trading pair",
+    "tags": [
+      "alt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALTTRY": {
+    "normalized_id": "ALT/TRY",
+    "base": "ALT",
+    "quote": "TRY",
+    "display_name": "ALT / Turkish Lira",
+    "description": "ALT to Turkish Lira spot trading pair",
+    "tags": [
+      "alt",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ALTUSDC": {
+    "normalized_id": "ALT/USD",
+    "base": "ALT",
+    "quote": "USD",
+    "display_name": "ALT / US Dollar",
+    "description": "ALT to US Dollar spot trading pair",
+    "tags": [
+      "alt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALTUSDT": {
+    "normalized_id": "ALT/USD",
+    "base": "ALT",
+    "quote": "USD",
+    "display_name": "ALT / US Dollar",
+    "description": "ALT to US Dollar spot trading pair",
+    "tags": [
+      "alt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AMPTRY": {
+    "normalized_id": "AMP/TRY",
+    "base": "AMP",
+    "quote": "TRY",
+    "display_name": "AMP / Turkish Lira",
+    "description": "AMP to Turkish Lira spot trading pair",
+    "tags": [
+      "amp",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "AMPUSDT": {
+    "normalized_id": "AMP/USD",
+    "base": "AMP",
+    "quote": "USD",
+    "display_name": "AMP / US Dollar",
+    "description": "AMP to US Dollar spot trading pair",
+    "tags": [
+      "amp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ANIMETRY": {
+    "normalized_id": "ANIME/TRY",
+    "base": "ANIME",
+    "quote": "TRY",
+    "display_name": "ANIME / Turkish Lira",
+    "description": "ANIME to Turkish Lira spot trading pair",
+    "tags": [
+      "anime",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ANIMEUSDC": {
+    "normalized_id": "ANIME/USD",
+    "base": "ANIME",
+    "quote": "USD",
+    "display_name": "ANIME / US Dollar",
+    "description": "ANIME to US Dollar spot trading pair",
+    "tags": [
+      "anime",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ANIMEUSDT": {
+    "normalized_id": "ANIME/USD",
+    "base": "ANIME",
+    "quote": "USD",
+    "display_name": "ANIME / US Dollar",
+    "description": "ANIME to US Dollar spot trading pair",
+    "tags": [
+      "anime",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ANKRBTC": {
+    "normalized_id": "ANKR/BTC",
+    "base": "ANKR",
+    "quote": "BTC",
+    "display_name": "ANKR / Bitcoin",
+    "description": "ANKR to Bitcoin spot trading pair",
+    "tags": [
+      "ankr",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ANKRTRY": {
+    "normalized_id": "ANKR/TRY",
+    "base": "ANKR",
+    "quote": "TRY",
+    "display_name": "ANKR / Turkish Lira",
+    "description": "ANKR to Turkish Lira spot trading pair",
+    "tags": [
+      "ankr",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ANKRUSDT": {
+    "normalized_id": "ANKR/USD",
+    "base": "ANKR",
+    "quote": "USD",
+    "display_name": "ANKR / US Dollar",
+    "description": "ANKR to US Dollar spot trading pair",
+    "tags": [
+      "ankr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APEBTC": {
+    "normalized_id": "APE/BTC",
+    "base": "APE",
+    "quote": "BTC",
+    "display_name": "APE / Bitcoin",
+    "description": "APE to Bitcoin spot trading pair",
+    "tags": [
+      "ape",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "APEFDUSD": {
+    "normalized_id": "APE/USD",
+    "base": "APE",
+    "quote": "USD",
+    "display_name": "APE / US Dollar",
+    "description": "APE to US Dollar spot trading pair",
+    "tags": [
+      "ape",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APETRY": {
+    "normalized_id": "APE/TRY",
+    "base": "APE",
+    "quote": "TRY",
+    "display_name": "APE / Turkish Lira",
+    "description": "APE to Turkish Lira spot trading pair",
+    "tags": [
+      "ape",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "APEUSDC": {
+    "normalized_id": "APE/USD",
+    "base": "APE",
+    "quote": "USD",
+    "display_name": "APE / US Dollar",
+    "description": "APE to US Dollar spot trading pair",
+    "tags": [
+      "ape",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APEUSDT": {
+    "normalized_id": "APE/USD",
+    "base": "APE",
+    "quote": "USD",
+    "display_name": "APE / US Dollar",
+    "description": "APE to US Dollar spot trading pair",
+    "tags": [
+      "ape",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "API3BTC": {
+    "normalized_id": "API3/BTC",
+    "base": "API3",
+    "quote": "BTC",
+    "display_name": "API3 / Bitcoin",
+    "description": "API3 to Bitcoin spot trading pair",
+    "tags": [
+      "api3",
+      "oracle",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "API3TRY": {
+    "normalized_id": "API3/TRY",
+    "base": "API3",
+    "quote": "TRY",
+    "display_name": "API3 / Turkish Lira",
+    "description": "API3 to Turkish Lira spot trading pair",
+    "tags": [
+      "api3",
+      "oracle",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "API3USDC": {
+    "normalized_id": "API3/USD",
+    "base": "API3",
+    "quote": "USD",
+    "display_name": "API3 / US Dollar",
+    "description": "API3 to US Dollar spot trading pair",
+    "tags": [
+      "api3",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "API3USDT": {
+    "normalized_id": "API3/USD",
+    "base": "API3",
+    "quote": "USD",
+    "display_name": "API3 / US Dollar",
+    "description": "API3 to US Dollar spot trading pair",
+    "tags": [
+      "api3",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APTBTC": {
+    "normalized_id": "APT/BTC",
+    "base": "APT",
+    "quote": "BTC",
+    "display_name": "Aptos / Bitcoin",
+    "description": "Aptos to Bitcoin spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "APTETH": {
+    "normalized_id": "APT/ETH",
+    "base": "APT",
+    "quote": "ETH",
+    "display_name": "Aptos / Ethereum",
+    "description": "Aptos to Ethereum spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "APTEUR": {
+    "normalized_id": "APT/EUR",
+    "base": "APT",
+    "quote": "EUR",
+    "display_name": "Aptos / Euro",
+    "description": "Aptos to Euro spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "APTFDUSD": {
+    "normalized_id": "APT/USD",
+    "base": "APT",
+    "quote": "USD",
+    "display_name": "Aptos / US Dollar",
+    "description": "Aptos to US Dollar spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APTJPY": {
+    "normalized_id": "APT/JPY",
+    "base": "APT",
+    "quote": "JPY",
+    "display_name": "Aptos / Japanese Yen",
+    "description": "Aptos to Japanese Yen spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "APTTRY": {
+    "normalized_id": "APT/TRY",
+    "base": "APT",
+    "quote": "TRY",
+    "display_name": "Aptos / Turkish Lira",
+    "description": "Aptos to Turkish Lira spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "APTUSDC": {
+    "normalized_id": "APT/USD",
+    "base": "APT",
+    "quote": "USD",
+    "display_name": "Aptos / US Dollar",
+    "description": "Aptos to US Dollar spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APTUSDT": {
+    "normalized_id": "APT/USD",
+    "base": "APT",
+    "quote": "USD",
+    "display_name": "Aptos / US Dollar",
+    "description": "Aptos to US Dollar spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARBBTC": {
+    "normalized_id": "ARB/BTC",
+    "base": "ARB",
+    "quote": "BTC",
+    "display_name": "Arbitrum / Bitcoin",
+    "description": "Arbitrum to Bitcoin spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ARBETH": {
+    "normalized_id": "ARB/ETH",
+    "base": "ARB",
+    "quote": "ETH",
+    "display_name": "Arbitrum / Ethereum",
+    "description": "Arbitrum to Ethereum spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "ARBEUR": {
+    "normalized_id": "ARB/EUR",
+    "base": "ARB",
+    "quote": "EUR",
+    "display_name": "Arbitrum / Euro",
+    "description": "Arbitrum to Euro spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ARBFDUSD": {
+    "normalized_id": "ARB/USD",
+    "base": "ARB",
+    "quote": "USD",
+    "display_name": "Arbitrum / US Dollar",
+    "description": "Arbitrum to US Dollar spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARBTC": {
+    "normalized_id": "AR/BTC",
+    "base": "AR",
+    "quote": "BTC",
+    "display_name": "AR / Bitcoin",
+    "description": "AR to Bitcoin spot trading pair",
+    "tags": [
+      "ar",
+      "storage",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ARBTRY": {
+    "normalized_id": "ARB/TRY",
+    "base": "ARB",
+    "quote": "TRY",
+    "display_name": "Arbitrum / Turkish Lira",
+    "description": "Arbitrum to Turkish Lira spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ARBUSDC": {
+    "normalized_id": "ARB/USD",
+    "base": "ARB",
+    "quote": "USD",
+    "display_name": "Arbitrum / US Dollar",
+    "description": "Arbitrum to US Dollar spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARBUSDT": {
+    "normalized_id": "ARB/USD",
+    "base": "ARB",
+    "quote": "USD",
+    "display_name": "Arbitrum / US Dollar",
+    "description": "Arbitrum to US Dollar spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARDRBTC": {
+    "normalized_id": "ARDR/BTC",
+    "base": "ARDR",
+    "quote": "BTC",
+    "display_name": "ARDR / Bitcoin",
+    "description": "ARDR to Bitcoin spot trading pair",
+    "tags": [
+      "ardr",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ARDRUSDT": {
+    "normalized_id": "ARDR/USD",
+    "base": "ARDR",
+    "quote": "USD",
+    "display_name": "ARDR / US Dollar",
+    "description": "ARDR to US Dollar spot trading pair",
+    "tags": [
+      "ardr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARFDUSD": {
+    "normalized_id": "AR/USD",
+    "base": "AR",
+    "quote": "USD",
+    "display_name": "AR / US Dollar",
+    "description": "AR to US Dollar spot trading pair",
+    "tags": [
+      "ar",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARKMBNB": {
+    "normalized_id": "ARKM/BNB",
+    "base": "ARKM",
+    "quote": "BNB",
+    "display_name": "ARKM / Binance Coin",
+    "description": "ARKM to Binance Coin spot trading pair",
+    "tags": [
+      "arkm",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "ARKMBTC": {
+    "normalized_id": "ARKM/BTC",
+    "base": "ARKM",
+    "quote": "BTC",
+    "display_name": "ARKM / Bitcoin",
+    "description": "ARKM to Bitcoin spot trading pair",
+    "tags": [
+      "arkm",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ARKMFDUSD": {
+    "normalized_id": "ARKM/USD",
+    "base": "ARKM",
+    "quote": "USD",
+    "display_name": "ARKM / US Dollar",
+    "description": "ARKM to US Dollar spot trading pair",
+    "tags": [
+      "arkm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARKMTRY": {
+    "normalized_id": "ARKM/TRY",
+    "base": "ARKM",
+    "quote": "TRY",
+    "display_name": "ARKM / Turkish Lira",
+    "description": "ARKM to Turkish Lira spot trading pair",
+    "tags": [
+      "arkm",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ARKMUSDC": {
+    "normalized_id": "ARKM/USD",
+    "base": "ARKM",
+    "quote": "USD",
+    "display_name": "ARKM / US Dollar",
+    "description": "ARKM to US Dollar spot trading pair",
+    "tags": [
+      "arkm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARKMUSDT": {
+    "normalized_id": "ARKM/USD",
+    "base": "ARKM",
+    "quote": "USD",
+    "display_name": "ARKM / US Dollar",
+    "description": "ARKM to US Dollar spot trading pair",
+    "tags": [
+      "arkm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARKTRY": {
+    "normalized_id": "ARK/TRY",
+    "base": "ARK",
+    "quote": "TRY",
+    "display_name": "ARK / Turkish Lira",
+    "description": "ARK to Turkish Lira spot trading pair",
+    "tags": [
+      "ark",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ARKUSDT": {
+    "normalized_id": "ARK/USD",
+    "base": "ARK",
+    "quote": "USD",
+    "display_name": "ARK / US Dollar",
+    "description": "ARK to US Dollar spot trading pair",
+    "tags": [
+      "ark",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARPABTC": {
+    "normalized_id": "ARPA/BTC",
+    "base": "ARPA",
+    "quote": "BTC",
+    "display_name": "ARPA / Bitcoin",
+    "description": "ARPA to Bitcoin spot trading pair",
+    "tags": [
+      "arpa",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ARPATRY": {
+    "normalized_id": "ARPA/TRY",
+    "base": "ARPA",
+    "quote": "TRY",
+    "display_name": "ARPA / Turkish Lira",
+    "description": "ARPA to Turkish Lira spot trading pair",
+    "tags": [
+      "arpa",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ARPAUSDT": {
+    "normalized_id": "ARPA/USD",
+    "base": "ARPA",
+    "quote": "USD",
+    "display_name": "ARPA / US Dollar",
+    "description": "ARPA to US Dollar spot trading pair",
+    "tags": [
+      "arpa",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARTRY": {
+    "normalized_id": "AR/TRY",
+    "base": "AR",
+    "quote": "TRY",
+    "display_name": "AR / Turkish Lira",
+    "description": "AR to Turkish Lira spot trading pair",
+    "tags": [
+      "ar",
+      "storage",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ARUSDC": {
+    "normalized_id": "AR/USD",
+    "base": "AR",
+    "quote": "USD",
+    "display_name": "AR / US Dollar",
+    "description": "AR to US Dollar spot trading pair",
+    "tags": [
+      "ar",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARUSDT": {
+    "normalized_id": "AR/USD",
+    "base": "AR",
+    "quote": "USD",
+    "display_name": "AR / US Dollar",
+    "description": "AR to US Dollar spot trading pair",
+    "tags": [
+      "ar",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ASRTRY": {
+    "normalized_id": "ASR/TRY",
+    "base": "ASR",
+    "quote": "TRY",
+    "display_name": "ASR / Turkish Lira",
+    "description": "ASR to Turkish Lira spot trading pair",
+    "tags": [
+      "asr",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ASRUSDT": {
+    "normalized_id": "ASR/USD",
+    "base": "ASR",
+    "quote": "USD",
+    "display_name": "ASR / US Dollar",
+    "description": "ASR to US Dollar spot trading pair",
+    "tags": [
+      "asr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ASTRBTC": {
+    "normalized_id": "ASTR/BTC",
+    "base": "ASTR",
+    "quote": "BTC",
+    "display_name": "ASTR / Bitcoin",
+    "description": "ASTR to Bitcoin spot trading pair",
+    "tags": [
+      "astr",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ASTRUSDT": {
+    "normalized_id": "ASTR/USD",
+    "base": "ASTR",
+    "quote": "USD",
+    "display_name": "ASTR / US Dollar",
+    "description": "ASTR to US Dollar spot trading pair",
+    "tags": [
+      "astr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATABTC": {
+    "normalized_id": "ATA/BTC",
+    "base": "ATA",
+    "quote": "BTC",
+    "display_name": "ATA / Bitcoin",
+    "description": "ATA to Bitcoin spot trading pair",
+    "tags": [
+      "ata",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ATAUSDT": {
+    "normalized_id": "ATA/USD",
+    "base": "ATA",
+    "quote": "USD",
+    "display_name": "ATA / US Dollar",
+    "description": "ATA to US Dollar spot trading pair",
+    "tags": [
+      "ata",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATMTRY": {
+    "normalized_id": "ATM/TRY",
+    "base": "ATM",
+    "quote": "TRY",
+    "display_name": "ATM / Turkish Lira",
+    "description": "ATM to Turkish Lira spot trading pair",
+    "tags": [
+      "atm",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ATMUSDT": {
+    "normalized_id": "ATM/USD",
+    "base": "ATM",
+    "quote": "USD",
+    "display_name": "ATM / US Dollar",
+    "description": "ATM to US Dollar spot trading pair",
+    "tags": [
+      "atm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATOMBTC": {
+    "normalized_id": "ATOM/BTC",
+    "base": "ATOM",
+    "quote": "BTC",
+    "display_name": "Cosmos / Bitcoin",
+    "description": "Cosmos to Bitcoin spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ATOMETH": {
+    "normalized_id": "ATOM/ETH",
+    "base": "ATOM",
+    "quote": "ETH",
+    "display_name": "Cosmos / Ethereum",
+    "description": "Cosmos to Ethereum spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "ATOMEUR": {
+    "normalized_id": "ATOM/EUR",
+    "base": "ATOM",
+    "quote": "EUR",
+    "display_name": "Cosmos / Euro",
+    "description": "Cosmos to Euro spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ATOMFDUSD": {
+    "normalized_id": "ATOM/USD",
+    "base": "ATOM",
+    "quote": "USD",
+    "display_name": "Cosmos / US Dollar",
+    "description": "Cosmos to US Dollar spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATOMTRY": {
+    "normalized_id": "ATOM/TRY",
+    "base": "ATOM",
+    "quote": "TRY",
+    "display_name": "Cosmos / Turkish Lira",
+    "description": "Cosmos to Turkish Lira spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ATOMUSDC": {
+    "normalized_id": "ATOM/USD",
+    "base": "ATOM",
+    "quote": "USD",
+    "display_name": "Cosmos / US Dollar",
+    "description": "Cosmos to US Dollar spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATOMUSDT": {
+    "normalized_id": "ATOM/USD",
+    "base": "ATOM",
+    "quote": "USD",
+    "display_name": "Cosmos / US Dollar",
+    "description": "Cosmos to US Dollar spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATRY": {
+    "normalized_id": "A/TRY",
+    "base": "A",
+    "quote": "TRY",
+    "display_name": "A / Turkish Lira",
+    "description": "A to Turkish Lira spot trading pair",
+    "tags": [
+      "a",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "AUCTIONBTC": {
+    "normalized_id": "AUCTION/BTC",
+    "base": "AUCTION",
+    "quote": "BTC",
+    "display_name": "AUCTION / Bitcoin",
+    "description": "AUCTION to Bitcoin spot trading pair",
+    "tags": [
+      "auction",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "AUCTIONFDUSD": {
+    "normalized_id": "AUCTION/USD",
+    "base": "AUCTION",
+    "quote": "USD",
+    "display_name": "AUCTION / US Dollar",
+    "description": "AUCTION to US Dollar spot trading pair",
+    "tags": [
+      "auction",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AUCTIONTRY": {
+    "normalized_id": "AUCTION/TRY",
+    "base": "AUCTION",
+    "quote": "TRY",
+    "display_name": "AUCTION / Turkish Lira",
+    "description": "AUCTION to Turkish Lira spot trading pair",
+    "tags": [
+      "auction",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "AUCTIONUSDC": {
+    "normalized_id": "AUCTION/USD",
+    "base": "AUCTION",
+    "quote": "USD",
+    "display_name": "AUCTION / US Dollar",
+    "description": "AUCTION to US Dollar spot trading pair",
+    "tags": [
+      "auction",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AUCTIONUSDT": {
+    "normalized_id": "AUCTION/USD",
+    "base": "AUCTION",
+    "quote": "USD",
+    "display_name": "AUCTION / US Dollar",
+    "description": "AUCTION to US Dollar spot trading pair",
+    "tags": [
+      "auction",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AUDIOBTC": {
+    "normalized_id": "AUDIO/BTC",
+    "base": "AUDIO",
+    "quote": "BTC",
+    "display_name": "AUDIO / Bitcoin",
+    "description": "AUDIO to Bitcoin spot trading pair",
+    "tags": [
+      "audio",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "AUDIOTRY": {
+    "normalized_id": "AUDIO/TRY",
+    "base": "AUDIO",
+    "quote": "TRY",
+    "display_name": "AUDIO / Turkish Lira",
+    "description": "AUDIO to Turkish Lira spot trading pair",
+    "tags": [
+      "audio",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "AUDIOUSDT": {
+    "normalized_id": "AUDIO/USD",
+    "base": "AUDIO",
+    "quote": "USD",
+    "display_name": "AUDIO / US Dollar",
+    "description": "AUDIO to US Dollar spot trading pair",
+    "tags": [
+      "audio",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AUSDC": {
+    "normalized_id": "A/USD",
+    "base": "A",
+    "quote": "USD",
+    "display_name": "A / US Dollar",
+    "description": "A to US Dollar spot trading pair",
+    "tags": [
+      "a",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AUSDT": {
+    "normalized_id": "A/USD",
+    "base": "A",
+    "quote": "USD",
+    "display_name": "A / US Dollar",
+    "description": "A to US Dollar spot trading pair",
+    "tags": [
+      "a",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AVABTC": {
+    "normalized_id": "AVA/BTC",
+    "base": "AVA",
+    "quote": "BTC",
+    "display_name": "AVA / Bitcoin",
+    "description": "AVA to Bitcoin spot trading pair",
+    "tags": [
+      "ava",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "AVAUSDT": {
+    "normalized_id": "AVA/USD",
+    "base": "AVA",
+    "quote": "USD",
+    "display_name": "AVA / US Dollar",
+    "description": "AVA to US Dollar spot trading pair",
+    "tags": [
+      "ava",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AVAXBNB": {
+    "normalized_id": "AVAX/BNB",
+    "base": "AVAX",
+    "quote": "BNB",
+    "display_name": "Avalanche / Binance Coin",
+    "description": "Avalanche to Binance Coin spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "AVAXBRL": {
+    "normalized_id": "AVAX/BRL",
+    "base": "AVAX",
+    "quote": "BRL",
+    "display_name": "Avalanche / Brazilian Real",
+    "description": "Avalanche to Brazilian Real spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "AVAXBTC": {
+    "normalized_id": "AVAX/BTC",
+    "base": "AVAX",
+    "quote": "BTC",
+    "display_name": "Avalanche / Bitcoin",
+    "description": "Avalanche to Bitcoin spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "AVAXETH": {
+    "normalized_id": "AVAX/ETH",
+    "base": "AVAX",
+    "quote": "ETH",
+    "display_name": "Avalanche / Ethereum",
+    "description": "Avalanche to Ethereum spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "AVAXEUR": {
+    "normalized_id": "AVAX/EUR",
+    "base": "AVAX",
+    "quote": "EUR",
+    "display_name": "Avalanche / Euro",
+    "description": "Avalanche to Euro spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AVAXFDUSD": {
+    "normalized_id": "AVAX/USD",
+    "base": "AVAX",
+    "quote": "USD",
+    "display_name": "Avalanche / US Dollar",
+    "description": "Avalanche to US Dollar spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AVAXTRY": {
+    "normalized_id": "AVAX/TRY",
+    "base": "AVAX",
+    "quote": "TRY",
+    "display_name": "Avalanche / Turkish Lira",
+    "description": "Avalanche to Turkish Lira spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "AVAXUSDC": {
+    "normalized_id": "AVAX/USD",
+    "base": "AVAX",
+    "quote": "USD",
+    "display_name": "Avalanche / US Dollar",
+    "description": "Avalanche to US Dollar spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AVAXUSDT": {
+    "normalized_id": "AVAX/USD",
+    "base": "AVAX",
+    "quote": "USD",
+    "display_name": "Avalanche / US Dollar",
+    "description": "Avalanche to US Dollar spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AWEUSDT": {
+    "normalized_id": "AWE/USD",
+    "base": "AWE",
+    "quote": "USD",
+    "display_name": "AWE / US Dollar",
+    "description": "AWE to US Dollar spot trading pair",
+    "tags": [
+      "awe",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AXLBTC": {
+    "normalized_id": "AXL/BTC",
+    "base": "AXL",
+    "quote": "BTC",
+    "display_name": "AXL / Bitcoin",
+    "description": "AXL to Bitcoin spot trading pair",
+    "tags": [
+      "axl",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "AXLTRY": {
+    "normalized_id": "AXL/TRY",
+    "base": "AXL",
+    "quote": "TRY",
+    "display_name": "AXL / Turkish Lira",
+    "description": "AXL to Turkish Lira spot trading pair",
+    "tags": [
+      "axl",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "AXLUSDT": {
+    "normalized_id": "AXL/USD",
+    "base": "AXL",
+    "quote": "USD",
+    "display_name": "AXL / US Dollar",
+    "description": "AXL to US Dollar spot trading pair",
+    "tags": [
+      "axl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AXSBNB": {
+    "normalized_id": "AXS/BNB",
+    "base": "AXS",
+    "quote": "BNB",
+    "display_name": "Axie Infinity / Binance Coin",
+    "description": "Axie Infinity to Binance Coin spot trading pair",
+    "tags": [
+      "axs",
+      "axie infinity",
+      "gaming",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "AXSBTC": {
+    "normalized_id": "AXS/BTC",
+    "base": "AXS",
+    "quote": "BTC",
+    "display_name": "Axie Infinity / Bitcoin",
+    "description": "Axie Infinity to Bitcoin spot trading pair",
+    "tags": [
+      "axs",
+      "axie infinity",
+      "gaming",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "AXSETH": {
+    "normalized_id": "AXS/ETH",
+    "base": "AXS",
+    "quote": "ETH",
+    "display_name": "Axie Infinity / Ethereum",
+    "description": "Axie Infinity to Ethereum spot trading pair",
+    "tags": [
+      "axs",
+      "axie infinity",
+      "gaming",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "AXSTRY": {
+    "normalized_id": "AXS/TRY",
+    "base": "AXS",
+    "quote": "TRY",
+    "display_name": "Axie Infinity / Turkish Lira",
+    "description": "Axie Infinity to Turkish Lira spot trading pair",
+    "tags": [
+      "axs",
+      "axie infinity",
+      "gaming",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "AXSUSDC": {
+    "normalized_id": "AXS/USD",
+    "base": "AXS",
+    "quote": "USD",
+    "display_name": "Axie Infinity / US Dollar",
+    "description": "Axie Infinity to US Dollar spot trading pair",
+    "tags": [
+      "axs",
+      "axie infinity",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AXSUSDT": {
+    "normalized_id": "AXS/USD",
+    "base": "AXS",
+    "quote": "USD",
+    "display_name": "Axie Infinity / US Dollar",
+    "description": "Axie Infinity to US Dollar spot trading pair",
+    "tags": [
+      "axs",
+      "axie infinity",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BABYBNB": {
+    "normalized_id": "BABY/BNB",
+    "base": "BABY",
+    "quote": "BNB",
+    "display_name": "BABY / Binance Coin",
+    "description": "BABY to Binance Coin spot trading pair",
+    "tags": [
+      "baby",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "BABYEUR": {
+    "normalized_id": "BABY/EUR",
+    "base": "BABY",
+    "quote": "EUR",
+    "display_name": "BABY / Euro",
+    "description": "BABY to Euro spot trading pair",
+    "tags": [
+      "baby",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BABYFDUSD": {
+    "normalized_id": "BABY/USD",
+    "base": "BABY",
+    "quote": "USD",
+    "display_name": "BABY / US Dollar",
+    "description": "BABY to US Dollar spot trading pair",
+    "tags": [
+      "baby",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BABYTRY": {
+    "normalized_id": "BABY/TRY",
+    "base": "BABY",
+    "quote": "TRY",
+    "display_name": "BABY / Turkish Lira",
+    "description": "BABY to Turkish Lira spot trading pair",
+    "tags": [
+      "baby",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BABYUSDC": {
+    "normalized_id": "BABY/USD",
+    "base": "BABY",
+    "quote": "USD",
+    "display_name": "BABY / US Dollar",
+    "description": "BABY to US Dollar spot trading pair",
+    "tags": [
+      "baby",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BABYUSDT": {
+    "normalized_id": "BABY/USD",
+    "base": "BABY",
+    "quote": "USD",
+    "display_name": "BABY / US Dollar",
+    "description": "BABY to US Dollar spot trading pair",
+    "tags": [
+      "baby",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BAKEBTC": {
+    "normalized_id": "BAKE/BTC",
+    "base": "BAKE",
+    "quote": "BTC",
+    "display_name": "BAKE / Bitcoin",
+    "description": "BAKE to Bitcoin spot trading pair",
+    "tags": [
+      "bake",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "BAKETRY": {
+    "normalized_id": "BAKE/TRY",
+    "base": "BAKE",
+    "quote": "TRY",
+    "display_name": "BAKE / Turkish Lira",
+    "description": "BAKE to Turkish Lira spot trading pair",
+    "tags": [
+      "bake",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BAKEUSDT": {
+    "normalized_id": "BAKE/USD",
+    "base": "BAKE",
+    "quote": "USD",
+    "display_name": "BAKE / US Dollar",
+    "description": "BAKE to US Dollar spot trading pair",
+    "tags": [
+      "bake",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BANANABNB": {
+    "normalized_id": "BANANA/BNB",
+    "base": "BANANA",
+    "quote": "BNB",
+    "display_name": "BANANA / Binance Coin",
+    "description": "BANANA to Binance Coin spot trading pair",
+    "tags": [
+      "banana",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "BANANABTC": {
+    "normalized_id": "BANANA/BTC",
+    "base": "BANANA",
+    "quote": "BTC",
+    "display_name": "BANANA / Bitcoin",
+    "description": "BANANA to Bitcoin spot trading pair",
+    "tags": [
+      "banana",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "BANANAFDUSD": {
+    "normalized_id": "BANANA/USD",
+    "base": "BANANA",
+    "quote": "USD",
+    "display_name": "BANANA / US Dollar",
+    "description": "BANANA to US Dollar spot trading pair",
+    "tags": [
+      "banana",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BANANAS31USDC": {
+    "normalized_id": "BANANAS31/USD",
+    "base": "BANANAS31",
+    "quote": "USD",
+    "display_name": "BANANAS31 / US Dollar",
+    "description": "BANANAS31 to US Dollar spot trading pair",
+    "tags": [
+      "bananas31",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BANANAS31USDT": {
+    "normalized_id": "BANANAS31/USD",
+    "base": "BANANAS31",
+    "quote": "USD",
+    "display_name": "BANANAS31 / US Dollar",
+    "description": "BANANAS31 to US Dollar spot trading pair",
+    "tags": [
+      "bananas31",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BANANATRY": {
+    "normalized_id": "BANANA/TRY",
+    "base": "BANANA",
+    "quote": "TRY",
+    "display_name": "BANANA / Turkish Lira",
+    "description": "BANANA to Turkish Lira spot trading pair",
+    "tags": [
+      "banana",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BANANAUSDC": {
+    "normalized_id": "BANANA/USD",
+    "base": "BANANA",
+    "quote": "USD",
+    "display_name": "BANANA / US Dollar",
+    "description": "BANANA to US Dollar spot trading pair",
+    "tags": [
+      "banana",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BANANAUSDT": {
+    "normalized_id": "BANANA/USD",
+    "base": "BANANA",
+    "quote": "USD",
+    "display_name": "BANANA / US Dollar",
+    "description": "BANANA to US Dollar spot trading pair",
+    "tags": [
+      "banana",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BANDBTC": {
+    "normalized_id": "BAND/BTC",
+    "base": "BAND",
+    "quote": "BTC",
+    "display_name": "BAND / Bitcoin",
+    "description": "BAND to Bitcoin spot trading pair",
+    "tags": [
+      "band",
+      "oracle",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "BANDUSDT": {
+    "normalized_id": "BAND/USD",
+    "base": "BAND",
+    "quote": "USD",
+    "display_name": "BAND / US Dollar",
+    "description": "BAND to US Dollar spot trading pair",
+    "tags": [
+      "band",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BARTRY": {
+    "normalized_id": "BAR/TRY",
+    "base": "BAR",
+    "quote": "TRY",
+    "display_name": "BAR / Turkish Lira",
+    "description": "BAR to Turkish Lira spot trading pair",
+    "tags": [
+      "bar",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BARUSDT": {
+    "normalized_id": "BAR/USD",
+    "base": "BAR",
+    "quote": "USD",
+    "display_name": "BAR / US Dollar",
+    "description": "BAR to US Dollar spot trading pair",
+    "tags": [
+      "bar",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BATBTC": {
+    "normalized_id": "BAT/BTC",
+    "base": "BAT",
+    "quote": "BTC",
+    "display_name": "Basic Attention Token / Bitcoin",
+    "description": "Basic Attention Token to Bitcoin spot trading pair",
+    "tags": [
+      "bat",
+      "basic attention token",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "BATUSDT": {
+    "normalized_id": "BAT/USD",
+    "base": "BAT",
+    "quote": "USD",
+    "display_name": "Basic Attention Token / US Dollar",
+    "description": "Basic Attention Token to US Dollar spot trading pair",
+    "tags": [
+      "bat",
+      "basic attention token",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BBBNB": {
+    "normalized_id": "BB/BNB",
+    "base": "BB",
+    "quote": "BNB",
+    "display_name": "BB / Binance Coin",
+    "description": "BB to Binance Coin spot trading pair",
+    "tags": [
+      "bb",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "BBBTC": {
+    "normalized_id": "BB/BTC",
+    "base": "BB",
+    "quote": "BTC",
+    "display_name": "BB / Bitcoin",
+    "description": "BB to Bitcoin spot trading pair",
+    "tags": [
+      "bb",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "BBFDUSD": {
+    "normalized_id": "BB/USD",
+    "base": "BB",
+    "quote": "USD",
+    "display_name": "BB / US Dollar",
+    "description": "BB to US Dollar spot trading pair",
+    "tags": [
+      "bb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BBTRY": {
+    "normalized_id": "BB/TRY",
+    "base": "BB",
+    "quote": "TRY",
+    "display_name": "BB / Turkish Lira",
+    "description": "BB to Turkish Lira spot trading pair",
+    "tags": [
+      "bb",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BBUSDC": {
+    "normalized_id": "BB/USD",
+    "base": "BB",
+    "quote": "USD",
+    "display_name": "BB / US Dollar",
+    "description": "BB to US Dollar spot trading pair",
+    "tags": [
+      "bb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BBUSDT": {
+    "normalized_id": "BB/USD",
+    "base": "BB",
+    "quote": "USD",
+    "display_name": "BB / US Dollar",
+    "description": "BB to US Dollar spot trading pair",
+    "tags": [
+      "bb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BCHBNB": {
+    "normalized_id": "BCH/BNB",
+    "base": "BCH",
+    "quote": "BNB",
+    "display_name": "Bitcoin Cash / Binance Coin",
+    "description": "Bitcoin Cash to Binance Coin spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "BCHBTC": {
+    "normalized_id": "BCH/BTC",
+    "base": "BCH",
+    "quote": "BTC",
+    "display_name": "Bitcoin Cash / Bitcoin",
+    "description": "Bitcoin Cash to Bitcoin spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "BCHEUR": {
+    "normalized_id": "BCH/EUR",
+    "base": "BCH",
+    "quote": "EUR",
+    "display_name": "Bitcoin Cash / Euro",
+    "description": "Bitcoin Cash to Euro spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BCHFDUSD": {
+    "normalized_id": "BCH/USD",
+    "base": "BCH",
+    "quote": "USD",
+    "display_name": "Bitcoin Cash / US Dollar",
+    "description": "Bitcoin Cash to US Dollar spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BCHJPY": {
+    "normalized_id": "BCH/JPY",
+    "base": "BCH",
+    "quote": "JPY",
+    "display_name": "Bitcoin Cash / Japanese Yen",
+    "description": "Bitcoin Cash to Japanese Yen spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "BCHTRY": {
+    "normalized_id": "BCH/TRY",
+    "base": "BCH",
+    "quote": "TRY",
+    "display_name": "Bitcoin Cash / Turkish Lira",
+    "description": "Bitcoin Cash to Turkish Lira spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BCHUSDC": {
+    "normalized_id": "BCH/USD",
+    "base": "BCH",
+    "quote": "USD",
+    "display_name": "Bitcoin Cash / US Dollar",
+    "description": "Bitcoin Cash to US Dollar spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BCHUSDT": {
+    "normalized_id": "BCH/USD",
+    "base": "BCH",
+    "quote": "USD",
+    "display_name": "Bitcoin Cash / US Dollar",
+    "description": "Bitcoin Cash to US Dollar spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BEAMXTRY": {
+    "normalized_id": "BEAMX/TRY",
+    "base": "BEAMX",
+    "quote": "TRY",
+    "display_name": "BEAMX / Turkish Lira",
+    "description": "BEAMX to Turkish Lira spot trading pair",
+    "tags": [
+      "beamx",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BEAMXUSDC": {
+    "normalized_id": "BEAMX/USD",
+    "base": "BEAMX",
+    "quote": "USD",
+    "display_name": "BEAMX / US Dollar",
+    "description": "BEAMX to US Dollar spot trading pair",
+    "tags": [
+      "beamx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BEAMXUSDT": {
+    "normalized_id": "BEAMX/USD",
+    "base": "BEAMX",
+    "quote": "USD",
+    "display_name": "BEAMX / US Dollar",
+    "description": "BEAMX to US Dollar spot trading pair",
+    "tags": [
+      "beamx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BELBTC": {
+    "normalized_id": "BEL/BTC",
+    "base": "BEL",
+    "quote": "BTC",
+    "display_name": "BEL / Bitcoin",
+    "description": "BEL to Bitcoin spot trading pair",
+    "tags": [
+      "bel",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "BELTRY": {
+    "normalized_id": "BEL/TRY",
+    "base": "BEL",
+    "quote": "TRY",
+    "display_name": "BEL / Turkish Lira",
+    "description": "BEL to Turkish Lira spot trading pair",
+    "tags": [
+      "bel",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BELUSDT": {
+    "normalized_id": "BEL/USD",
+    "base": "BEL",
+    "quote": "USD",
+    "display_name": "BEL / US Dollar",
+    "description": "BEL to US Dollar spot trading pair",
+    "tags": [
+      "bel",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BERABNB": {
+    "normalized_id": "BERA/BNB",
+    "base": "BERA",
+    "quote": "BNB",
+    "display_name": "BERA / Binance Coin",
+    "description": "BERA to Binance Coin spot trading pair",
+    "tags": [
+      "bera",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "BERABTC": {
+    "normalized_id": "BERA/BTC",
+    "base": "BERA",
+    "quote": "BTC",
+    "display_name": "BERA / Bitcoin",
+    "description": "BERA to Bitcoin spot trading pair",
+    "tags": [
+      "bera",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "BERAFDUSD": {
+    "normalized_id": "BERA/USD",
+    "base": "BERA",
+    "quote": "USD",
+    "display_name": "BERA / US Dollar",
+    "description": "BERA to US Dollar spot trading pair",
+    "tags": [
+      "bera",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BERATRY": {
+    "normalized_id": "BERA/TRY",
+    "base": "BERA",
+    "quote": "TRY",
+    "display_name": "BERA / Turkish Lira",
+    "description": "BERA to Turkish Lira spot trading pair",
+    "tags": [
+      "bera",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BERAUSDC": {
+    "normalized_id": "BERA/USD",
+    "base": "BERA",
+    "quote": "USD",
+    "display_name": "BERA / US Dollar",
+    "description": "BERA to US Dollar spot trading pair",
+    "tags": [
+      "bera",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BERAUSDT": {
+    "normalized_id": "BERA/USD",
+    "base": "BERA",
+    "quote": "USD",
+    "display_name": "BERA / US Dollar",
+    "description": "BERA to US Dollar spot trading pair",
+    "tags": [
+      "bera",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BFUSDUSDT": {
+    "normalized_id": "BFUSD/USD",
+    "base": "BFUSD",
+    "quote": "USD",
+    "display_name": "BFUSD / US Dollar",
+    "description": "BFUSD to US Dollar spot trading pair",
+    "tags": [
+      "bfusd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BICOBTC": {
+    "normalized_id": "BICO/BTC",
+    "base": "BICO",
+    "quote": "BTC",
+    "display_name": "BICO / Bitcoin",
+    "description": "BICO to Bitcoin spot trading pair",
+    "tags": [
+      "bico",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "BICOUSDT": {
+    "normalized_id": "BICO/USD",
+    "base": "BICO",
+    "quote": "USD",
+    "display_name": "BICO / US Dollar",
+    "description": "BICO to US Dollar spot trading pair",
+    "tags": [
+      "bico",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BIFIUSDT": {
+    "normalized_id": "BIFI/USD",
+    "base": "BIFI",
+    "quote": "USD",
+    "display_name": "BIFI / US Dollar",
+    "description": "BIFI to US Dollar spot trading pair",
+    "tags": [
+      "bifi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BIGTIMEUSDC": {
+    "normalized_id": "BIGTIME/USD",
+    "base": "BIGTIME",
+    "quote": "USD",
+    "display_name": "BIGTIME / US Dollar",
+    "description": "BIGTIME to US Dollar spot trading pair",
+    "tags": [
+      "bigtime",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BIGTIMEUSDT": {
+    "normalized_id": "BIGTIME/USD",
+    "base": "BIGTIME",
+    "quote": "USD",
+    "display_name": "BIGTIME / US Dollar",
+    "description": "BIGTIME to US Dollar spot trading pair",
+    "tags": [
+      "bigtime",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BIOBNB": {
+    "normalized_id": "BIO/BNB",
+    "base": "BIO",
+    "quote": "BNB",
+    "display_name": "BIO / Binance Coin",
+    "description": "BIO to Binance Coin spot trading pair",
+    "tags": [
+      "bio",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "BIOFDUSD": {
+    "normalized_id": "BIO/USD",
+    "base": "BIO",
+    "quote": "USD",
+    "display_name": "BIO / US Dollar",
+    "description": "BIO to US Dollar spot trading pair",
+    "tags": [
+      "bio",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BIOTRY": {
+    "normalized_id": "BIO/TRY",
+    "base": "BIO",
+    "quote": "TRY",
+    "display_name": "BIO / Turkish Lira",
+    "description": "BIO to Turkish Lira spot trading pair",
+    "tags": [
+      "bio",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BIOUSDC": {
+    "normalized_id": "BIO/USD",
+    "base": "BIO",
+    "quote": "USD",
+    "display_name": "BIO / US Dollar",
+    "description": "BIO to US Dollar spot trading pair",
+    "tags": [
+      "bio",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BIOUSDT": {
+    "normalized_id": "BIO/USD",
+    "base": "BIO",
+    "quote": "USD",
+    "display_name": "BIO / US Dollar",
+    "description": "BIO to US Dollar spot trading pair",
+    "tags": [
+      "bio",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BLURTRY": {
+    "normalized_id": "BLUR/TRY",
+    "base": "BLUR",
+    "quote": "TRY",
+    "display_name": "BLUR / Turkish Lira",
+    "description": "BLUR to Turkish Lira spot trading pair",
+    "tags": [
+      "blur",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BLURUSDC": {
+    "normalized_id": "BLUR/USD",
+    "base": "BLUR",
+    "quote": "USD",
+    "display_name": "BLUR / US Dollar",
+    "description": "BLUR to US Dollar spot trading pair",
+    "tags": [
+      "blur",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BLURUSDT": {
+    "normalized_id": "BLUR/USD",
+    "base": "BLUR",
+    "quote": "USD",
+    "display_name": "BLUR / US Dollar",
+    "description": "BLUR to US Dollar spot trading pair",
+    "tags": [
+      "blur",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BMTBNB": {
+    "normalized_id": "BMT/BNB",
+    "base": "BMT",
+    "quote": "BNB",
+    "display_name": "BMT / Binance Coin",
+    "description": "BMT to Binance Coin spot trading pair",
+    "tags": [
+      "bmt",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "BMTFDUSD": {
+    "normalized_id": "BMT/USD",
+    "base": "BMT",
+    "quote": "USD",
+    "display_name": "BMT / US Dollar",
+    "description": "BMT to US Dollar spot trading pair",
+    "tags": [
+      "bmt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BMTTRY": {
+    "normalized_id": "BMT/TRY",
+    "base": "BMT",
+    "quote": "TRY",
+    "display_name": "BMT / Turkish Lira",
+    "description": "BMT to Turkish Lira spot trading pair",
+    "tags": [
+      "bmt",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BMTUSDC": {
+    "normalized_id": "BMT/USD",
+    "base": "BMT",
+    "quote": "USD",
+    "display_name": "BMT / US Dollar",
+    "description": "BMT to US Dollar spot trading pair",
+    "tags": [
+      "bmt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BMTUSDT": {
+    "normalized_id": "BMT/USD",
+    "base": "BMT",
+    "quote": "USD",
+    "display_name": "BMT / US Dollar",
+    "description": "BMT to US Dollar spot trading pair",
+    "tags": [
+      "bmt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNBBRL": {
+    "normalized_id": "BNB/BRL",
+    "base": "BNB",
+    "quote": "BRL",
+    "display_name": "Binance Coin / Brazilian Real",
+    "description": "Binance Coin to Brazilian Real spot trading pair",
+    "tags": [
+      "bnb",
+      "binance coin",
+      "major",
+      "exchange",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "BNBBTC": {
+    "normalized_id": "BNB/BTC",
+    "base": "BNB",
+    "quote": "BTC",
+    "display_name": "Binance Coin / Bitcoin",
+    "description": "Binance Coin to Bitcoin spot trading pair",
+    "tags": [
+      "bnb",
+      "binance coin",
+      "major",
+      "exchange",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "BNBETH": {
+    "normalized_id": "BNB/ETH",
+    "base": "BNB",
+    "quote": "ETH",
+    "display_name": "Binance Coin / Ethereum",
+    "description": "Binance Coin to Ethereum spot trading pair",
+    "tags": [
+      "bnb",
+      "binance coin",
+      "major",
+      "exchange",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "BNBEUR": {
+    "normalized_id": "BNB/EUR",
+    "base": "BNB",
+    "quote": "EUR",
+    "display_name": "Binance Coin / Euro",
+    "description": "Binance Coin to Euro spot trading pair",
+    "tags": [
+      "bnb",
+      "binance coin",
+      "major",
+      "exchange",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BNBFDUSD": {
+    "normalized_id": "BNB/USD",
+    "base": "BNB",
+    "quote": "USD",
+    "display_name": "Binance Coin / US Dollar",
+    "description": "Binance Coin to US Dollar spot trading pair",
+    "tags": [
+      "bnb",
+      "binance coin",
+      "major",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNBJPY": {
+    "normalized_id": "BNB/JPY",
+    "base": "BNB",
+    "quote": "JPY",
+    "display_name": "Binance Coin / Japanese Yen",
+    "description": "Binance Coin to Japanese Yen spot trading pair",
+    "tags": [
+      "bnb",
+      "binance coin",
+      "major",
+      "exchange",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "BNBTRY": {
+    "normalized_id": "BNB/TRY",
+    "base": "BNB",
+    "quote": "TRY",
+    "display_name": "Binance Coin / Turkish Lira",
+    "description": "Binance Coin to Turkish Lira spot trading pair",
+    "tags": [
+      "bnb",
+      "binance coin",
+      "major",
+      "exchange",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BNBUSDC": {
+    "normalized_id": "BNB/USD",
+    "base": "BNB",
+    "quote": "USD",
+    "display_name": "Binance Coin / US Dollar",
+    "description": "Binance Coin to US Dollar spot trading pair",
+    "tags": [
+      "bnb",
+      "binance coin",
+      "major",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNBUSDT": {
+    "normalized_id": "BNB/USD",
+    "base": "BNB",
+    "quote": "USD",
+    "display_name": "Binance Coin / US Dollar",
+    "description": "Binance Coin to US Dollar spot trading pair",
+    "tags": [
+      "bnb",
+      "binance coin",
+      "major",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNSOLUSDT": {
+    "normalized_id": "BNSOL/USD",
+    "base": "BNSOL",
+    "quote": "USD",
+    "display_name": "BNSOL / US Dollar",
+    "description": "BNSOL to US Dollar spot trading pair",
+    "tags": [
+      "bnsol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNTUSDT": {
+    "normalized_id": "BNT/USD",
+    "base": "BNT",
+    "quote": "USD",
+    "display_name": "BNT / US Dollar",
+    "description": "BNT to US Dollar spot trading pair",
+    "tags": [
+      "bnt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BOMEEUR": {
+    "normalized_id": "BOME/EUR",
+    "base": "BOME",
+    "quote": "EUR",
+    "display_name": "BOME / Euro",
+    "description": "BOME to Euro spot trading pair",
+    "tags": [
+      "bome",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BOMEFDUSD": {
+    "normalized_id": "BOME/USD",
+    "base": "BOME",
+    "quote": "USD",
+    "display_name": "BOME / US Dollar",
+    "description": "BOME to US Dollar spot trading pair",
+    "tags": [
+      "bome",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BOMETRY": {
+    "normalized_id": "BOME/TRY",
+    "base": "BOME",
+    "quote": "TRY",
+    "display_name": "BOME / Turkish Lira",
+    "description": "BOME to Turkish Lira spot trading pair",
+    "tags": [
+      "bome",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BOMEUSDC": {
+    "normalized_id": "BOME/USD",
+    "base": "BOME",
+    "quote": "USD",
+    "display_name": "BOME / US Dollar",
+    "description": "BOME to US Dollar spot trading pair",
+    "tags": [
+      "bome",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BOMEUSDT": {
+    "normalized_id": "BOME/USD",
+    "base": "BOME",
+    "quote": "USD",
+    "display_name": "BOME / US Dollar",
+    "description": "BOME to US Dollar spot trading pair",
+    "tags": [
+      "bome",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BONKBRL": {
+    "normalized_id": "BONK/BRL",
+    "base": "BONK",
+    "quote": "BRL",
+    "display_name": "Bonk / Brazilian Real",
+    "description": "Bonk to Brazilian Real spot trading pair",
+    "tags": [
+      "bonk",
+      "meme",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "BONKFDUSD": {
+    "normalized_id": "BONK/USD",
+    "base": "BONK",
+    "quote": "USD",
+    "display_name": "Bonk / US Dollar",
+    "description": "Bonk to US Dollar spot trading pair",
+    "tags": [
+      "bonk",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BONKTRY": {
+    "normalized_id": "BONK/TRY",
+    "base": "BONK",
+    "quote": "TRY",
+    "display_name": "Bonk / Turkish Lira",
+    "description": "Bonk to Turkish Lira spot trading pair",
+    "tags": [
+      "bonk",
+      "meme",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BONKUSDC": {
+    "normalized_id": "BONK/USD",
+    "base": "BONK",
+    "quote": "USD",
+    "display_name": "Bonk / US Dollar",
+    "description": "Bonk to US Dollar spot trading pair",
+    "tags": [
+      "bonk",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BONKUSDT": {
+    "normalized_id": "BONK/USD",
+    "base": "BONK",
+    "quote": "USD",
+    "display_name": "Bonk / US Dollar",
+    "description": "Bonk to US Dollar spot trading pair",
+    "tags": [
+      "bonk",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BROCCOLI714USDC": {
+    "normalized_id": "BROCCOLI714/USD",
+    "base": "BROCCOLI714",
+    "quote": "USD",
+    "display_name": "BROCCOLI714 / US Dollar",
+    "description": "BROCCOLI714 to US Dollar spot trading pair",
+    "tags": [
+      "broccoli714",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BROCCOLI714USDT": {
+    "normalized_id": "BROCCOLI714/USD",
+    "base": "BROCCOLI714",
+    "quote": "USD",
+    "display_name": "BROCCOLI714 / US Dollar",
+    "description": "BROCCOLI714 to US Dollar spot trading pair",
+    "tags": [
+      "broccoli714",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BTCBRL": {
+    "normalized_id": "BTC/BRL",
+    "base": "BTC",
+    "quote": "BRL",
+    "display_name": "Bitcoin / Brazilian Real",
+    "description": "Bitcoin to Brazilian Real spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "BTCEUR": {
+    "normalized_id": "BTC/EUR",
+    "base": "BTC",
+    "quote": "EUR",
+    "display_name": "Bitcoin / Euro",
+    "description": "Bitcoin to Euro spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BTCFDUSD": {
+    "normalized_id": "BTC/USD",
+    "base": "BTC",
+    "quote": "USD",
+    "display_name": "Bitcoin / US Dollar",
+    "description": "Bitcoin to US Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BTCJPY": {
+    "normalized_id": "BTC/JPY",
+    "base": "BTC",
+    "quote": "JPY",
+    "display_name": "Bitcoin / Japanese Yen",
+    "description": "Bitcoin to Japanese Yen spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "BTCTRY": {
+    "normalized_id": "BTC/TRY",
+    "base": "BTC",
+    "quote": "TRY",
+    "display_name": "Bitcoin / Turkish Lira",
+    "description": "Bitcoin to Turkish Lira spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BTCUSDC": {
+    "normalized_id": "BTC/USD",
+    "base": "BTC",
+    "quote": "USD",
+    "display_name": "Bitcoin / US Dollar",
+    "description": "Bitcoin to US Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BTCUSDT": {
+    "normalized_id": "BTC/USD",
+    "base": "BTC",
+    "quote": "USD",
+    "display_name": "Bitcoin / US Dollar",
+    "description": "Bitcoin to US Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BTTCTRY": {
+    "normalized_id": "BTTC/TRY",
+    "base": "BTTC",
+    "quote": "TRY",
+    "display_name": "BTTC / Turkish Lira",
+    "description": "BTTC to Turkish Lira spot trading pair",
+    "tags": [
+      "bttc",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BTTCUSDT": {
+    "normalized_id": "BTTC/USD",
+    "base": "BTTC",
+    "quote": "USD",
+    "display_name": "BTTC / US Dollar",
+    "description": "BTTC to US Dollar spot trading pair",
+    "tags": [
+      "bttc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "C98USDT": {
+    "normalized_id": "C98/USD",
+    "base": "C98",
+    "quote": "USD",
+    "display_name": "C98 / US Dollar",
+    "description": "C98 to US Dollar spot trading pair",
+    "tags": [
+      "c98",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CAKEBNB": {
+    "normalized_id": "CAKE/BNB",
+    "base": "CAKE",
+    "quote": "BNB",
+    "display_name": "CAKE / Binance Coin",
+    "description": "CAKE to Binance Coin spot trading pair",
+    "tags": [
+      "cake",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "CAKEBTC": {
+    "normalized_id": "CAKE/BTC",
+    "base": "CAKE",
+    "quote": "BTC",
+    "display_name": "CAKE / Bitcoin",
+    "description": "CAKE to Bitcoin spot trading pair",
+    "tags": [
+      "cake",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "CAKETRY": {
+    "normalized_id": "CAKE/TRY",
+    "base": "CAKE",
+    "quote": "TRY",
+    "display_name": "CAKE / Turkish Lira",
+    "description": "CAKE to Turkish Lira spot trading pair",
+    "tags": [
+      "cake",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "CAKEUSDC": {
+    "normalized_id": "CAKE/USD",
+    "base": "CAKE",
+    "quote": "USD",
+    "display_name": "CAKE / US Dollar",
+    "description": "CAKE to US Dollar spot trading pair",
+    "tags": [
+      "cake",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CAKEUSDT": {
+    "normalized_id": "CAKE/USD",
+    "base": "CAKE",
+    "quote": "USD",
+    "display_name": "CAKE / US Dollar",
+    "description": "CAKE to US Dollar spot trading pair",
+    "tags": [
+      "cake",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CATITRY": {
+    "normalized_id": "CATI/TRY",
+    "base": "CATI",
+    "quote": "TRY",
+    "display_name": "CATI / Turkish Lira",
+    "description": "CATI to Turkish Lira spot trading pair",
+    "tags": [
+      "cati",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "CATIUSDC": {
+    "normalized_id": "CATI/USD",
+    "base": "CATI",
+    "quote": "USD",
+    "display_name": "CATI / US Dollar",
+    "description": "CATI to US Dollar spot trading pair",
+    "tags": [
+      "cati",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CATIUSDT": {
+    "normalized_id": "CATI/USD",
+    "base": "CATI",
+    "quote": "USD",
+    "display_name": "CATI / US Dollar",
+    "description": "CATI to US Dollar spot trading pair",
+    "tags": [
+      "cati",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CBNB": {
+    "normalized_id": "C/BNB",
+    "base": "C",
+    "quote": "BNB",
+    "display_name": "C / Binance Coin",
+    "description": "C to Binance Coin spot trading pair",
+    "tags": [
+      "c",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "CELOBTC": {
+    "normalized_id": "CELO/BTC",
+    "base": "CELO",
+    "quote": "BTC",
+    "display_name": "CELO / Bitcoin",
+    "description": "CELO to Bitcoin spot trading pair",
+    "tags": [
+      "celo",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "CELOTRY": {
+    "normalized_id": "CELO/TRY",
+    "base": "CELO",
+    "quote": "TRY",
+    "display_name": "CELO / Turkish Lira",
+    "description": "CELO to Turkish Lira spot trading pair",
+    "tags": [
+      "celo",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "CELOUSDT": {
+    "normalized_id": "CELO/USD",
+    "base": "CELO",
+    "quote": "USD",
+    "display_name": "CELO / US Dollar",
+    "description": "CELO to US Dollar spot trading pair",
+    "tags": [
+      "celo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CELRUSDT": {
+    "normalized_id": "CELR/USD",
+    "base": "CELR",
+    "quote": "USD",
+    "display_name": "CELR / US Dollar",
+    "description": "CELR to US Dollar spot trading pair",
+    "tags": [
+      "celr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CETUSTRY": {
+    "normalized_id": "CETUS/TRY",
+    "base": "CETUS",
+    "quote": "TRY",
+    "display_name": "CETUS / Turkish Lira",
+    "description": "CETUS to Turkish Lira spot trading pair",
+    "tags": [
+      "cetus",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "CETUSUSDC": {
+    "normalized_id": "CETUS/USD",
+    "base": "CETUS",
+    "quote": "USD",
+    "display_name": "CETUS / US Dollar",
+    "description": "CETUS to US Dollar spot trading pair",
+    "tags": [
+      "cetus",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CETUSUSDT": {
+    "normalized_id": "CETUS/USD",
+    "base": "CETUS",
+    "quote": "USD",
+    "display_name": "CETUS / US Dollar",
+    "description": "CETUS to US Dollar spot trading pair",
+    "tags": [
+      "cetus",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CFDUSD": {
+    "normalized_id": "C/USD",
+    "base": "C",
+    "quote": "USD",
+    "display_name": "C / US Dollar",
+    "description": "C to US Dollar spot trading pair",
+    "tags": [
+      "c",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CFXBTC": {
+    "normalized_id": "CFX/BTC",
+    "base": "CFX",
+    "quote": "BTC",
+    "display_name": "CFX / Bitcoin",
+    "description": "CFX to Bitcoin spot trading pair",
+    "tags": [
+      "cfx",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "CFXTRY": {
+    "normalized_id": "CFX/TRY",
+    "base": "CFX",
+    "quote": "TRY",
+    "display_name": "CFX / Turkish Lira",
+    "description": "CFX to Turkish Lira spot trading pair",
+    "tags": [
+      "cfx",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "CFXUSDC": {
+    "normalized_id": "CFX/USD",
+    "base": "CFX",
+    "quote": "USD",
+    "display_name": "CFX / US Dollar",
+    "description": "CFX to US Dollar spot trading pair",
+    "tags": [
+      "cfx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CFXUSDT": {
+    "normalized_id": "CFX/USD",
+    "base": "CFX",
+    "quote": "USD",
+    "display_name": "CFX / US Dollar",
+    "description": "CFX to US Dollar spot trading pair",
+    "tags": [
+      "cfx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CGPTUSDC": {
+    "normalized_id": "CGPT/USD",
+    "base": "CGPT",
+    "quote": "USD",
+    "display_name": "CGPT / US Dollar",
+    "description": "CGPT to US Dollar spot trading pair",
+    "tags": [
+      "cgpt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CGPTUSDT": {
+    "normalized_id": "CGPT/USD",
+    "base": "CGPT",
+    "quote": "USD",
+    "display_name": "CGPT / US Dollar",
+    "description": "CGPT to US Dollar spot trading pair",
+    "tags": [
+      "cgpt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CHESSUSDC": {
+    "normalized_id": "CHESS/USD",
+    "base": "CHESS",
+    "quote": "USD",
+    "display_name": "CHESS / US Dollar",
+    "description": "CHESS to US Dollar spot trading pair",
+    "tags": [
+      "chess",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CHESSUSDT": {
+    "normalized_id": "CHESS/USD",
+    "base": "CHESS",
+    "quote": "USD",
+    "display_name": "CHESS / US Dollar",
+    "description": "CHESS to US Dollar spot trading pair",
+    "tags": [
+      "chess",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CHRBTC": {
+    "normalized_id": "CHR/BTC",
+    "base": "CHR",
+    "quote": "BTC",
+    "display_name": "CHR / Bitcoin",
+    "description": "CHR to Bitcoin spot trading pair",
+    "tags": [
+      "chr",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "CHRUSDT": {
+    "normalized_id": "CHR/USD",
+    "base": "CHR",
+    "quote": "USD",
+    "display_name": "CHR / US Dollar",
+    "description": "CHR to US Dollar spot trading pair",
+    "tags": [
+      "chr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CHZBNB": {
+    "normalized_id": "CHZ/BNB",
+    "base": "CHZ",
+    "quote": "BNB",
+    "display_name": "Chiliz / Binance Coin",
+    "description": "Chiliz to Binance Coin spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "CHZBTC": {
+    "normalized_id": "CHZ/BTC",
+    "base": "CHZ",
+    "quote": "BTC",
+    "display_name": "Chiliz / Bitcoin",
+    "description": "Chiliz to Bitcoin spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "CHZTRY": {
+    "normalized_id": "CHZ/TRY",
+    "base": "CHZ",
+    "quote": "TRY",
+    "display_name": "Chiliz / Turkish Lira",
+    "description": "Chiliz to Turkish Lira spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "CHZUSDC": {
+    "normalized_id": "CHZ/USD",
+    "base": "CHZ",
+    "quote": "USD",
+    "display_name": "Chiliz / US Dollar",
+    "description": "Chiliz to US Dollar spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CHZUSDT": {
+    "normalized_id": "CHZ/USD",
+    "base": "CHZ",
+    "quote": "USD",
+    "display_name": "Chiliz / US Dollar",
+    "description": "Chiliz to US Dollar spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CITYTRY": {
+    "normalized_id": "CITY/TRY",
+    "base": "CITY",
+    "quote": "TRY",
+    "display_name": "CITY / Turkish Lira",
+    "description": "CITY to Turkish Lira spot trading pair",
+    "tags": [
+      "city",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "CITYUSDT": {
+    "normalized_id": "CITY/USD",
+    "base": "CITY",
+    "quote": "USD",
+    "display_name": "CITY / US Dollar",
+    "description": "CITY to US Dollar spot trading pair",
+    "tags": [
+      "city",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CKBTRY": {
+    "normalized_id": "CKB/TRY",
+    "base": "CKB",
+    "quote": "TRY",
+    "display_name": "CKB / Turkish Lira",
+    "description": "CKB to Turkish Lira spot trading pair",
+    "tags": [
+      "ckb",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "CKBUSDC": {
+    "normalized_id": "CKB/USD",
+    "base": "CKB",
+    "quote": "USD",
+    "display_name": "CKB / US Dollar",
+    "description": "CKB to US Dollar spot trading pair",
+    "tags": [
+      "ckb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CKBUSDT": {
+    "normalized_id": "CKB/USD",
+    "base": "CKB",
+    "quote": "USD",
+    "display_name": "CKB / US Dollar",
+    "description": "CKB to US Dollar spot trading pair",
+    "tags": [
+      "ckb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COMPBTC": {
+    "normalized_id": "COMP/BTC",
+    "base": "COMP",
+    "quote": "BTC",
+    "display_name": "Compound / Bitcoin",
+    "description": "Compound to Bitcoin spot trading pair",
+    "tags": [
+      "comp",
+      "compound",
+      "defi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "COMPTRY": {
+    "normalized_id": "COMP/TRY",
+    "base": "COMP",
+    "quote": "TRY",
+    "display_name": "Compound / Turkish Lira",
+    "description": "Compound to Turkish Lira spot trading pair",
+    "tags": [
+      "comp",
+      "compound",
+      "defi",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "COMPUSDC": {
+    "normalized_id": "COMP/USD",
+    "base": "COMP",
+    "quote": "USD",
+    "display_name": "Compound / US Dollar",
+    "description": "Compound to US Dollar spot trading pair",
+    "tags": [
+      "comp",
+      "compound",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COMPUSDT": {
+    "normalized_id": "COMP/USD",
+    "base": "COMP",
+    "quote": "USD",
+    "display_name": "Compound / US Dollar",
+    "description": "Compound to US Dollar spot trading pair",
+    "tags": [
+      "comp",
+      "compound",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COOKIEUSDC": {
+    "normalized_id": "COOKIE/USD",
+    "base": "COOKIE",
+    "quote": "USD",
+    "display_name": "COOKIE / US Dollar",
+    "description": "COOKIE to US Dollar spot trading pair",
+    "tags": [
+      "cookie",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COOKIEUSDT": {
+    "normalized_id": "COOKIE/USD",
+    "base": "COOKIE",
+    "quote": "USD",
+    "display_name": "COOKIE / US Dollar",
+    "description": "COOKIE to US Dollar spot trading pair",
+    "tags": [
+      "cookie",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COSTRY": {
+    "normalized_id": "COS/TRY",
+    "base": "COS",
+    "quote": "TRY",
+    "display_name": "COS / Turkish Lira",
+    "description": "COS to Turkish Lira spot trading pair",
+    "tags": [
+      "cos",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "COSUSDT": {
+    "normalized_id": "COS/USD",
+    "base": "COS",
+    "quote": "USD",
+    "display_name": "COS / US Dollar",
+    "description": "COS to US Dollar spot trading pair",
+    "tags": [
+      "cos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COTIBTC": {
+    "normalized_id": "COTI/BTC",
+    "base": "COTI",
+    "quote": "BTC",
+    "display_name": "COTI / Bitcoin",
+    "description": "COTI to Bitcoin spot trading pair",
+    "tags": [
+      "coti",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "COTITRY": {
+    "normalized_id": "COTI/TRY",
+    "base": "COTI",
+    "quote": "TRY",
+    "display_name": "COTI / Turkish Lira",
+    "description": "COTI to Turkish Lira spot trading pair",
+    "tags": [
+      "coti",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "COTIUSDT": {
+    "normalized_id": "COTI/USD",
+    "base": "COTI",
+    "quote": "USD",
+    "display_name": "COTI / US Dollar",
+    "description": "COTI to US Dollar spot trading pair",
+    "tags": [
+      "coti",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COWTRY": {
+    "normalized_id": "COW/TRY",
+    "base": "COW",
+    "quote": "TRY",
+    "display_name": "COW / Turkish Lira",
+    "description": "COW to Turkish Lira spot trading pair",
+    "tags": [
+      "cow",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "COWUSDC": {
+    "normalized_id": "COW/USD",
+    "base": "COW",
+    "quote": "USD",
+    "display_name": "COW / US Dollar",
+    "description": "COW to US Dollar spot trading pair",
+    "tags": [
+      "cow",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COWUSDT": {
+    "normalized_id": "COW/USD",
+    "base": "COW",
+    "quote": "USD",
+    "display_name": "COW / US Dollar",
+    "description": "COW to US Dollar spot trading pair",
+    "tags": [
+      "cow",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CRVBTC": {
+    "normalized_id": "CRV/BTC",
+    "base": "CRV",
+    "quote": "BTC",
+    "display_name": "Curve / Bitcoin",
+    "description": "Curve to Bitcoin spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "CRVTRY": {
+    "normalized_id": "CRV/TRY",
+    "base": "CRV",
+    "quote": "TRY",
+    "display_name": "Curve / Turkish Lira",
+    "description": "Curve to Turkish Lira spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "CRVUSDC": {
+    "normalized_id": "CRV/USD",
+    "base": "CRV",
+    "quote": "USD",
+    "display_name": "Curve / US Dollar",
+    "description": "Curve to US Dollar spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CRVUSDT": {
+    "normalized_id": "CRV/USD",
+    "base": "CRV",
+    "quote": "USD",
+    "display_name": "Curve / US Dollar",
+    "description": "Curve to US Dollar spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CTKBNB": {
+    "normalized_id": "CTK/BNB",
+    "base": "CTK",
+    "quote": "BNB",
+    "display_name": "CTK / Binance Coin",
+    "description": "CTK to Binance Coin spot trading pair",
+    "tags": [
+      "ctk",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "CTKBTC": {
+    "normalized_id": "CTK/BTC",
+    "base": "CTK",
+    "quote": "BTC",
+    "display_name": "CTK / Bitcoin",
+    "description": "CTK to Bitcoin spot trading pair",
+    "tags": [
+      "ctk",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "CTKUSDT": {
+    "normalized_id": "CTK/USD",
+    "base": "CTK",
+    "quote": "USD",
+    "display_name": "CTK / US Dollar",
+    "description": "CTK to US Dollar spot trading pair",
+    "tags": [
+      "ctk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CTRY": {
+    "normalized_id": "C/TRY",
+    "base": "C",
+    "quote": "TRY",
+    "display_name": "C / Turkish Lira",
+    "description": "C to Turkish Lira spot trading pair",
+    "tags": [
+      "c",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "CTSIBTC": {
+    "normalized_id": "CTSI/BTC",
+    "base": "CTSI",
+    "quote": "BTC",
+    "display_name": "CTSI / Bitcoin",
+    "description": "CTSI to Bitcoin spot trading pair",
+    "tags": [
+      "ctsi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "CTSIUSDT": {
+    "normalized_id": "CTSI/USD",
+    "base": "CTSI",
+    "quote": "USD",
+    "display_name": "CTSI / US Dollar",
+    "description": "CTSI to US Dollar spot trading pair",
+    "tags": [
+      "ctsi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CUSDC": {
+    "normalized_id": "C/USD",
+    "base": "C",
+    "quote": "USD",
+    "display_name": "C / US Dollar",
+    "description": "C to US Dollar spot trading pair",
+    "tags": [
+      "c",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CUSDT": {
+    "normalized_id": "C/USD",
+    "base": "C",
+    "quote": "USD",
+    "display_name": "C / US Dollar",
+    "description": "C to US Dollar spot trading pair",
+    "tags": [
+      "c",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CVCUSDC": {
+    "normalized_id": "CVC/USD",
+    "base": "CVC",
+    "quote": "USD",
+    "display_name": "CVC / US Dollar",
+    "description": "CVC to US Dollar spot trading pair",
+    "tags": [
+      "cvc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CVCUSDT": {
+    "normalized_id": "CVC/USD",
+    "base": "CVC",
+    "quote": "USD",
+    "display_name": "CVC / US Dollar",
+    "description": "CVC to US Dollar spot trading pair",
+    "tags": [
+      "cvc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CVXUSDC": {
+    "normalized_id": "CVX/USD",
+    "base": "CVX",
+    "quote": "USD",
+    "display_name": "CVX / US Dollar",
+    "description": "CVX to US Dollar spot trading pair",
+    "tags": [
+      "cvx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CVXUSDT": {
+    "normalized_id": "CVX/USD",
+    "base": "CVX",
+    "quote": "USD",
+    "display_name": "CVX / US Dollar",
+    "description": "CVX to US Dollar spot trading pair",
+    "tags": [
+      "cvx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CYBERBNB": {
+    "normalized_id": "CYBER/BNB",
+    "base": "CYBER",
+    "quote": "BNB",
+    "display_name": "CYBER / Binance Coin",
+    "description": "CYBER to Binance Coin spot trading pair",
+    "tags": [
+      "cyber",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "CYBERBTC": {
+    "normalized_id": "CYBER/BTC",
+    "base": "CYBER",
+    "quote": "BTC",
+    "display_name": "CYBER / Bitcoin",
+    "description": "CYBER to Bitcoin spot trading pair",
+    "tags": [
+      "cyber",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "CYBERETH": {
+    "normalized_id": "CYBER/ETH",
+    "base": "CYBER",
+    "quote": "ETH",
+    "display_name": "CYBER / Ethereum",
+    "description": "CYBER to Ethereum spot trading pair",
+    "tags": [
+      "cyber",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "CYBERFDUSD": {
+    "normalized_id": "CYBER/USD",
+    "base": "CYBER",
+    "quote": "USD",
+    "display_name": "CYBER / US Dollar",
+    "description": "CYBER to US Dollar spot trading pair",
+    "tags": [
+      "cyber",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CYBERTRY": {
+    "normalized_id": "CYBER/TRY",
+    "base": "CYBER",
+    "quote": "TRY",
+    "display_name": "CYBER / Turkish Lira",
+    "description": "CYBER to Turkish Lira spot trading pair",
+    "tags": [
+      "cyber",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "CYBERUSDT": {
+    "normalized_id": "CYBER/USD",
+    "base": "CYBER",
+    "quote": "USD",
+    "display_name": "CYBER / US Dollar",
+    "description": "CYBER to US Dollar spot trading pair",
+    "tags": [
+      "cyber",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DAIJPY": {
+    "normalized_id": "DAI/JPY",
+    "base": "DAI",
+    "quote": "JPY",
+    "display_name": "Dai / Japanese Yen",
+    "description": "Dai to Japanese Yen spot trading pair",
+    "tags": [
+      "dai",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "DASHBTC": {
+    "normalized_id": "DASH/BTC",
+    "base": "DASH",
+    "quote": "BTC",
+    "display_name": "DASH / Bitcoin",
+    "description": "DASH to Bitcoin spot trading pair",
+    "tags": [
+      "dash",
+      "privacy",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "DASHETH": {
+    "normalized_id": "DASH/ETH",
+    "base": "DASH",
+    "quote": "ETH",
+    "display_name": "DASH / Ethereum",
+    "description": "DASH to Ethereum spot trading pair",
+    "tags": [
+      "dash",
+      "privacy",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "DASHUSDT": {
+    "normalized_id": "DASH/USD",
+    "base": "DASH",
+    "quote": "USD",
+    "display_name": "DASH / US Dollar",
+    "description": "DASH to US Dollar spot trading pair",
+    "tags": [
+      "dash",
+      "privacy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DATAUSDT": {
+    "normalized_id": "DATA/USD",
+    "base": "DATA",
+    "quote": "USD",
+    "display_name": "DATA / US Dollar",
+    "description": "DATA to US Dollar spot trading pair",
+    "tags": [
+      "data",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DCRUSDT": {
+    "normalized_id": "DCR/USD",
+    "base": "DCR",
+    "quote": "USD",
+    "display_name": "DCR / US Dollar",
+    "description": "DCR to US Dollar spot trading pair",
+    "tags": [
+      "dcr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DEGOUSDT": {
+    "normalized_id": "DEGO/USD",
+    "base": "DEGO",
+    "quote": "USD",
+    "display_name": "DEGO / US Dollar",
+    "description": "DEGO to US Dollar spot trading pair",
+    "tags": [
+      "dego",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DENTETH": {
+    "normalized_id": "DENT/ETH",
+    "base": "DENT",
+    "quote": "ETH",
+    "display_name": "DENT / Ethereum",
+    "description": "DENT to Ethereum spot trading pair",
+    "tags": [
+      "dent",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "DENTTRY": {
+    "normalized_id": "DENT/TRY",
+    "base": "DENT",
+    "quote": "TRY",
+    "display_name": "DENT / Turkish Lira",
+    "description": "DENT to Turkish Lira spot trading pair",
+    "tags": [
+      "dent",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "DENTUSDT": {
+    "normalized_id": "DENT/USD",
+    "base": "DENT",
+    "quote": "USD",
+    "display_name": "DENT / US Dollar",
+    "description": "DENT to US Dollar spot trading pair",
+    "tags": [
+      "dent",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DEXEUSDT": {
+    "normalized_id": "DEXE/USD",
+    "base": "DEXE",
+    "quote": "USD",
+    "display_name": "DEXE / US Dollar",
+    "description": "DEXE to US Dollar spot trading pair",
+    "tags": [
+      "dexe",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DFUSDC": {
+    "normalized_id": "DF/USD",
+    "base": "DF",
+    "quote": "USD",
+    "display_name": "DF / US Dollar",
+    "description": "DF to US Dollar spot trading pair",
+    "tags": [
+      "df",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DFUSDT": {
+    "normalized_id": "DF/USD",
+    "base": "DF",
+    "quote": "USD",
+    "display_name": "DF / US Dollar",
+    "description": "DF to US Dollar spot trading pair",
+    "tags": [
+      "df",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DGBUSDT": {
+    "normalized_id": "DGB/USD",
+    "base": "DGB",
+    "quote": "USD",
+    "display_name": "DGB / US Dollar",
+    "description": "DGB to US Dollar spot trading pair",
+    "tags": [
+      "dgb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DIABTC": {
+    "normalized_id": "DIA/BTC",
+    "base": "DIA",
+    "quote": "BTC",
+    "display_name": "DIA / Bitcoin",
+    "description": "DIA to Bitcoin spot trading pair",
+    "tags": [
+      "dia",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "DIAUSDT": {
+    "normalized_id": "DIA/USD",
+    "base": "DIA",
+    "quote": "USD",
+    "display_name": "DIA / US Dollar",
+    "description": "DIA to US Dollar spot trading pair",
+    "tags": [
+      "dia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DODOUSDT": {
+    "normalized_id": "DODO/USD",
+    "base": "DODO",
+    "quote": "USD",
+    "display_name": "DODO / US Dollar",
+    "description": "DODO to US Dollar spot trading pair",
+    "tags": [
+      "dodo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGEBRL": {
+    "normalized_id": "DOGE/BRL",
+    "base": "DOGE",
+    "quote": "BRL",
+    "display_name": "Dogecoin / Brazilian Real",
+    "description": "Dogecoin to Brazilian Real spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "DOGEBTC": {
+    "normalized_id": "DOGE/BTC",
+    "base": "DOGE",
+    "quote": "BTC",
+    "display_name": "Dogecoin / Bitcoin",
+    "description": "Dogecoin to Bitcoin spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "DOGEEUR": {
+    "normalized_id": "DOGE/EUR",
+    "base": "DOGE",
+    "quote": "EUR",
+    "display_name": "Dogecoin / Euro",
+    "description": "Dogecoin to Euro spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DOGEFDUSD": {
+    "normalized_id": "DOGE/USD",
+    "base": "DOGE",
+    "quote": "USD",
+    "display_name": "Dogecoin / US Dollar",
+    "description": "Dogecoin to US Dollar spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGEJPY": {
+    "normalized_id": "DOGE/JPY",
+    "base": "DOGE",
+    "quote": "JPY",
+    "display_name": "Dogecoin / Japanese Yen",
+    "description": "Dogecoin to Japanese Yen spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "DOGETRY": {
+    "normalized_id": "DOGE/TRY",
+    "base": "DOGE",
+    "quote": "TRY",
+    "display_name": "Dogecoin / Turkish Lira",
+    "description": "Dogecoin to Turkish Lira spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "DOGEUSDC": {
+    "normalized_id": "DOGE/USD",
+    "base": "DOGE",
+    "quote": "USD",
+    "display_name": "Dogecoin / US Dollar",
+    "description": "Dogecoin to US Dollar spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGEUSDT": {
+    "normalized_id": "DOGE/USD",
+    "base": "DOGE",
+    "quote": "USD",
+    "display_name": "Dogecoin / US Dollar",
+    "description": "Dogecoin to US Dollar spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGSFDUSD": {
+    "normalized_id": "DOGS/USD",
+    "base": "DOGS",
+    "quote": "USD",
+    "display_name": "DOGS / US Dollar",
+    "description": "DOGS to US Dollar spot trading pair",
+    "tags": [
+      "dogs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGSTRY": {
+    "normalized_id": "DOGS/TRY",
+    "base": "DOGS",
+    "quote": "TRY",
+    "display_name": "DOGS / Turkish Lira",
+    "description": "DOGS to Turkish Lira spot trading pair",
+    "tags": [
+      "dogs",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "DOGSUSDC": {
+    "normalized_id": "DOGS/USD",
+    "base": "DOGS",
+    "quote": "USD",
+    "display_name": "DOGS / US Dollar",
+    "description": "DOGS to US Dollar spot trading pair",
+    "tags": [
+      "dogs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGSUSDT": {
+    "normalized_id": "DOGS/USD",
+    "base": "DOGS",
+    "quote": "USD",
+    "display_name": "DOGS / US Dollar",
+    "description": "DOGS to US Dollar spot trading pair",
+    "tags": [
+      "dogs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOTBNB": {
+    "normalized_id": "DOT/BNB",
+    "base": "DOT",
+    "quote": "BNB",
+    "display_name": "Polkadot / Binance Coin",
+    "description": "Polkadot to Binance Coin spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "DOTBRL": {
+    "normalized_id": "DOT/BRL",
+    "base": "DOT",
+    "quote": "BRL",
+    "display_name": "Polkadot / Brazilian Real",
+    "description": "Polkadot to Brazilian Real spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "DOTBTC": {
+    "normalized_id": "DOT/BTC",
+    "base": "DOT",
+    "quote": "BTC",
+    "display_name": "Polkadot / Bitcoin",
+    "description": "Polkadot to Bitcoin spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "DOTETH": {
+    "normalized_id": "DOT/ETH",
+    "base": "DOT",
+    "quote": "ETH",
+    "display_name": "Polkadot / Ethereum",
+    "description": "Polkadot to Ethereum spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "DOTEUR": {
+    "normalized_id": "DOT/EUR",
+    "base": "DOT",
+    "quote": "EUR",
+    "display_name": "Polkadot / Euro",
+    "description": "Polkadot to Euro spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DOTFDUSD": {
+    "normalized_id": "DOT/USD",
+    "base": "DOT",
+    "quote": "USD",
+    "display_name": "Polkadot / US Dollar",
+    "description": "Polkadot to US Dollar spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOTTRY": {
+    "normalized_id": "DOT/TRY",
+    "base": "DOT",
+    "quote": "TRY",
+    "display_name": "Polkadot / Turkish Lira",
+    "description": "Polkadot to Turkish Lira spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "DOTUSDC": {
+    "normalized_id": "DOT/USD",
+    "base": "DOT",
+    "quote": "USD",
+    "display_name": "Polkadot / US Dollar",
+    "description": "Polkadot to US Dollar spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOTUSDT": {
+    "normalized_id": "DOT/USD",
+    "base": "DOT",
+    "quote": "USD",
+    "display_name": "Polkadot / US Dollar",
+    "description": "Polkadot to US Dollar spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DTRY": {
+    "normalized_id": "D/TRY",
+    "base": "D",
+    "quote": "TRY",
+    "display_name": "D / Turkish Lira",
+    "description": "D to Turkish Lira spot trading pair",
+    "tags": [
+      "d",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "DUSDT": {
+    "normalized_id": "D/USD",
+    "base": "D",
+    "quote": "USD",
+    "display_name": "D / US Dollar",
+    "description": "D to US Dollar spot trading pair",
+    "tags": [
+      "d",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DUSKBTC": {
+    "normalized_id": "DUSK/BTC",
+    "base": "DUSK",
+    "quote": "BTC",
+    "display_name": "DUSK / Bitcoin",
+    "description": "DUSK to Bitcoin spot trading pair",
+    "tags": [
+      "dusk",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "DUSKUSDT": {
+    "normalized_id": "DUSK/USD",
+    "base": "DUSK",
+    "quote": "USD",
+    "display_name": "DUSK / US Dollar",
+    "description": "DUSK to US Dollar spot trading pair",
+    "tags": [
+      "dusk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DYDXBTC": {
+    "normalized_id": "DYDX/BTC",
+    "base": "DYDX",
+    "quote": "BTC",
+    "display_name": "DYDX / Bitcoin",
+    "description": "DYDX to Bitcoin spot trading pair",
+    "tags": [
+      "dydx",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "DYDXFDUSD": {
+    "normalized_id": "DYDX/USD",
+    "base": "DYDX",
+    "quote": "USD",
+    "display_name": "DYDX / US Dollar",
+    "description": "DYDX to US Dollar spot trading pair",
+    "tags": [
+      "dydx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DYDXTRY": {
+    "normalized_id": "DYDX/TRY",
+    "base": "DYDX",
+    "quote": "TRY",
+    "display_name": "DYDX / Turkish Lira",
+    "description": "DYDX to Turkish Lira spot trading pair",
+    "tags": [
+      "dydx",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "DYDXUSDC": {
+    "normalized_id": "DYDX/USD",
+    "base": "DYDX",
+    "quote": "USD",
+    "display_name": "DYDX / US Dollar",
+    "description": "DYDX to US Dollar spot trading pair",
+    "tags": [
+      "dydx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DYDXUSDT": {
+    "normalized_id": "DYDX/USD",
+    "base": "DYDX",
+    "quote": "USD",
+    "display_name": "DYDX / US Dollar",
+    "description": "DYDX to US Dollar spot trading pair",
+    "tags": [
+      "dydx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DYMTRY": {
+    "normalized_id": "DYM/TRY",
+    "base": "DYM",
+    "quote": "TRY",
+    "display_name": "DYM / Turkish Lira",
+    "description": "DYM to Turkish Lira spot trading pair",
+    "tags": [
+      "dym",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "DYMUSDT": {
+    "normalized_id": "DYM/USD",
+    "base": "DYM",
+    "quote": "USD",
+    "display_name": "DYM / US Dollar",
+    "description": "DYM to US Dollar spot trading pair",
+    "tags": [
+      "dym",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EDUTRY": {
+    "normalized_id": "EDU/TRY",
+    "base": "EDU",
+    "quote": "TRY",
+    "display_name": "EDU / Turkish Lira",
+    "description": "EDU to Turkish Lira spot trading pair",
+    "tags": [
+      "edu",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "EDUUSDT": {
+    "normalized_id": "EDU/USD",
+    "base": "EDU",
+    "quote": "USD",
+    "display_name": "EDU / US Dollar",
+    "description": "EDU to US Dollar spot trading pair",
+    "tags": [
+      "edu",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EGLDBNB": {
+    "normalized_id": "EGLD/BNB",
+    "base": "EGLD",
+    "quote": "BNB",
+    "display_name": "MultiversX / Binance Coin",
+    "description": "MultiversX to Binance Coin spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "EGLDBTC": {
+    "normalized_id": "EGLD/BTC",
+    "base": "EGLD",
+    "quote": "BTC",
+    "display_name": "MultiversX / Bitcoin",
+    "description": "MultiversX to Bitcoin spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "EGLDETH": {
+    "normalized_id": "EGLD/ETH",
+    "base": "EGLD",
+    "quote": "ETH",
+    "display_name": "MultiversX / Ethereum",
+    "description": "MultiversX to Ethereum spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "EGLDEUR": {
+    "normalized_id": "EGLD/EUR",
+    "base": "EGLD",
+    "quote": "EUR",
+    "display_name": "MultiversX / Euro",
+    "description": "MultiversX to Euro spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "EGLDFDUSD": {
+    "normalized_id": "EGLD/USD",
+    "base": "EGLD",
+    "quote": "USD",
+    "display_name": "MultiversX / US Dollar",
+    "description": "MultiversX to US Dollar spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EGLDTRY": {
+    "normalized_id": "EGLD/TRY",
+    "base": "EGLD",
+    "quote": "TRY",
+    "display_name": "MultiversX / Turkish Lira",
+    "description": "MultiversX to Turkish Lira spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "EGLDUSDC": {
+    "normalized_id": "EGLD/USD",
+    "base": "EGLD",
+    "quote": "USD",
+    "display_name": "MultiversX / US Dollar",
+    "description": "MultiversX to US Dollar spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EGLDUSDT": {
+    "normalized_id": "EGLD/USD",
+    "base": "EGLD",
+    "quote": "USD",
+    "display_name": "MultiversX / US Dollar",
+    "description": "MultiversX to US Dollar spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EIGENBTC": {
+    "normalized_id": "EIGEN/BTC",
+    "base": "EIGEN",
+    "quote": "BTC",
+    "display_name": "EIGEN / Bitcoin",
+    "description": "EIGEN to Bitcoin spot trading pair",
+    "tags": [
+      "eigen",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "EIGENFDUSD": {
+    "normalized_id": "EIGEN/USD",
+    "base": "EIGEN",
+    "quote": "USD",
+    "display_name": "EIGEN / US Dollar",
+    "description": "EIGEN to US Dollar spot trading pair",
+    "tags": [
+      "eigen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EIGENTRY": {
+    "normalized_id": "EIGEN/TRY",
+    "base": "EIGEN",
+    "quote": "TRY",
+    "display_name": "EIGEN / Turkish Lira",
+    "description": "EIGEN to Turkish Lira spot trading pair",
+    "tags": [
+      "eigen",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "EIGENUSDC": {
+    "normalized_id": "EIGEN/USD",
+    "base": "EIGEN",
+    "quote": "USD",
+    "display_name": "EIGEN / US Dollar",
+    "description": "EIGEN to US Dollar spot trading pair",
+    "tags": [
+      "eigen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EIGENUSDT": {
+    "normalized_id": "EIGEN/USD",
+    "base": "EIGEN",
+    "quote": "USD",
+    "display_name": "EIGEN / US Dollar",
+    "description": "EIGEN to US Dollar spot trading pair",
+    "tags": [
+      "eigen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENABNB": {
+    "normalized_id": "ENA/BNB",
+    "base": "ENA",
+    "quote": "BNB",
+    "display_name": "ENA / Binance Coin",
+    "description": "ENA to Binance Coin spot trading pair",
+    "tags": [
+      "ena",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "ENABRL": {
+    "normalized_id": "ENA/BRL",
+    "base": "ENA",
+    "quote": "BRL",
+    "display_name": "ENA / Brazilian Real",
+    "description": "ENA to Brazilian Real spot trading pair",
+    "tags": [
+      "ena",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "ENABTC": {
+    "normalized_id": "ENA/BTC",
+    "base": "ENA",
+    "quote": "BTC",
+    "display_name": "ENA / Bitcoin",
+    "description": "ENA to Bitcoin spot trading pair",
+    "tags": [
+      "ena",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ENAFDUSD": {
+    "normalized_id": "ENA/USD",
+    "base": "ENA",
+    "quote": "USD",
+    "display_name": "ENA / US Dollar",
+    "description": "ENA to US Dollar spot trading pair",
+    "tags": [
+      "ena",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENATRY": {
+    "normalized_id": "ENA/TRY",
+    "base": "ENA",
+    "quote": "TRY",
+    "display_name": "ENA / Turkish Lira",
+    "description": "ENA to Turkish Lira spot trading pair",
+    "tags": [
+      "ena",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ENAUSDC": {
+    "normalized_id": "ENA/USD",
+    "base": "ENA",
+    "quote": "USD",
+    "display_name": "ENA / US Dollar",
+    "description": "ENA to US Dollar spot trading pair",
+    "tags": [
+      "ena",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENAUSDT": {
+    "normalized_id": "ENA/USD",
+    "base": "ENA",
+    "quote": "USD",
+    "display_name": "ENA / US Dollar",
+    "description": "ENA to US Dollar spot trading pair",
+    "tags": [
+      "ena",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENJBTC": {
+    "normalized_id": "ENJ/BTC",
+    "base": "ENJ",
+    "quote": "BTC",
+    "display_name": "Enjin / Bitcoin",
+    "description": "Enjin to Bitcoin spot trading pair",
+    "tags": [
+      "enj",
+      "enjin",
+      "gaming",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ENJTRY": {
+    "normalized_id": "ENJ/TRY",
+    "base": "ENJ",
+    "quote": "TRY",
+    "display_name": "Enjin / Turkish Lira",
+    "description": "Enjin to Turkish Lira spot trading pair",
+    "tags": [
+      "enj",
+      "enjin",
+      "gaming",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ENJUSDC": {
+    "normalized_id": "ENJ/USD",
+    "base": "ENJ",
+    "quote": "USD",
+    "display_name": "Enjin / US Dollar",
+    "description": "Enjin to US Dollar spot trading pair",
+    "tags": [
+      "enj",
+      "enjin",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENJUSDT": {
+    "normalized_id": "ENJ/USD",
+    "base": "ENJ",
+    "quote": "USD",
+    "display_name": "Enjin / US Dollar",
+    "description": "Enjin to US Dollar spot trading pair",
+    "tags": [
+      "enj",
+      "enjin",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENSBTC": {
+    "normalized_id": "ENS/BTC",
+    "base": "ENS",
+    "quote": "BTC",
+    "display_name": "ENS / Bitcoin",
+    "description": "ENS to Bitcoin spot trading pair",
+    "tags": [
+      "ens",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ENSFDUSD": {
+    "normalized_id": "ENS/USD",
+    "base": "ENS",
+    "quote": "USD",
+    "display_name": "ENS / US Dollar",
+    "description": "ENS to US Dollar spot trading pair",
+    "tags": [
+      "ens",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENSTRY": {
+    "normalized_id": "ENS/TRY",
+    "base": "ENS",
+    "quote": "TRY",
+    "display_name": "ENS / Turkish Lira",
+    "description": "ENS to Turkish Lira spot trading pair",
+    "tags": [
+      "ens",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ENSUSDC": {
+    "normalized_id": "ENS/USD",
+    "base": "ENS",
+    "quote": "USD",
+    "display_name": "ENS / US Dollar",
+    "description": "ENS to US Dollar spot trading pair",
+    "tags": [
+      "ens",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENSUSDT": {
+    "normalized_id": "ENS/USD",
+    "base": "ENS",
+    "quote": "USD",
+    "display_name": "ENS / US Dollar",
+    "description": "ENS to US Dollar spot trading pair",
+    "tags": [
+      "ens",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EPICUSDC": {
+    "normalized_id": "EPIC/USD",
+    "base": "EPIC",
+    "quote": "USD",
+    "display_name": "EPIC / US Dollar",
+    "description": "EPIC to US Dollar spot trading pair",
+    "tags": [
+      "epic",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EPICUSDT": {
+    "normalized_id": "EPIC/USD",
+    "base": "EPIC",
+    "quote": "USD",
+    "display_name": "EPIC / US Dollar",
+    "description": "EPIC to US Dollar spot trading pair",
+    "tags": [
+      "epic",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ERABNB": {
+    "normalized_id": "ERA/BNB",
+    "base": "ERA",
+    "quote": "BNB",
+    "display_name": "ERA / Binance Coin",
+    "description": "ERA to Binance Coin spot trading pair",
+    "tags": [
+      "era",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "ERAFDUSD": {
+    "normalized_id": "ERA/USD",
+    "base": "ERA",
+    "quote": "USD",
+    "display_name": "ERA / US Dollar",
+    "description": "ERA to US Dollar spot trading pair",
+    "tags": [
+      "era",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ERATRY": {
+    "normalized_id": "ERA/TRY",
+    "base": "ERA",
+    "quote": "TRY",
+    "display_name": "ERA / Turkish Lira",
+    "description": "ERA to Turkish Lira spot trading pair",
+    "tags": [
+      "era",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ERAUSDC": {
+    "normalized_id": "ERA/USD",
+    "base": "ERA",
+    "quote": "USD",
+    "display_name": "ERA / US Dollar",
+    "description": "ERA to US Dollar spot trading pair",
+    "tags": [
+      "era",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ERAUSDT": {
+    "normalized_id": "ERA/USD",
+    "base": "ERA",
+    "quote": "USD",
+    "display_name": "ERA / US Dollar",
+    "description": "ERA to US Dollar spot trading pair",
+    "tags": [
+      "era",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETCBNB": {
+    "normalized_id": "ETC/BNB",
+    "base": "ETC",
+    "quote": "BNB",
+    "display_name": "ETC / Binance Coin",
+    "description": "ETC to Binance Coin spot trading pair",
+    "tags": [
+      "etc",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "ETCBTC": {
+    "normalized_id": "ETC/BTC",
+    "base": "ETC",
+    "quote": "BTC",
+    "display_name": "ETC / Bitcoin",
+    "description": "ETC to Bitcoin spot trading pair",
+    "tags": [
+      "etc",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ETCETH": {
+    "normalized_id": "ETC/ETH",
+    "base": "ETC",
+    "quote": "ETH",
+    "display_name": "ETC / Ethereum",
+    "description": "ETC to Ethereum spot trading pair",
+    "tags": [
+      "etc",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "ETCFDUSD": {
+    "normalized_id": "ETC/USD",
+    "base": "ETC",
+    "quote": "USD",
+    "display_name": "ETC / US Dollar",
+    "description": "ETC to US Dollar spot trading pair",
+    "tags": [
+      "etc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETCTRY": {
+    "normalized_id": "ETC/TRY",
+    "base": "ETC",
+    "quote": "TRY",
+    "display_name": "ETC / Turkish Lira",
+    "description": "ETC to Turkish Lira spot trading pair",
+    "tags": [
+      "etc",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ETCUSDC": {
+    "normalized_id": "ETC/USD",
+    "base": "ETC",
+    "quote": "USD",
+    "display_name": "ETC / US Dollar",
+    "description": "ETC to US Dollar spot trading pair",
+    "tags": [
+      "etc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETCUSDT": {
+    "normalized_id": "ETC/USD",
+    "base": "ETC",
+    "quote": "USD",
+    "display_name": "ETC / US Dollar",
+    "description": "ETC to US Dollar spot trading pair",
+    "tags": [
+      "etc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETHBRL": {
+    "normalized_id": "ETH/BRL",
+    "base": "ETH",
+    "quote": "BRL",
+    "display_name": "Ethereum / Brazilian Real",
+    "description": "Ethereum to Brazilian Real spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "ETHBTC": {
+    "normalized_id": "ETH/BTC",
+    "base": "ETH",
+    "quote": "BTC",
+    "display_name": "Ethereum / Bitcoin",
+    "description": "Ethereum to Bitcoin spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ETHEUR": {
+    "normalized_id": "ETH/EUR",
+    "base": "ETH",
+    "quote": "EUR",
+    "display_name": "Ethereum / Euro",
+    "description": "Ethereum to Euro spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ETHFDUSD": {
+    "normalized_id": "ETH/USD",
+    "base": "ETH",
+    "quote": "USD",
+    "display_name": "Ethereum / US Dollar",
+    "description": "Ethereum to US Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETHFIFDUSD": {
+    "normalized_id": "ETHFI/USD",
+    "base": "ETHFI",
+    "quote": "USD",
+    "display_name": "ETHFI / US Dollar",
+    "description": "ETHFI to US Dollar spot trading pair",
+    "tags": [
+      "ethfi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETHFITRY": {
+    "normalized_id": "ETHFI/TRY",
+    "base": "ETHFI",
+    "quote": "TRY",
+    "display_name": "ETHFI / Turkish Lira",
+    "description": "ETHFI to Turkish Lira spot trading pair",
+    "tags": [
+      "ethfi",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ETHFIUSDC": {
+    "normalized_id": "ETHFI/USD",
+    "base": "ETHFI",
+    "quote": "USD",
+    "display_name": "ETHFI / US Dollar",
+    "description": "ETHFI to US Dollar spot trading pair",
+    "tags": [
+      "ethfi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETHFIUSDT": {
+    "normalized_id": "ETHFI/USD",
+    "base": "ETHFI",
+    "quote": "USD",
+    "display_name": "ETHFI / US Dollar",
+    "description": "ETHFI to US Dollar spot trading pair",
+    "tags": [
+      "ethfi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETHJPY": {
+    "normalized_id": "ETH/JPY",
+    "base": "ETH",
+    "quote": "JPY",
+    "display_name": "Ethereum / Japanese Yen",
+    "description": "Ethereum to Japanese Yen spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "ETHTRY": {
+    "normalized_id": "ETH/TRY",
+    "base": "ETH",
+    "quote": "TRY",
+    "display_name": "Ethereum / Turkish Lira",
+    "description": "Ethereum to Turkish Lira spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ETHUSDC": {
+    "normalized_id": "ETH/USD",
+    "base": "ETH",
+    "quote": "USD",
+    "display_name": "Ethereum / US Dollar",
+    "description": "Ethereum to US Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETHUSDT": {
+    "normalized_id": "ETH/USD",
+    "base": "ETH",
+    "quote": "USD",
+    "display_name": "Ethereum / US Dollar",
+    "description": "Ethereum to US Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EURIUSDC": {
+    "normalized_id": "EURI/USD",
+    "base": "EURI",
+    "quote": "USD",
+    "display_name": "EURI / US Dollar",
+    "description": "EURI to US Dollar spot trading pair",
+    "tags": [
+      "euri",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EURIUSDT": {
+    "normalized_id": "EURI/USD",
+    "base": "EURI",
+    "quote": "USD",
+    "display_name": "EURI / US Dollar",
+    "description": "EURI to US Dollar spot trading pair",
+    "tags": [
+      "euri",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EURUSDC": {
+    "normalized_id": "EUR/USD",
+    "base": "EUR",
+    "quote": "USD",
+    "display_name": "Euro / US Dollar",
+    "description": "Euro to US Dollar  trading pair",
+    "tags": [
+      "eur",
+      "euro",
+      "usd"
+    ],
+    "category": "forex"
+  },
+  "EURUSDT": {
+    "normalized_id": "EUR/USD",
+    "base": "EUR",
+    "quote": "USD",
+    "display_name": "Euro / US Dollar",
+    "description": "Euro to US Dollar  trading pair",
+    "tags": [
+      "eur",
+      "euro",
+      "usd"
+    ],
+    "category": "forex"
+  },
+  "FARMUSDT": {
+    "normalized_id": "FARM/USD",
+    "base": "FARM",
+    "quote": "USD",
+    "display_name": "FARM / US Dollar",
+    "description": "FARM to US Dollar spot trading pair",
+    "tags": [
+      "farm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FDUSDTRY": {
+    "normalized_id": "FDUSD/TRY",
+    "base": "FDUSD",
+    "quote": "TRY",
+    "display_name": "FDUSD / Turkish Lira",
+    "description": "FDUSD to Turkish Lira spot trading pair",
+    "tags": [
+      "fdusd",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "FDUSDUSDC": {
+    "normalized_id": "FDUSD/USD",
+    "base": "FDUSD",
+    "quote": "USD",
+    "display_name": "FDUSD / US Dollar",
+    "description": "FDUSD to US Dollar spot trading pair",
+    "tags": [
+      "fdusd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FDUSDUSDT": {
+    "normalized_id": "FDUSD/USD",
+    "base": "FDUSD",
+    "quote": "USD",
+    "display_name": "FDUSD / US Dollar",
+    "description": "FDUSD to US Dollar spot trading pair",
+    "tags": [
+      "fdusd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FETBNB": {
+    "normalized_id": "FET/BNB",
+    "base": "FET",
+    "quote": "BNB",
+    "display_name": "FET / Binance Coin",
+    "description": "FET to Binance Coin spot trading pair",
+    "tags": [
+      "fet",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "FETBTC": {
+    "normalized_id": "FET/BTC",
+    "base": "FET",
+    "quote": "BTC",
+    "display_name": "FET / Bitcoin",
+    "description": "FET to Bitcoin spot trading pair",
+    "tags": [
+      "fet",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "FETFDUSD": {
+    "normalized_id": "FET/USD",
+    "base": "FET",
+    "quote": "USD",
+    "display_name": "FET / US Dollar",
+    "description": "FET to US Dollar spot trading pair",
+    "tags": [
+      "fet",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FETTRY": {
+    "normalized_id": "FET/TRY",
+    "base": "FET",
+    "quote": "TRY",
+    "display_name": "FET / Turkish Lira",
+    "description": "FET to Turkish Lira spot trading pair",
+    "tags": [
+      "fet",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "FETUSDC": {
+    "normalized_id": "FET/USD",
+    "base": "FET",
+    "quote": "USD",
+    "display_name": "FET / US Dollar",
+    "description": "FET to US Dollar spot trading pair",
+    "tags": [
+      "fet",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FETUSDT": {
+    "normalized_id": "FET/USD",
+    "base": "FET",
+    "quote": "USD",
+    "display_name": "FET / US Dollar",
+    "description": "FET to US Dollar spot trading pair",
+    "tags": [
+      "fet",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FIDABTC": {
+    "normalized_id": "FIDA/BTC",
+    "base": "FIDA",
+    "quote": "BTC",
+    "display_name": "FIDA / Bitcoin",
+    "description": "FIDA to Bitcoin spot trading pair",
+    "tags": [
+      "fida",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "FIDATRY": {
+    "normalized_id": "FIDA/TRY",
+    "base": "FIDA",
+    "quote": "TRY",
+    "display_name": "FIDA / Turkish Lira",
+    "description": "FIDA to Turkish Lira spot trading pair",
+    "tags": [
+      "fida",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "FIDAUSDT": {
+    "normalized_id": "FIDA/USD",
+    "base": "FIDA",
+    "quote": "USD",
+    "display_name": "FIDA / US Dollar",
+    "description": "FIDA to US Dollar spot trading pair",
+    "tags": [
+      "fida",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FILBTC": {
+    "normalized_id": "FIL/BTC",
+    "base": "FIL",
+    "quote": "BTC",
+    "display_name": "Filecoin / Bitcoin",
+    "description": "Filecoin to Bitcoin spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "FILETH": {
+    "normalized_id": "FIL/ETH",
+    "base": "FIL",
+    "quote": "ETH",
+    "display_name": "Filecoin / Ethereum",
+    "description": "Filecoin to Ethereum spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "FILFDUSD": {
+    "normalized_id": "FIL/USD",
+    "base": "FIL",
+    "quote": "USD",
+    "display_name": "Filecoin / US Dollar",
+    "description": "Filecoin to US Dollar spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FILTRY": {
+    "normalized_id": "FIL/TRY",
+    "base": "FIL",
+    "quote": "TRY",
+    "display_name": "Filecoin / Turkish Lira",
+    "description": "Filecoin to Turkish Lira spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "FILUSDC": {
+    "normalized_id": "FIL/USD",
+    "base": "FIL",
+    "quote": "USD",
+    "display_name": "Filecoin / US Dollar",
+    "description": "Filecoin to US Dollar spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FILUSDT": {
+    "normalized_id": "FIL/USD",
+    "base": "FIL",
+    "quote": "USD",
+    "display_name": "Filecoin / US Dollar",
+    "description": "Filecoin to US Dollar spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FIOUSDT": {
+    "normalized_id": "FIO/USD",
+    "base": "FIO",
+    "quote": "USD",
+    "display_name": "FIO / US Dollar",
+    "description": "FIO to US Dollar spot trading pair",
+    "tags": [
+      "fio",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FISBTC": {
+    "normalized_id": "FIS/BTC",
+    "base": "FIS",
+    "quote": "BTC",
+    "display_name": "FIS / Bitcoin",
+    "description": "FIS to Bitcoin spot trading pair",
+    "tags": [
+      "fis",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "FISUSDT": {
+    "normalized_id": "FIS/USD",
+    "base": "FIS",
+    "quote": "USD",
+    "display_name": "FIS / US Dollar",
+    "description": "FIS to US Dollar spot trading pair",
+    "tags": [
+      "fis",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLMBTC": {
+    "normalized_id": "FLM/BTC",
+    "base": "FLM",
+    "quote": "BTC",
+    "display_name": "FLM / Bitcoin",
+    "description": "FLM to Bitcoin spot trading pair",
+    "tags": [
+      "flm",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "FLMUSDT": {
+    "normalized_id": "FLM/USD",
+    "base": "FLM",
+    "quote": "USD",
+    "display_name": "FLM / US Dollar",
+    "description": "FLM to US Dollar spot trading pair",
+    "tags": [
+      "flm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLOKIFDUSD": {
+    "normalized_id": "FLOKI/USD",
+    "base": "FLOKI",
+    "quote": "USD",
+    "display_name": "Floki / US Dollar",
+    "description": "Floki to US Dollar spot trading pair",
+    "tags": [
+      "floki",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLOKITRY": {
+    "normalized_id": "FLOKI/TRY",
+    "base": "FLOKI",
+    "quote": "TRY",
+    "display_name": "Floki / Turkish Lira",
+    "description": "Floki to Turkish Lira spot trading pair",
+    "tags": [
+      "floki",
+      "meme",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "FLOKIUSDC": {
+    "normalized_id": "FLOKI/USD",
+    "base": "FLOKI",
+    "quote": "USD",
+    "display_name": "Floki / US Dollar",
+    "description": "Floki to US Dollar spot trading pair",
+    "tags": [
+      "floki",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLOKIUSDT": {
+    "normalized_id": "FLOKI/USD",
+    "base": "FLOKI",
+    "quote": "USD",
+    "display_name": "Floki / US Dollar",
+    "description": "Floki to US Dollar spot trading pair",
+    "tags": [
+      "floki",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLOWBTC": {
+    "normalized_id": "FLOW/BTC",
+    "base": "FLOW",
+    "quote": "BTC",
+    "display_name": "Flow / Bitcoin",
+    "description": "Flow to Bitcoin spot trading pair",
+    "tags": [
+      "flow",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "FLOWUSDT": {
+    "normalized_id": "FLOW/USD",
+    "base": "FLOW",
+    "quote": "USD",
+    "display_name": "Flow / US Dollar",
+    "description": "Flow to US Dollar spot trading pair",
+    "tags": [
+      "flow",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLUXBTC": {
+    "normalized_id": "FLUX/BTC",
+    "base": "FLUX",
+    "quote": "BTC",
+    "display_name": "FLUX / Bitcoin",
+    "description": "FLUX to Bitcoin spot trading pair",
+    "tags": [
+      "flux",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "FLUXUSDC": {
+    "normalized_id": "FLUX/USD",
+    "base": "FLUX",
+    "quote": "USD",
+    "display_name": "FLUX / US Dollar",
+    "description": "FLUX to US Dollar spot trading pair",
+    "tags": [
+      "flux",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLUXUSDT": {
+    "normalized_id": "FLUX/USD",
+    "base": "FLUX",
+    "quote": "USD",
+    "display_name": "FLUX / US Dollar",
+    "description": "FLUX to US Dollar spot trading pair",
+    "tags": [
+      "flux",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FORMTRY": {
+    "normalized_id": "FORM/TRY",
+    "base": "FORM",
+    "quote": "TRY",
+    "display_name": "FORM / Turkish Lira",
+    "description": "FORM to Turkish Lira spot trading pair",
+    "tags": [
+      "form",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "FORMUSDC": {
+    "normalized_id": "FORM/USD",
+    "base": "FORM",
+    "quote": "USD",
+    "display_name": "FORM / US Dollar",
+    "description": "FORM to US Dollar spot trading pair",
+    "tags": [
+      "form",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FORMUSDT": {
+    "normalized_id": "FORM/USD",
+    "base": "FORM",
+    "quote": "USD",
+    "display_name": "FORM / US Dollar",
+    "description": "FORM to US Dollar spot trading pair",
+    "tags": [
+      "form",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FORTHBTC": {
+    "normalized_id": "FORTH/BTC",
+    "base": "FORTH",
+    "quote": "BTC",
+    "display_name": "FORTH / Bitcoin",
+    "description": "FORTH to Bitcoin spot trading pair",
+    "tags": [
+      "forth",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "FORTHUSDT": {
+    "normalized_id": "FORTH/USD",
+    "base": "FORTH",
+    "quote": "USD",
+    "display_name": "FORTH / US Dollar",
+    "description": "FORTH to US Dollar spot trading pair",
+    "tags": [
+      "forth",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FTTUSDT": {
+    "normalized_id": "FTT/USD",
+    "base": "FTT",
+    "quote": "USD",
+    "display_name": "FTT / US Dollar",
+    "description": "FTT to US Dollar spot trading pair",
+    "tags": [
+      "ftt",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FUNUSDC": {
+    "normalized_id": "FUN/USD",
+    "base": "FUN",
+    "quote": "USD",
+    "display_name": "FUN / US Dollar",
+    "description": "FUN to US Dollar spot trading pair",
+    "tags": [
+      "fun",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FUNUSDT": {
+    "normalized_id": "FUN/USD",
+    "base": "FUN",
+    "quote": "USD",
+    "display_name": "FUN / US Dollar",
+    "description": "FUN to US Dollar spot trading pair",
+    "tags": [
+      "fun",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FXSUSDT": {
+    "normalized_id": "FXS/USD",
+    "base": "FXS",
+    "quote": "USD",
+    "display_name": "FXS / US Dollar",
+    "description": "FXS to US Dollar spot trading pair",
+    "tags": [
+      "fxs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GALABRL": {
+    "normalized_id": "GALA/BRL",
+    "base": "GALA",
+    "quote": "BRL",
+    "display_name": "Gala / Brazilian Real",
+    "description": "Gala to Brazilian Real spot trading pair",
+    "tags": [
+      "gala",
+      "gaming",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "GALABTC": {
+    "normalized_id": "GALA/BTC",
+    "base": "GALA",
+    "quote": "BTC",
+    "display_name": "Gala / Bitcoin",
+    "description": "Gala to Bitcoin spot trading pair",
+    "tags": [
+      "gala",
+      "gaming",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "GALAETH": {
+    "normalized_id": "GALA/ETH",
+    "base": "GALA",
+    "quote": "ETH",
+    "display_name": "Gala / Ethereum",
+    "description": "Gala to Ethereum spot trading pair",
+    "tags": [
+      "gala",
+      "gaming",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "GALAEUR": {
+    "normalized_id": "GALA/EUR",
+    "base": "GALA",
+    "quote": "EUR",
+    "display_name": "Gala / Euro",
+    "description": "Gala to Euro spot trading pair",
+    "tags": [
+      "gala",
+      "gaming",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GALAFDUSD": {
+    "normalized_id": "GALA/USD",
+    "base": "GALA",
+    "quote": "USD",
+    "display_name": "Gala / US Dollar",
+    "description": "Gala to US Dollar spot trading pair",
+    "tags": [
+      "gala",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GALATRY": {
+    "normalized_id": "GALA/TRY",
+    "base": "GALA",
+    "quote": "TRY",
+    "display_name": "Gala / Turkish Lira",
+    "description": "Gala to Turkish Lira spot trading pair",
+    "tags": [
+      "gala",
+      "gaming",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "GALAUSDC": {
+    "normalized_id": "GALA/USD",
+    "base": "GALA",
+    "quote": "USD",
+    "display_name": "Gala / US Dollar",
+    "description": "Gala to US Dollar spot trading pair",
+    "tags": [
+      "gala",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GALAUSDT": {
+    "normalized_id": "GALA/USD",
+    "base": "GALA",
+    "quote": "USD",
+    "display_name": "Gala / US Dollar",
+    "description": "Gala to US Dollar spot trading pair",
+    "tags": [
+      "gala",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GASBTC": {
+    "normalized_id": "GAS/BTC",
+    "base": "GAS",
+    "quote": "BTC",
+    "display_name": "GAS / Bitcoin",
+    "description": "GAS to Bitcoin spot trading pair",
+    "tags": [
+      "gas",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "GASTRY": {
+    "normalized_id": "GAS/TRY",
+    "base": "GAS",
+    "quote": "TRY",
+    "display_name": "GAS / Turkish Lira",
+    "description": "GAS to Turkish Lira spot trading pair",
+    "tags": [
+      "gas",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "GASUSDT": {
+    "normalized_id": "GAS/USD",
+    "base": "GAS",
+    "quote": "USD",
+    "display_name": "GAS / US Dollar",
+    "description": "GAS to US Dollar spot trading pair",
+    "tags": [
+      "gas",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GHSTUSDT": {
+    "normalized_id": "GHST/USD",
+    "base": "GHST",
+    "quote": "USD",
+    "display_name": "GHST / US Dollar",
+    "description": "GHST to US Dollar spot trading pair",
+    "tags": [
+      "ghst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GLMBTC": {
+    "normalized_id": "GLM/BTC",
+    "base": "GLM",
+    "quote": "BTC",
+    "display_name": "GLM / Bitcoin",
+    "description": "GLM to Bitcoin spot trading pair",
+    "tags": [
+      "glm",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "GLMRBTC": {
+    "normalized_id": "GLMR/BTC",
+    "base": "GLMR",
+    "quote": "BTC",
+    "display_name": "GLMR / Bitcoin",
+    "description": "GLMR to Bitcoin spot trading pair",
+    "tags": [
+      "glmr",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "GLMRUSDT": {
+    "normalized_id": "GLMR/USD",
+    "base": "GLMR",
+    "quote": "USD",
+    "display_name": "GLMR / US Dollar",
+    "description": "GLMR to US Dollar spot trading pair",
+    "tags": [
+      "glmr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GLMUSDT": {
+    "normalized_id": "GLM/USD",
+    "base": "GLM",
+    "quote": "USD",
+    "display_name": "GLM / US Dollar",
+    "description": "GLM to US Dollar spot trading pair",
+    "tags": [
+      "glm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GMTBTC": {
+    "normalized_id": "GMT/BTC",
+    "base": "GMT",
+    "quote": "BTC",
+    "display_name": "GMT / Bitcoin",
+    "description": "GMT to Bitcoin spot trading pair",
+    "tags": [
+      "gmt",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "GMTEUR": {
+    "normalized_id": "GMT/EUR",
+    "base": "GMT",
+    "quote": "EUR",
+    "display_name": "GMT / Euro",
+    "description": "GMT to Euro spot trading pair",
+    "tags": [
+      "gmt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GMTTRY": {
+    "normalized_id": "GMT/TRY",
+    "base": "GMT",
+    "quote": "TRY",
+    "display_name": "GMT / Turkish Lira",
+    "description": "GMT to Turkish Lira spot trading pair",
+    "tags": [
+      "gmt",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "GMTUSDC": {
+    "normalized_id": "GMT/USD",
+    "base": "GMT",
+    "quote": "USD",
+    "display_name": "GMT / US Dollar",
+    "description": "GMT to US Dollar spot trading pair",
+    "tags": [
+      "gmt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GMTUSDT": {
+    "normalized_id": "GMT/USD",
+    "base": "GMT",
+    "quote": "USD",
+    "display_name": "GMT / US Dollar",
+    "description": "GMT to US Dollar spot trading pair",
+    "tags": [
+      "gmt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GMXUSDC": {
+    "normalized_id": "GMX/USD",
+    "base": "GMX",
+    "quote": "USD",
+    "display_name": "GMX / US Dollar",
+    "description": "GMX to US Dollar spot trading pair",
+    "tags": [
+      "gmx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GMXUSDT": {
+    "normalized_id": "GMX/USD",
+    "base": "GMX",
+    "quote": "USD",
+    "display_name": "GMX / US Dollar",
+    "description": "GMX to US Dollar spot trading pair",
+    "tags": [
+      "gmx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GNOUSDT": {
+    "normalized_id": "GNO/USD",
+    "base": "GNO",
+    "quote": "USD",
+    "display_name": "GNO / US Dollar",
+    "description": "GNO to US Dollar spot trading pair",
+    "tags": [
+      "gno",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GNSUSDT": {
+    "normalized_id": "GNS/USD",
+    "base": "GNS",
+    "quote": "USD",
+    "display_name": "GNS / US Dollar",
+    "description": "GNS to US Dollar spot trading pair",
+    "tags": [
+      "gns",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GPSBNB": {
+    "normalized_id": "GPS/BNB",
+    "base": "GPS",
+    "quote": "BNB",
+    "display_name": "GPS / Binance Coin",
+    "description": "GPS to Binance Coin spot trading pair",
+    "tags": [
+      "gps",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "GPSTRY": {
+    "normalized_id": "GPS/TRY",
+    "base": "GPS",
+    "quote": "TRY",
+    "display_name": "GPS / Turkish Lira",
+    "description": "GPS to Turkish Lira spot trading pair",
+    "tags": [
+      "gps",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "GPSUSDC": {
+    "normalized_id": "GPS/USD",
+    "base": "GPS",
+    "quote": "USD",
+    "display_name": "GPS / US Dollar",
+    "description": "GPS to US Dollar spot trading pair",
+    "tags": [
+      "gps",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GPSUSDT": {
+    "normalized_id": "GPS/USD",
+    "base": "GPS",
+    "quote": "USD",
+    "display_name": "GPS / US Dollar",
+    "description": "GPS to US Dollar spot trading pair",
+    "tags": [
+      "gps",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GRTBTC": {
+    "normalized_id": "GRT/BTC",
+    "base": "GRT",
+    "quote": "BTC",
+    "display_name": "GRT / Bitcoin",
+    "description": "GRT to Bitcoin spot trading pair",
+    "tags": [
+      "grt",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "GRTETH": {
+    "normalized_id": "GRT/ETH",
+    "base": "GRT",
+    "quote": "ETH",
+    "display_name": "GRT / Ethereum",
+    "description": "GRT to Ethereum spot trading pair",
+    "tags": [
+      "grt",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "GRTEUR": {
+    "normalized_id": "GRT/EUR",
+    "base": "GRT",
+    "quote": "EUR",
+    "display_name": "GRT / Euro",
+    "description": "GRT to Euro spot trading pair",
+    "tags": [
+      "grt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GRTFDUSD": {
+    "normalized_id": "GRT/USD",
+    "base": "GRT",
+    "quote": "USD",
+    "display_name": "GRT / US Dollar",
+    "description": "GRT to US Dollar spot trading pair",
+    "tags": [
+      "grt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GRTTRY": {
+    "normalized_id": "GRT/TRY",
+    "base": "GRT",
+    "quote": "TRY",
+    "display_name": "GRT / Turkish Lira",
+    "description": "GRT to Turkish Lira spot trading pair",
+    "tags": [
+      "grt",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "GRTUSDC": {
+    "normalized_id": "GRT/USD",
+    "base": "GRT",
+    "quote": "USD",
+    "display_name": "GRT / US Dollar",
+    "description": "GRT to US Dollar spot trading pair",
+    "tags": [
+      "grt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GRTUSDT": {
+    "normalized_id": "GRT/USD",
+    "base": "GRT",
+    "quote": "USD",
+    "display_name": "GRT / US Dollar",
+    "description": "GRT to US Dollar spot trading pair",
+    "tags": [
+      "grt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GTCUSDT": {
+    "normalized_id": "GTC/USD",
+    "base": "GTC",
+    "quote": "USD",
+    "display_name": "GTC / US Dollar",
+    "description": "GTC to US Dollar spot trading pair",
+    "tags": [
+      "gtc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GTRY": {
+    "normalized_id": "G/TRY",
+    "base": "G",
+    "quote": "TRY",
+    "display_name": "G / Turkish Lira",
+    "description": "G to Turkish Lira spot trading pair",
+    "tags": [
+      "g",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "GUNBNB": {
+    "normalized_id": "GUN/BNB",
+    "base": "GUN",
+    "quote": "BNB",
+    "display_name": "GUN / Binance Coin",
+    "description": "GUN to Binance Coin spot trading pair",
+    "tags": [
+      "gun",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "GUNFDUSD": {
+    "normalized_id": "GUN/USD",
+    "base": "GUN",
+    "quote": "USD",
+    "display_name": "GUN / US Dollar",
+    "description": "GUN to US Dollar spot trading pair",
+    "tags": [
+      "gun",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GUNTRY": {
+    "normalized_id": "GUN/TRY",
+    "base": "GUN",
+    "quote": "TRY",
+    "display_name": "GUN / Turkish Lira",
+    "description": "GUN to Turkish Lira spot trading pair",
+    "tags": [
+      "gun",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "GUNUSDC": {
+    "normalized_id": "GUN/USD",
+    "base": "GUN",
+    "quote": "USD",
+    "display_name": "GUN / US Dollar",
+    "description": "GUN to US Dollar spot trading pair",
+    "tags": [
+      "gun",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GUNUSDT": {
+    "normalized_id": "GUN/USD",
+    "base": "GUN",
+    "quote": "USD",
+    "display_name": "GUN / US Dollar",
+    "description": "GUN to US Dollar spot trading pair",
+    "tags": [
+      "gun",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GUSDT": {
+    "normalized_id": "G/USD",
+    "base": "G",
+    "quote": "USD",
+    "display_name": "G / US Dollar",
+    "description": "G to US Dollar spot trading pair",
+    "tags": [
+      "g",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HAEDALBNB": {
+    "normalized_id": "HAEDAL/BNB",
+    "base": "HAEDAL",
+    "quote": "BNB",
+    "display_name": "HAEDAL / Binance Coin",
+    "description": "HAEDAL to Binance Coin spot trading pair",
+    "tags": [
+      "haedal",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "HAEDALFDUSD": {
+    "normalized_id": "HAEDAL/USD",
+    "base": "HAEDAL",
+    "quote": "USD",
+    "display_name": "HAEDAL / US Dollar",
+    "description": "HAEDAL to US Dollar spot trading pair",
+    "tags": [
+      "haedal",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HAEDALTRY": {
+    "normalized_id": "HAEDAL/TRY",
+    "base": "HAEDAL",
+    "quote": "TRY",
+    "display_name": "HAEDAL / Turkish Lira",
+    "description": "HAEDAL to Turkish Lira spot trading pair",
+    "tags": [
+      "haedal",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "HAEDALUSDC": {
+    "normalized_id": "HAEDAL/USD",
+    "base": "HAEDAL",
+    "quote": "USD",
+    "display_name": "HAEDAL / US Dollar",
+    "description": "HAEDAL to US Dollar spot trading pair",
+    "tags": [
+      "haedal",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HAEDALUSDT": {
+    "normalized_id": "HAEDAL/USD",
+    "base": "HAEDAL",
+    "quote": "USD",
+    "display_name": "HAEDAL / US Dollar",
+    "description": "HAEDAL to US Dollar spot trading pair",
+    "tags": [
+      "haedal",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HBARBNB": {
+    "normalized_id": "HBAR/BNB",
+    "base": "HBAR",
+    "quote": "BNB",
+    "display_name": "Hedera / Binance Coin",
+    "description": "Hedera to Binance Coin spot trading pair",
+    "tags": [
+      "hbar",
+      "hedera",
+      "layer1",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "HBARBTC": {
+    "normalized_id": "HBAR/BTC",
+    "base": "HBAR",
+    "quote": "BTC",
+    "display_name": "Hedera / Bitcoin",
+    "description": "Hedera to Bitcoin spot trading pair",
+    "tags": [
+      "hbar",
+      "hedera",
+      "layer1",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "HBARFDUSD": {
+    "normalized_id": "HBAR/USD",
+    "base": "HBAR",
+    "quote": "USD",
+    "display_name": "Hedera / US Dollar",
+    "description": "Hedera to US Dollar spot trading pair",
+    "tags": [
+      "hbar",
+      "hedera",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HBARTRY": {
+    "normalized_id": "HBAR/TRY",
+    "base": "HBAR",
+    "quote": "TRY",
+    "display_name": "Hedera / Turkish Lira",
+    "description": "Hedera to Turkish Lira spot trading pair",
+    "tags": [
+      "hbar",
+      "hedera",
+      "layer1",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "HBARUSDC": {
+    "normalized_id": "HBAR/USD",
+    "base": "HBAR",
+    "quote": "USD",
+    "display_name": "Hedera / US Dollar",
+    "description": "Hedera to US Dollar spot trading pair",
+    "tags": [
+      "hbar",
+      "hedera",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HBARUSDT": {
+    "normalized_id": "HBAR/USD",
+    "base": "HBAR",
+    "quote": "USD",
+    "display_name": "Hedera / US Dollar",
+    "description": "Hedera to US Dollar spot trading pair",
+    "tags": [
+      "hbar",
+      "hedera",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HEIBTC": {
+    "normalized_id": "HEI/BTC",
+    "base": "HEI",
+    "quote": "BTC",
+    "display_name": "HEI / Bitcoin",
+    "description": "HEI to Bitcoin spot trading pair",
+    "tags": [
+      "hei",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "HEIUSDC": {
+    "normalized_id": "HEI/USD",
+    "base": "HEI",
+    "quote": "USD",
+    "display_name": "HEI / US Dollar",
+    "description": "HEI to US Dollar spot trading pair",
+    "tags": [
+      "hei",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HEIUSDT": {
+    "normalized_id": "HEI/USD",
+    "base": "HEI",
+    "quote": "USD",
+    "display_name": "HEI / US Dollar",
+    "description": "HEI to US Dollar spot trading pair",
+    "tags": [
+      "hei",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HFTBTC": {
+    "normalized_id": "HFT/BTC",
+    "base": "HFT",
+    "quote": "BTC",
+    "display_name": "HFT / Bitcoin",
+    "description": "HFT to Bitcoin spot trading pair",
+    "tags": [
+      "hft",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "HFTUSDT": {
+    "normalized_id": "HFT/USD",
+    "base": "HFT",
+    "quote": "USD",
+    "display_name": "HFT / US Dollar",
+    "description": "HFT to US Dollar spot trading pair",
+    "tags": [
+      "hft",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HIFIUSDT": {
+    "normalized_id": "HIFI/USD",
+    "base": "HIFI",
+    "quote": "USD",
+    "display_name": "HIFI / US Dollar",
+    "description": "HIFI to US Dollar spot trading pair",
+    "tags": [
+      "hifi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HIGHTRY": {
+    "normalized_id": "HIGH/TRY",
+    "base": "HIGH",
+    "quote": "TRY",
+    "display_name": "HIGH / Turkish Lira",
+    "description": "HIGH to Turkish Lira spot trading pair",
+    "tags": [
+      "high",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "HIGHUSDT": {
+    "normalized_id": "HIGH/USD",
+    "base": "HIGH",
+    "quote": "USD",
+    "display_name": "HIGH / US Dollar",
+    "description": "HIGH to US Dollar spot trading pair",
+    "tags": [
+      "high",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HIVEBTC": {
+    "normalized_id": "HIVE/BTC",
+    "base": "HIVE",
+    "quote": "BTC",
+    "display_name": "HIVE / Bitcoin",
+    "description": "HIVE to Bitcoin spot trading pair",
+    "tags": [
+      "hive",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "HIVETRY": {
+    "normalized_id": "HIVE/TRY",
+    "base": "HIVE",
+    "quote": "TRY",
+    "display_name": "HIVE / Turkish Lira",
+    "description": "HIVE to Turkish Lira spot trading pair",
+    "tags": [
+      "hive",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "HIVEUSDC": {
+    "normalized_id": "HIVE/USD",
+    "base": "HIVE",
+    "quote": "USD",
+    "display_name": "HIVE / US Dollar",
+    "description": "HIVE to US Dollar spot trading pair",
+    "tags": [
+      "hive",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HIVEUSDT": {
+    "normalized_id": "HIVE/USD",
+    "base": "HIVE",
+    "quote": "USD",
+    "display_name": "HIVE / US Dollar",
+    "description": "HIVE to US Dollar spot trading pair",
+    "tags": [
+      "hive",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HMSTRFDUSD": {
+    "normalized_id": "HMSTR/USD",
+    "base": "HMSTR",
+    "quote": "USD",
+    "display_name": "HMSTR / US Dollar",
+    "description": "HMSTR to US Dollar spot trading pair",
+    "tags": [
+      "hmstr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HMSTRTRY": {
+    "normalized_id": "HMSTR/TRY",
+    "base": "HMSTR",
+    "quote": "TRY",
+    "display_name": "HMSTR / Turkish Lira",
+    "description": "HMSTR to Turkish Lira spot trading pair",
+    "tags": [
+      "hmstr",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "HMSTRUSDC": {
+    "normalized_id": "HMSTR/USD",
+    "base": "HMSTR",
+    "quote": "USD",
+    "display_name": "HMSTR / US Dollar",
+    "description": "HMSTR to US Dollar spot trading pair",
+    "tags": [
+      "hmstr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HMSTRUSDT": {
+    "normalized_id": "HMSTR/USD",
+    "base": "HMSTR",
+    "quote": "USD",
+    "display_name": "HMSTR / US Dollar",
+    "description": "HMSTR to US Dollar spot trading pair",
+    "tags": [
+      "hmstr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HOMEBNB": {
+    "normalized_id": "HOME/BNB",
+    "base": "HOME",
+    "quote": "BNB",
+    "display_name": "HOME / Binance Coin",
+    "description": "HOME to Binance Coin spot trading pair",
+    "tags": [
+      "home",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "HOMEFDUSD": {
+    "normalized_id": "HOME/USD",
+    "base": "HOME",
+    "quote": "USD",
+    "display_name": "HOME / US Dollar",
+    "description": "HOME to US Dollar spot trading pair",
+    "tags": [
+      "home",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HOMETRY": {
+    "normalized_id": "HOME/TRY",
+    "base": "HOME",
+    "quote": "TRY",
+    "display_name": "HOME / Turkish Lira",
+    "description": "HOME to Turkish Lira spot trading pair",
+    "tags": [
+      "home",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "HOMEUSDC": {
+    "normalized_id": "HOME/USD",
+    "base": "HOME",
+    "quote": "USD",
+    "display_name": "HOME / US Dollar",
+    "description": "HOME to US Dollar spot trading pair",
+    "tags": [
+      "home",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HOMEUSDT": {
+    "normalized_id": "HOME/USD",
+    "base": "HOME",
+    "quote": "USD",
+    "display_name": "HOME / US Dollar",
+    "description": "HOME to US Dollar spot trading pair",
+    "tags": [
+      "home",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HOOKUSDT": {
+    "normalized_id": "HOOK/USD",
+    "base": "HOOK",
+    "quote": "USD",
+    "display_name": "HOOK / US Dollar",
+    "description": "HOOK to US Dollar spot trading pair",
+    "tags": [
+      "hook",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HOTTRY": {
+    "normalized_id": "HOT/TRY",
+    "base": "HOT",
+    "quote": "TRY",
+    "display_name": "HOT / Turkish Lira",
+    "description": "HOT to Turkish Lira spot trading pair",
+    "tags": [
+      "hot",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "HOTUSDT": {
+    "normalized_id": "HOT/USD",
+    "base": "HOT",
+    "quote": "USD",
+    "display_name": "HOT / US Dollar",
+    "description": "HOT to US Dollar spot trading pair",
+    "tags": [
+      "hot",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HUMABNB": {
+    "normalized_id": "HUMA/BNB",
+    "base": "HUMA",
+    "quote": "BNB",
+    "display_name": "HUMA / Binance Coin",
+    "description": "HUMA to Binance Coin spot trading pair",
+    "tags": [
+      "huma",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "HUMATRY": {
+    "normalized_id": "HUMA/TRY",
+    "base": "HUMA",
+    "quote": "TRY",
+    "display_name": "HUMA / Turkish Lira",
+    "description": "HUMA to Turkish Lira spot trading pair",
+    "tags": [
+      "huma",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "HUMAUSDC": {
+    "normalized_id": "HUMA/USD",
+    "base": "HUMA",
+    "quote": "USD",
+    "display_name": "HUMA / US Dollar",
+    "description": "HUMA to US Dollar spot trading pair",
+    "tags": [
+      "huma",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HUMAUSDT": {
+    "normalized_id": "HUMA/USD",
+    "base": "HUMA",
+    "quote": "USD",
+    "display_name": "HUMA / US Dollar",
+    "description": "HUMA to US Dollar spot trading pair",
+    "tags": [
+      "huma",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HYPERBNB": {
+    "normalized_id": "HYPER/BNB",
+    "base": "HYPER",
+    "quote": "BNB",
+    "display_name": "HYPER / Binance Coin",
+    "description": "HYPER to Binance Coin spot trading pair",
+    "tags": [
+      "hyper",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "HYPERTRY": {
+    "normalized_id": "HYPER/TRY",
+    "base": "HYPER",
+    "quote": "TRY",
+    "display_name": "HYPER / Turkish Lira",
+    "description": "HYPER to Turkish Lira spot trading pair",
+    "tags": [
+      "hyper",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "HYPERUSDC": {
+    "normalized_id": "HYPER/USD",
+    "base": "HYPER",
+    "quote": "USD",
+    "display_name": "HYPER / US Dollar",
+    "description": "HYPER to US Dollar spot trading pair",
+    "tags": [
+      "hyper",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HYPERUSDT": {
+    "normalized_id": "HYPER/USD",
+    "base": "HYPER",
+    "quote": "USD",
+    "display_name": "HYPER / US Dollar",
+    "description": "HYPER to US Dollar spot trading pair",
+    "tags": [
+      "hyper",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICPBTC": {
+    "normalized_id": "ICP/BTC",
+    "base": "ICP",
+    "quote": "BTC",
+    "display_name": "Internet Computer / Bitcoin",
+    "description": "Internet Computer to Bitcoin spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ICPETH": {
+    "normalized_id": "ICP/ETH",
+    "base": "ICP",
+    "quote": "ETH",
+    "display_name": "Internet Computer / Ethereum",
+    "description": "Internet Computer to Ethereum spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "ICPEUR": {
+    "normalized_id": "ICP/EUR",
+    "base": "ICP",
+    "quote": "EUR",
+    "display_name": "Internet Computer / Euro",
+    "description": "Internet Computer to Euro spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ICPFDUSD": {
+    "normalized_id": "ICP/USD",
+    "base": "ICP",
+    "quote": "USD",
+    "display_name": "Internet Computer / US Dollar",
+    "description": "Internet Computer to US Dollar spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICPTRY": {
+    "normalized_id": "ICP/TRY",
+    "base": "ICP",
+    "quote": "TRY",
+    "display_name": "Internet Computer / Turkish Lira",
+    "description": "Internet Computer to Turkish Lira spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ICPUSDC": {
+    "normalized_id": "ICP/USD",
+    "base": "ICP",
+    "quote": "USD",
+    "display_name": "Internet Computer / US Dollar",
+    "description": "Internet Computer to US Dollar spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICPUSDT": {
+    "normalized_id": "ICP/USD",
+    "base": "ICP",
+    "quote": "USD",
+    "display_name": "Internet Computer / US Dollar",
+    "description": "Internet Computer to US Dollar spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICXBTC": {
+    "normalized_id": "ICX/BTC",
+    "base": "ICX",
+    "quote": "BTC",
+    "display_name": "ICX / Bitcoin",
+    "description": "ICX to Bitcoin spot trading pair",
+    "tags": [
+      "icx",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ICXUSDT": {
+    "normalized_id": "ICX/USD",
+    "base": "ICX",
+    "quote": "USD",
+    "display_name": "ICX / US Dollar",
+    "description": "ICX to US Dollar spot trading pair",
+    "tags": [
+      "icx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IDBTC": {
+    "normalized_id": "ID/BTC",
+    "base": "ID",
+    "quote": "BTC",
+    "display_name": "ID / Bitcoin",
+    "description": "ID to Bitcoin spot trading pair",
+    "tags": [
+      "id",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "IDEXUSDC": {
+    "normalized_id": "IDEX/USD",
+    "base": "IDEX",
+    "quote": "USD",
+    "display_name": "IDEX / US Dollar",
+    "description": "IDEX to US Dollar spot trading pair",
+    "tags": [
+      "idex",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IDEXUSDT": {
+    "normalized_id": "IDEX/USD",
+    "base": "IDEX",
+    "quote": "USD",
+    "display_name": "IDEX / US Dollar",
+    "description": "IDEX to US Dollar spot trading pair",
+    "tags": [
+      "idex",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IDTRY": {
+    "normalized_id": "ID/TRY",
+    "base": "ID",
+    "quote": "TRY",
+    "display_name": "ID / Turkish Lira",
+    "description": "ID to Turkish Lira spot trading pair",
+    "tags": [
+      "id",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "IDUSDT": {
+    "normalized_id": "ID/USD",
+    "base": "ID",
+    "quote": "USD",
+    "display_name": "ID / US Dollar",
+    "description": "ID to US Dollar spot trading pair",
+    "tags": [
+      "id",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ILVBTC": {
+    "normalized_id": "ILV/BTC",
+    "base": "ILV",
+    "quote": "BTC",
+    "display_name": "ILV / Bitcoin",
+    "description": "ILV to Bitcoin spot trading pair",
+    "tags": [
+      "ilv",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ILVUSDC": {
+    "normalized_id": "ILV/USD",
+    "base": "ILV",
+    "quote": "USD",
+    "display_name": "ILV / US Dollar",
+    "description": "ILV to US Dollar spot trading pair",
+    "tags": [
+      "ilv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ILVUSDT": {
+    "normalized_id": "ILV/USD",
+    "base": "ILV",
+    "quote": "USD",
+    "display_name": "ILV / US Dollar",
+    "description": "ILV to US Dollar spot trading pair",
+    "tags": [
+      "ilv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IMXBTC": {
+    "normalized_id": "IMX/BTC",
+    "base": "IMX",
+    "quote": "BTC",
+    "display_name": "IMX / Bitcoin",
+    "description": "IMX to Bitcoin spot trading pair",
+    "tags": [
+      "imx",
+      "layer2",
+      "gaming",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "IMXUSDT": {
+    "normalized_id": "IMX/USD",
+    "base": "IMX",
+    "quote": "USD",
+    "display_name": "IMX / US Dollar",
+    "description": "IMX to US Dollar spot trading pair",
+    "tags": [
+      "imx",
+      "layer2",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "INITBNB": {
+    "normalized_id": "INIT/BNB",
+    "base": "INIT",
+    "quote": "BNB",
+    "display_name": "INIT / Binance Coin",
+    "description": "INIT to Binance Coin spot trading pair",
+    "tags": [
+      "init",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "INITFDUSD": {
+    "normalized_id": "INIT/USD",
+    "base": "INIT",
+    "quote": "USD",
+    "display_name": "INIT / US Dollar",
+    "description": "INIT to US Dollar spot trading pair",
+    "tags": [
+      "init",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "INITTRY": {
+    "normalized_id": "INIT/TRY",
+    "base": "INIT",
+    "quote": "TRY",
+    "display_name": "INIT / Turkish Lira",
+    "description": "INIT to Turkish Lira spot trading pair",
+    "tags": [
+      "init",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "INITUSDC": {
+    "normalized_id": "INIT/USD",
+    "base": "INIT",
+    "quote": "USD",
+    "display_name": "INIT / US Dollar",
+    "description": "INIT to US Dollar spot trading pair",
+    "tags": [
+      "init",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "INITUSDT": {
+    "normalized_id": "INIT/USD",
+    "base": "INIT",
+    "quote": "USD",
+    "display_name": "INIT / US Dollar",
+    "description": "INIT to US Dollar spot trading pair",
+    "tags": [
+      "init",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "INJBNB": {
+    "normalized_id": "INJ/BNB",
+    "base": "INJ",
+    "quote": "BNB",
+    "display_name": "Injective / Binance Coin",
+    "description": "Injective to Binance Coin spot trading pair",
+    "tags": [
+      "inj",
+      "injective",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "INJBTC": {
+    "normalized_id": "INJ/BTC",
+    "base": "INJ",
+    "quote": "BTC",
+    "display_name": "Injective / Bitcoin",
+    "description": "Injective to Bitcoin spot trading pair",
+    "tags": [
+      "inj",
+      "injective",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "INJETH": {
+    "normalized_id": "INJ/ETH",
+    "base": "INJ",
+    "quote": "ETH",
+    "display_name": "Injective / Ethereum",
+    "description": "Injective to Ethereum spot trading pair",
+    "tags": [
+      "inj",
+      "injective",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "INJFDUSD": {
+    "normalized_id": "INJ/USD",
+    "base": "INJ",
+    "quote": "USD",
+    "display_name": "Injective / US Dollar",
+    "description": "Injective to US Dollar spot trading pair",
+    "tags": [
+      "inj",
+      "injective",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "INJTRY": {
+    "normalized_id": "INJ/TRY",
+    "base": "INJ",
+    "quote": "TRY",
+    "display_name": "Injective / Turkish Lira",
+    "description": "Injective to Turkish Lira spot trading pair",
+    "tags": [
+      "inj",
+      "injective",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "INJUSDC": {
+    "normalized_id": "INJ/USD",
+    "base": "INJ",
+    "quote": "USD",
+    "display_name": "Injective / US Dollar",
+    "description": "Injective to US Dollar spot trading pair",
+    "tags": [
+      "inj",
+      "injective",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "INJUSDT": {
+    "normalized_id": "INJ/USD",
+    "base": "INJ",
+    "quote": "USD",
+    "display_name": "Injective / US Dollar",
+    "description": "Injective to US Dollar spot trading pair",
+    "tags": [
+      "inj",
+      "injective",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IOBNB": {
+    "normalized_id": "IO/BNB",
+    "base": "IO",
+    "quote": "BNB",
+    "display_name": "IO / Binance Coin",
+    "description": "IO to Binance Coin spot trading pair",
+    "tags": [
+      "io",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "IOBTC": {
+    "normalized_id": "IO/BTC",
+    "base": "IO",
+    "quote": "BTC",
+    "display_name": "IO / Bitcoin",
+    "description": "IO to Bitcoin spot trading pair",
+    "tags": [
+      "io",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "IOFDUSD": {
+    "normalized_id": "IO/USD",
+    "base": "IO",
+    "quote": "USD",
+    "display_name": "IO / US Dollar",
+    "description": "IO to US Dollar spot trading pair",
+    "tags": [
+      "io",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IOSTUSDT": {
+    "normalized_id": "IOST/USD",
+    "base": "IOST",
+    "quote": "USD",
+    "display_name": "IOST / US Dollar",
+    "description": "IOST to US Dollar spot trading pair",
+    "tags": [
+      "iost",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IOTABTC": {
+    "normalized_id": "IOTA/BTC",
+    "base": "IOTA",
+    "quote": "BTC",
+    "display_name": "IOTA / Bitcoin",
+    "description": "IOTA to Bitcoin spot trading pair",
+    "tags": [
+      "iota",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "IOTAETH": {
+    "normalized_id": "IOTA/ETH",
+    "base": "IOTA",
+    "quote": "ETH",
+    "display_name": "IOTA / Ethereum",
+    "description": "IOTA to Ethereum spot trading pair",
+    "tags": [
+      "iota",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "IOTATRY": {
+    "normalized_id": "IOTA/TRY",
+    "base": "IOTA",
+    "quote": "TRY",
+    "display_name": "IOTA / Turkish Lira",
+    "description": "IOTA to Turkish Lira spot trading pair",
+    "tags": [
+      "iota",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "IOTAUSDC": {
+    "normalized_id": "IOTA/USD",
+    "base": "IOTA",
+    "quote": "USD",
+    "display_name": "IOTA / US Dollar",
+    "description": "IOTA to US Dollar spot trading pair",
+    "tags": [
+      "iota",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IOTAUSDT": {
+    "normalized_id": "IOTA/USD",
+    "base": "IOTA",
+    "quote": "USD",
+    "display_name": "IOTA / US Dollar",
+    "description": "IOTA to US Dollar spot trading pair",
+    "tags": [
+      "iota",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IOTRY": {
+    "normalized_id": "IO/TRY",
+    "base": "IO",
+    "quote": "TRY",
+    "display_name": "IO / Turkish Lira",
+    "description": "IO to Turkish Lira spot trading pair",
+    "tags": [
+      "io",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "IOTXBTC": {
+    "normalized_id": "IOTX/BTC",
+    "base": "IOTX",
+    "quote": "BTC",
+    "display_name": "IOTX / Bitcoin",
+    "description": "IOTX to Bitcoin spot trading pair",
+    "tags": [
+      "iotx",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "IOTXETH": {
+    "normalized_id": "IOTX/ETH",
+    "base": "IOTX",
+    "quote": "ETH",
+    "display_name": "IOTX / Ethereum",
+    "description": "IOTX to Ethereum spot trading pair",
+    "tags": [
+      "iotx",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "IOTXJPY": {
+    "normalized_id": "IOTX/JPY",
+    "base": "IOTX",
+    "quote": "JPY",
+    "display_name": "IOTX / Japanese Yen",
+    "description": "IOTX to Japanese Yen spot trading pair",
+    "tags": [
+      "iotx",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "IOTXUSDT": {
+    "normalized_id": "IOTX/USD",
+    "base": "IOTX",
+    "quote": "USD",
+    "display_name": "IOTX / US Dollar",
+    "description": "IOTX to US Dollar spot trading pair",
+    "tags": [
+      "iotx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IOUSDC": {
+    "normalized_id": "IO/USD",
+    "base": "IO",
+    "quote": "USD",
+    "display_name": "IO / US Dollar",
+    "description": "IO to US Dollar spot trading pair",
+    "tags": [
+      "io",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IOUSDT": {
+    "normalized_id": "IO/USD",
+    "base": "IO",
+    "quote": "USD",
+    "display_name": "IO / US Dollar",
+    "description": "IO to US Dollar spot trading pair",
+    "tags": [
+      "io",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IQUSDT": {
+    "normalized_id": "IQ/USD",
+    "base": "IQ",
+    "quote": "USD",
+    "display_name": "IQ / US Dollar",
+    "description": "IQ to US Dollar spot trading pair",
+    "tags": [
+      "iq",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JASMYTRY": {
+    "normalized_id": "JASMY/TRY",
+    "base": "JASMY",
+    "quote": "TRY",
+    "display_name": "JASMY / Turkish Lira",
+    "description": "JASMY to Turkish Lira spot trading pair",
+    "tags": [
+      "jasmy",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "JASMYUSDT": {
+    "normalized_id": "JASMY/USD",
+    "base": "JASMY",
+    "quote": "USD",
+    "display_name": "JASMY / US Dollar",
+    "description": "JASMY to US Dollar spot trading pair",
+    "tags": [
+      "jasmy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JOEBTC": {
+    "normalized_id": "JOE/BTC",
+    "base": "JOE",
+    "quote": "BTC",
+    "display_name": "JOE / Bitcoin",
+    "description": "JOE to Bitcoin spot trading pair",
+    "tags": [
+      "joe",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "JOEUSDT": {
+    "normalized_id": "JOE/USD",
+    "base": "JOE",
+    "quote": "USD",
+    "display_name": "JOE / US Dollar",
+    "description": "JOE to US Dollar spot trading pair",
+    "tags": [
+      "joe",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JSTBTC": {
+    "normalized_id": "JST/BTC",
+    "base": "JST",
+    "quote": "BTC",
+    "display_name": "JST / Bitcoin",
+    "description": "JST to Bitcoin spot trading pair",
+    "tags": [
+      "jst",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "JSTUSDT": {
+    "normalized_id": "JST/USD",
+    "base": "JST",
+    "quote": "USD",
+    "display_name": "JST / US Dollar",
+    "description": "JST to US Dollar spot trading pair",
+    "tags": [
+      "jst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JTOFDUSD": {
+    "normalized_id": "JTO/USD",
+    "base": "JTO",
+    "quote": "USD",
+    "display_name": "JTO / US Dollar",
+    "description": "JTO to US Dollar spot trading pair",
+    "tags": [
+      "jto",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JTOTRY": {
+    "normalized_id": "JTO/TRY",
+    "base": "JTO",
+    "quote": "TRY",
+    "display_name": "JTO / Turkish Lira",
+    "description": "JTO to Turkish Lira spot trading pair",
+    "tags": [
+      "jto",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "JTOUSDC": {
+    "normalized_id": "JTO/USD",
+    "base": "JTO",
+    "quote": "USD",
+    "display_name": "JTO / US Dollar",
+    "description": "JTO to US Dollar spot trading pair",
+    "tags": [
+      "jto",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JTOUSDT": {
+    "normalized_id": "JTO/USD",
+    "base": "JTO",
+    "quote": "USD",
+    "display_name": "JTO / US Dollar",
+    "description": "JTO to US Dollar spot trading pair",
+    "tags": [
+      "jto",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JUPFDUSD": {
+    "normalized_id": "JUP/USD",
+    "base": "JUP",
+    "quote": "USD",
+    "display_name": "Jupiter / US Dollar",
+    "description": "Jupiter to US Dollar spot trading pair",
+    "tags": [
+      "jup",
+      "jupiter",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JUPTRY": {
+    "normalized_id": "JUP/TRY",
+    "base": "JUP",
+    "quote": "TRY",
+    "display_name": "Jupiter / Turkish Lira",
+    "description": "Jupiter to Turkish Lira spot trading pair",
+    "tags": [
+      "jup",
+      "jupiter",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "JUPUSDC": {
+    "normalized_id": "JUP/USD",
+    "base": "JUP",
+    "quote": "USD",
+    "display_name": "Jupiter / US Dollar",
+    "description": "Jupiter to US Dollar spot trading pair",
+    "tags": [
+      "jup",
+      "jupiter",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JUPUSDT": {
+    "normalized_id": "JUP/USD",
+    "base": "JUP",
+    "quote": "USD",
+    "display_name": "Jupiter / US Dollar",
+    "description": "Jupiter to US Dollar spot trading pair",
+    "tags": [
+      "jup",
+      "jupiter",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JUVTRY": {
+    "normalized_id": "JUV/TRY",
+    "base": "JUV",
+    "quote": "TRY",
+    "display_name": "JUV / Turkish Lira",
+    "description": "JUV to Turkish Lira spot trading pair",
+    "tags": [
+      "juv",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "JUVUSDC": {
+    "normalized_id": "JUV/USD",
+    "base": "JUV",
+    "quote": "USD",
+    "display_name": "JUV / US Dollar",
+    "description": "JUV to US Dollar spot trading pair",
+    "tags": [
+      "juv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JUVUSDT": {
+    "normalized_id": "JUV/USD",
+    "base": "JUV",
+    "quote": "USD",
+    "display_name": "JUV / US Dollar",
+    "description": "JUV to US Dollar spot trading pair",
+    "tags": [
+      "juv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAIAUSDC": {
+    "normalized_id": "KAIA/USD",
+    "base": "KAIA",
+    "quote": "USD",
+    "display_name": "KAIA / US Dollar",
+    "description": "KAIA to US Dollar spot trading pair",
+    "tags": [
+      "kaia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAIAUSDT": {
+    "normalized_id": "KAIA/USD",
+    "base": "KAIA",
+    "quote": "USD",
+    "display_name": "KAIA / US Dollar",
+    "description": "KAIA to US Dollar spot trading pair",
+    "tags": [
+      "kaia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAITOBTC": {
+    "normalized_id": "KAITO/BTC",
+    "base": "KAITO",
+    "quote": "BTC",
+    "display_name": "KAITO / Bitcoin",
+    "description": "KAITO to Bitcoin spot trading pair",
+    "tags": [
+      "kaito",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "KAITOFDUSD": {
+    "normalized_id": "KAITO/USD",
+    "base": "KAITO",
+    "quote": "USD",
+    "display_name": "KAITO / US Dollar",
+    "description": "KAITO to US Dollar spot trading pair",
+    "tags": [
+      "kaito",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAITOTRY": {
+    "normalized_id": "KAITO/TRY",
+    "base": "KAITO",
+    "quote": "TRY",
+    "display_name": "KAITO / Turkish Lira",
+    "description": "KAITO to Turkish Lira spot trading pair",
+    "tags": [
+      "kaito",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "KAITOUSDC": {
+    "normalized_id": "KAITO/USD",
+    "base": "KAITO",
+    "quote": "USD",
+    "display_name": "KAITO / US Dollar",
+    "description": "KAITO to US Dollar spot trading pair",
+    "tags": [
+      "kaito",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAITOUSDT": {
+    "normalized_id": "KAITO/USD",
+    "base": "KAITO",
+    "quote": "USD",
+    "display_name": "KAITO / US Dollar",
+    "description": "KAITO to US Dollar spot trading pair",
+    "tags": [
+      "kaito",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAVABTC": {
+    "normalized_id": "KAVA/BTC",
+    "base": "KAVA",
+    "quote": "BTC",
+    "display_name": "KAVA / Bitcoin",
+    "description": "KAVA to Bitcoin spot trading pair",
+    "tags": [
+      "kava",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "KAVAUSDT": {
+    "normalized_id": "KAVA/USD",
+    "base": "KAVA",
+    "quote": "USD",
+    "display_name": "KAVA / US Dollar",
+    "description": "KAVA to US Dollar spot trading pair",
+    "tags": [
+      "kava",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KDABTC": {
+    "normalized_id": "KDA/BTC",
+    "base": "KDA",
+    "quote": "BTC",
+    "display_name": "KDA / Bitcoin",
+    "description": "KDA to Bitcoin spot trading pair",
+    "tags": [
+      "kda",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "KDAUSDT": {
+    "normalized_id": "KDA/USD",
+    "base": "KDA",
+    "quote": "USD",
+    "display_name": "KDA / US Dollar",
+    "description": "KDA to US Dollar spot trading pair",
+    "tags": [
+      "kda",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KERNELBNB": {
+    "normalized_id": "KERNEL/BNB",
+    "base": "KERNEL",
+    "quote": "BNB",
+    "display_name": "KERNEL / Binance Coin",
+    "description": "KERNEL to Binance Coin spot trading pair",
+    "tags": [
+      "kernel",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "KERNELFDUSD": {
+    "normalized_id": "KERNEL/USD",
+    "base": "KERNEL",
+    "quote": "USD",
+    "display_name": "KERNEL / US Dollar",
+    "description": "KERNEL to US Dollar spot trading pair",
+    "tags": [
+      "kernel",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KERNELTRY": {
+    "normalized_id": "KERNEL/TRY",
+    "base": "KERNEL",
+    "quote": "TRY",
+    "display_name": "KERNEL / Turkish Lira",
+    "description": "KERNEL to Turkish Lira spot trading pair",
+    "tags": [
+      "kernel",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "KERNELUSDC": {
+    "normalized_id": "KERNEL/USD",
+    "base": "KERNEL",
+    "quote": "USD",
+    "display_name": "KERNEL / US Dollar",
+    "description": "KERNEL to US Dollar spot trading pair",
+    "tags": [
+      "kernel",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KERNELUSDT": {
+    "normalized_id": "KERNEL/USD",
+    "base": "KERNEL",
+    "quote": "USD",
+    "display_name": "KERNEL / US Dollar",
+    "description": "KERNEL to US Dollar spot trading pair",
+    "tags": [
+      "kernel",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KMNOUSDC": {
+    "normalized_id": "KMNO/USD",
+    "base": "KMNO",
+    "quote": "USD",
+    "display_name": "KMNO / US Dollar",
+    "description": "KMNO to US Dollar spot trading pair",
+    "tags": [
+      "kmno",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KMNOUSDT": {
+    "normalized_id": "KMNO/USD",
+    "base": "KMNO",
+    "quote": "USD",
+    "display_name": "KMNO / US Dollar",
+    "description": "KMNO to US Dollar spot trading pair",
+    "tags": [
+      "kmno",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KNCBTC": {
+    "normalized_id": "KNC/BTC",
+    "base": "KNC",
+    "quote": "BTC",
+    "display_name": "KNC / Bitcoin",
+    "description": "KNC to Bitcoin spot trading pair",
+    "tags": [
+      "knc",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "KNCUSDT": {
+    "normalized_id": "KNC/USD",
+    "base": "KNC",
+    "quote": "USD",
+    "display_name": "KNC / US Dollar",
+    "description": "KNC to US Dollar spot trading pair",
+    "tags": [
+      "knc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KSMBTC": {
+    "normalized_id": "KSM/BTC",
+    "base": "KSM",
+    "quote": "BTC",
+    "display_name": "KSM / Bitcoin",
+    "description": "KSM to Bitcoin spot trading pair",
+    "tags": [
+      "ksm",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "KSMTRY": {
+    "normalized_id": "KSM/TRY",
+    "base": "KSM",
+    "quote": "TRY",
+    "display_name": "KSM / Turkish Lira",
+    "description": "KSM to Turkish Lira spot trading pair",
+    "tags": [
+      "ksm",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "KSMUSDT": {
+    "normalized_id": "KSM/USD",
+    "base": "KSM",
+    "quote": "USD",
+    "display_name": "KSM / US Dollar",
+    "description": "KSM to US Dollar spot trading pair",
+    "tags": [
+      "ksm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LABNB": {
+    "normalized_id": "LA/BNB",
+    "base": "LA",
+    "quote": "BNB",
+    "display_name": "LA / Binance Coin",
+    "description": "LA to Binance Coin spot trading pair",
+    "tags": [
+      "la",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "LAFDUSD": {
+    "normalized_id": "LA/USD",
+    "base": "LA",
+    "quote": "USD",
+    "display_name": "LA / US Dollar",
+    "description": "LA to US Dollar spot trading pair",
+    "tags": [
+      "la",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LATRY": {
+    "normalized_id": "LA/TRY",
+    "base": "LA",
+    "quote": "TRY",
+    "display_name": "LA / Turkish Lira",
+    "description": "LA to Turkish Lira spot trading pair",
+    "tags": [
+      "la",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "LAUSDC": {
+    "normalized_id": "LA/USD",
+    "base": "LA",
+    "quote": "USD",
+    "display_name": "LA / US Dollar",
+    "description": "LA to US Dollar spot trading pair",
+    "tags": [
+      "la",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LAUSDT": {
+    "normalized_id": "LA/USD",
+    "base": "LA",
+    "quote": "USD",
+    "display_name": "LA / US Dollar",
+    "description": "LA to US Dollar spot trading pair",
+    "tags": [
+      "la",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LAYERBNB": {
+    "normalized_id": "LAYER/BNB",
+    "base": "LAYER",
+    "quote": "BNB",
+    "display_name": "LAYER / Binance Coin",
+    "description": "LAYER to Binance Coin spot trading pair",
+    "tags": [
+      "layer",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "LAYERBTC": {
+    "normalized_id": "LAYER/BTC",
+    "base": "LAYER",
+    "quote": "BTC",
+    "display_name": "LAYER / Bitcoin",
+    "description": "LAYER to Bitcoin spot trading pair",
+    "tags": [
+      "layer",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "LAYERFDUSD": {
+    "normalized_id": "LAYER/USD",
+    "base": "LAYER",
+    "quote": "USD",
+    "display_name": "LAYER / US Dollar",
+    "description": "LAYER to US Dollar spot trading pair",
+    "tags": [
+      "layer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LAYERTRY": {
+    "normalized_id": "LAYER/TRY",
+    "base": "LAYER",
+    "quote": "TRY",
+    "display_name": "LAYER / Turkish Lira",
+    "description": "LAYER to Turkish Lira spot trading pair",
+    "tags": [
+      "layer",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "LAYERUSDC": {
+    "normalized_id": "LAYER/USD",
+    "base": "LAYER",
+    "quote": "USD",
+    "display_name": "LAYER / US Dollar",
+    "description": "LAYER to US Dollar spot trading pair",
+    "tags": [
+      "layer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LAYERUSDT": {
+    "normalized_id": "LAYER/USD",
+    "base": "LAYER",
+    "quote": "USD",
+    "display_name": "LAYER / US Dollar",
+    "description": "LAYER to US Dollar spot trading pair",
+    "tags": [
+      "layer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LAZIOTRY": {
+    "normalized_id": "LAZIO/TRY",
+    "base": "LAZIO",
+    "quote": "TRY",
+    "display_name": "LAZIO / Turkish Lira",
+    "description": "LAZIO to Turkish Lira spot trading pair",
+    "tags": [
+      "lazio",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "LAZIOUSDT": {
+    "normalized_id": "LAZIO/USD",
+    "base": "LAZIO",
+    "quote": "USD",
+    "display_name": "LAZIO / US Dollar",
+    "description": "LAZIO to US Dollar spot trading pair",
+    "tags": [
+      "lazio",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LDOBTC": {
+    "normalized_id": "LDO/BTC",
+    "base": "LDO",
+    "quote": "BTC",
+    "display_name": "LDO / Bitcoin",
+    "description": "LDO to Bitcoin spot trading pair",
+    "tags": [
+      "ldo",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "LDOFDUSD": {
+    "normalized_id": "LDO/USD",
+    "base": "LDO",
+    "quote": "USD",
+    "display_name": "LDO / US Dollar",
+    "description": "LDO to US Dollar spot trading pair",
+    "tags": [
+      "ldo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LDOTRY": {
+    "normalized_id": "LDO/TRY",
+    "base": "LDO",
+    "quote": "TRY",
+    "display_name": "LDO / Turkish Lira",
+    "description": "LDO to Turkish Lira spot trading pair",
+    "tags": [
+      "ldo",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "LDOUSDC": {
+    "normalized_id": "LDO/USD",
+    "base": "LDO",
+    "quote": "USD",
+    "display_name": "LDO / US Dollar",
+    "description": "LDO to US Dollar spot trading pair",
+    "tags": [
+      "ldo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LDOUSDT": {
+    "normalized_id": "LDO/USD",
+    "base": "LDO",
+    "quote": "USD",
+    "display_name": "LDO / US Dollar",
+    "description": "LDO to US Dollar spot trading pair",
+    "tags": [
+      "ldo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LINKBNB": {
+    "normalized_id": "LINK/BNB",
+    "base": "LINK",
+    "quote": "BNB",
+    "display_name": "Chainlink / Binance Coin",
+    "description": "Chainlink to Binance Coin spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "LINKBRL": {
+    "normalized_id": "LINK/BRL",
+    "base": "LINK",
+    "quote": "BRL",
+    "display_name": "Chainlink / Brazilian Real",
+    "description": "Chainlink to Brazilian Real spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "LINKBTC": {
+    "normalized_id": "LINK/BTC",
+    "base": "LINK",
+    "quote": "BTC",
+    "display_name": "Chainlink / Bitcoin",
+    "description": "Chainlink to Bitcoin spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "LINKETH": {
+    "normalized_id": "LINK/ETH",
+    "base": "LINK",
+    "quote": "ETH",
+    "display_name": "Chainlink / Ethereum",
+    "description": "Chainlink to Ethereum spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "LINKEUR": {
+    "normalized_id": "LINK/EUR",
+    "base": "LINK",
+    "quote": "EUR",
+    "display_name": "Chainlink / Euro",
+    "description": "Chainlink to Euro spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LINKFDUSD": {
+    "normalized_id": "LINK/USD",
+    "base": "LINK",
+    "quote": "USD",
+    "display_name": "Chainlink / US Dollar",
+    "description": "Chainlink to US Dollar spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LINKJPY": {
+    "normalized_id": "LINK/JPY",
+    "base": "LINK",
+    "quote": "JPY",
+    "display_name": "Chainlink / Japanese Yen",
+    "description": "Chainlink to Japanese Yen spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "LINKTRY": {
+    "normalized_id": "LINK/TRY",
+    "base": "LINK",
+    "quote": "TRY",
+    "display_name": "Chainlink / Turkish Lira",
+    "description": "Chainlink to Turkish Lira spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "LINKUSDC": {
+    "normalized_id": "LINK/USD",
+    "base": "LINK",
+    "quote": "USD",
+    "display_name": "Chainlink / US Dollar",
+    "description": "Chainlink to US Dollar spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LINKUSDT": {
+    "normalized_id": "LINK/USD",
+    "base": "LINK",
+    "quote": "USD",
+    "display_name": "Chainlink / US Dollar",
+    "description": "Chainlink to US Dollar spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LISTABNB": {
+    "normalized_id": "LISTA/BNB",
+    "base": "LISTA",
+    "quote": "BNB",
+    "display_name": "LISTA / Binance Coin",
+    "description": "LISTA to Binance Coin spot trading pair",
+    "tags": [
+      "lista",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "LISTAFDUSD": {
+    "normalized_id": "LISTA/USD",
+    "base": "LISTA",
+    "quote": "USD",
+    "display_name": "LISTA / US Dollar",
+    "description": "LISTA to US Dollar spot trading pair",
+    "tags": [
+      "lista",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LISTATRY": {
+    "normalized_id": "LISTA/TRY",
+    "base": "LISTA",
+    "quote": "TRY",
+    "display_name": "LISTA / Turkish Lira",
+    "description": "LISTA to Turkish Lira spot trading pair",
+    "tags": [
+      "lista",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "LISTAUSDC": {
+    "normalized_id": "LISTA/USD",
+    "base": "LISTA",
+    "quote": "USD",
+    "display_name": "LISTA / US Dollar",
+    "description": "LISTA to US Dollar spot trading pair",
+    "tags": [
+      "lista",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LISTAUSDT": {
+    "normalized_id": "LISTA/USD",
+    "base": "LISTA",
+    "quote": "USD",
+    "display_name": "LISTA / US Dollar",
+    "description": "LISTA to US Dollar spot trading pair",
+    "tags": [
+      "lista",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LPTBNB": {
+    "normalized_id": "LPT/BNB",
+    "base": "LPT",
+    "quote": "BNB",
+    "display_name": "LPT / Binance Coin",
+    "description": "LPT to Binance Coin spot trading pair",
+    "tags": [
+      "lpt",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "LPTBTC": {
+    "normalized_id": "LPT/BTC",
+    "base": "LPT",
+    "quote": "BTC",
+    "display_name": "LPT / Bitcoin",
+    "description": "LPT to Bitcoin spot trading pair",
+    "tags": [
+      "lpt",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "LPTJPY": {
+    "normalized_id": "LPT/JPY",
+    "base": "LPT",
+    "quote": "JPY",
+    "display_name": "LPT / Japanese Yen",
+    "description": "LPT to Japanese Yen spot trading pair",
+    "tags": [
+      "lpt",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "LPTTRY": {
+    "normalized_id": "LPT/TRY",
+    "base": "LPT",
+    "quote": "TRY",
+    "display_name": "LPT / Turkish Lira",
+    "description": "LPT to Turkish Lira spot trading pair",
+    "tags": [
+      "lpt",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "LPTUSDC": {
+    "normalized_id": "LPT/USD",
+    "base": "LPT",
+    "quote": "USD",
+    "display_name": "LPT / US Dollar",
+    "description": "LPT to US Dollar spot trading pair",
+    "tags": [
+      "lpt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LPTUSDT": {
+    "normalized_id": "LPT/USD",
+    "base": "LPT",
+    "quote": "USD",
+    "display_name": "LPT / US Dollar",
+    "description": "LPT to US Dollar spot trading pair",
+    "tags": [
+      "lpt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LQTYUSDT": {
+    "normalized_id": "LQTY/USD",
+    "base": "LQTY",
+    "quote": "USD",
+    "display_name": "LQTY / US Dollar",
+    "description": "LQTY to US Dollar spot trading pair",
+    "tags": [
+      "lqty",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LRCBTC": {
+    "normalized_id": "LRC/BTC",
+    "base": "LRC",
+    "quote": "BTC",
+    "display_name": "LRC / Bitcoin",
+    "description": "LRC to Bitcoin spot trading pair",
+    "tags": [
+      "lrc",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "LRCETH": {
+    "normalized_id": "LRC/ETH",
+    "base": "LRC",
+    "quote": "ETH",
+    "display_name": "LRC / Ethereum",
+    "description": "LRC to Ethereum spot trading pair",
+    "tags": [
+      "lrc",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "LRCTRY": {
+    "normalized_id": "LRC/TRY",
+    "base": "LRC",
+    "quote": "TRY",
+    "display_name": "LRC / Turkish Lira",
+    "description": "LRC to Turkish Lira spot trading pair",
+    "tags": [
+      "lrc",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "LRCUSDT": {
+    "normalized_id": "LRC/USD",
+    "base": "LRC",
+    "quote": "USD",
+    "display_name": "LRC / US Dollar",
+    "description": "LRC to US Dollar spot trading pair",
+    "tags": [
+      "lrc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LSKBTC": {
+    "normalized_id": "LSK/BTC",
+    "base": "LSK",
+    "quote": "BTC",
+    "display_name": "LSK / Bitcoin",
+    "description": "LSK to Bitcoin spot trading pair",
+    "tags": [
+      "lsk",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "LSKUSDT": {
+    "normalized_id": "LSK/USD",
+    "base": "LSK",
+    "quote": "USD",
+    "display_name": "LSK / US Dollar",
+    "description": "LSK to US Dollar spot trading pair",
+    "tags": [
+      "lsk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LTCBNB": {
+    "normalized_id": "LTC/BNB",
+    "base": "LTC",
+    "quote": "BNB",
+    "display_name": "Litecoin / Binance Coin",
+    "description": "Litecoin to Binance Coin spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "LTCBRL": {
+    "normalized_id": "LTC/BRL",
+    "base": "LTC",
+    "quote": "BRL",
+    "display_name": "Litecoin / Brazilian Real",
+    "description": "Litecoin to Brazilian Real spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "LTCBTC": {
+    "normalized_id": "LTC/BTC",
+    "base": "LTC",
+    "quote": "BTC",
+    "display_name": "Litecoin / Bitcoin",
+    "description": "Litecoin to Bitcoin spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "LTCETH": {
+    "normalized_id": "LTC/ETH",
+    "base": "LTC",
+    "quote": "ETH",
+    "display_name": "Litecoin / Ethereum",
+    "description": "Litecoin to Ethereum spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "LTCEUR": {
+    "normalized_id": "LTC/EUR",
+    "base": "LTC",
+    "quote": "EUR",
+    "display_name": "Litecoin / Euro",
+    "description": "Litecoin to Euro spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LTCFDUSD": {
+    "normalized_id": "LTC/USD",
+    "base": "LTC",
+    "quote": "USD",
+    "display_name": "Litecoin / US Dollar",
+    "description": "Litecoin to US Dollar spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LTCJPY": {
+    "normalized_id": "LTC/JPY",
+    "base": "LTC",
+    "quote": "JPY",
+    "display_name": "Litecoin / Japanese Yen",
+    "description": "Litecoin to Japanese Yen spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "LTCTRY": {
+    "normalized_id": "LTC/TRY",
+    "base": "LTC",
+    "quote": "TRY",
+    "display_name": "Litecoin / Turkish Lira",
+    "description": "Litecoin to Turkish Lira spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "LTCUSDC": {
+    "normalized_id": "LTC/USD",
+    "base": "LTC",
+    "quote": "USD",
+    "display_name": "Litecoin / US Dollar",
+    "description": "Litecoin to US Dollar spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LTCUSDT": {
+    "normalized_id": "LTC/USD",
+    "base": "LTC",
+    "quote": "USD",
+    "display_name": "Litecoin / US Dollar",
+    "description": "Litecoin to US Dollar spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LUMIATRY": {
+    "normalized_id": "LUMIA/TRY",
+    "base": "LUMIA",
+    "quote": "TRY",
+    "display_name": "LUMIA / Turkish Lira",
+    "description": "LUMIA to Turkish Lira spot trading pair",
+    "tags": [
+      "lumia",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "LUMIAUSDT": {
+    "normalized_id": "LUMIA/USD",
+    "base": "LUMIA",
+    "quote": "USD",
+    "display_name": "LUMIA / US Dollar",
+    "description": "LUMIA to US Dollar spot trading pair",
+    "tags": [
+      "lumia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LUNATRY": {
+    "normalized_id": "LUNA/TRY",
+    "base": "LUNA",
+    "quote": "TRY",
+    "display_name": "LUNA / Turkish Lira",
+    "description": "LUNA to Turkish Lira spot trading pair",
+    "tags": [
+      "luna",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "LUNAUSDT": {
+    "normalized_id": "LUNA/USD",
+    "base": "LUNA",
+    "quote": "USD",
+    "display_name": "LUNA / US Dollar",
+    "description": "LUNA to US Dollar spot trading pair",
+    "tags": [
+      "luna",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LUNCTRY": {
+    "normalized_id": "LUNC/TRY",
+    "base": "LUNC",
+    "quote": "TRY",
+    "display_name": "LUNC / Turkish Lira",
+    "description": "LUNC to Turkish Lira spot trading pair",
+    "tags": [
+      "lunc",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "LUNCUSDT": {
+    "normalized_id": "LUNC/USD",
+    "base": "LUNC",
+    "quote": "USD",
+    "display_name": "LUNC / US Dollar",
+    "description": "LUNC to US Dollar spot trading pair",
+    "tags": [
+      "lunc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MAGICBTC": {
+    "normalized_id": "MAGIC/BTC",
+    "base": "MAGIC",
+    "quote": "BTC",
+    "display_name": "MAGIC / Bitcoin",
+    "description": "MAGIC to Bitcoin spot trading pair",
+    "tags": [
+      "magic",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "MAGICTRY": {
+    "normalized_id": "MAGIC/TRY",
+    "base": "MAGIC",
+    "quote": "TRY",
+    "display_name": "MAGIC / Turkish Lira",
+    "description": "MAGIC to Turkish Lira spot trading pair",
+    "tags": [
+      "magic",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "MAGICUSDC": {
+    "normalized_id": "MAGIC/USD",
+    "base": "MAGIC",
+    "quote": "USD",
+    "display_name": "MAGIC / US Dollar",
+    "description": "MAGIC to US Dollar spot trading pair",
+    "tags": [
+      "magic",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MAGICUSDT": {
+    "normalized_id": "MAGIC/USD",
+    "base": "MAGIC",
+    "quote": "USD",
+    "display_name": "MAGIC / US Dollar",
+    "description": "MAGIC to US Dollar spot trading pair",
+    "tags": [
+      "magic",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MANABTC": {
+    "normalized_id": "MANA/BTC",
+    "base": "MANA",
+    "quote": "BTC",
+    "display_name": "Decentraland / Bitcoin",
+    "description": "Decentraland to Bitcoin spot trading pair",
+    "tags": [
+      "mana",
+      "decentraland",
+      "gaming",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "MANAETH": {
+    "normalized_id": "MANA/ETH",
+    "base": "MANA",
+    "quote": "ETH",
+    "display_name": "Decentraland / Ethereum",
+    "description": "Decentraland to Ethereum spot trading pair",
+    "tags": [
+      "mana",
+      "decentraland",
+      "gaming",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "MANATRY": {
+    "normalized_id": "MANA/TRY",
+    "base": "MANA",
+    "quote": "TRY",
+    "display_name": "Decentraland / Turkish Lira",
+    "description": "Decentraland to Turkish Lira spot trading pair",
+    "tags": [
+      "mana",
+      "decentraland",
+      "gaming",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "MANAUSDT": {
+    "normalized_id": "MANA/USD",
+    "base": "MANA",
+    "quote": "USD",
+    "display_name": "Decentraland / US Dollar",
+    "description": "Decentraland to US Dollar spot trading pair",
+    "tags": [
+      "mana",
+      "decentraland",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MANTABTC": {
+    "normalized_id": "MANTA/BTC",
+    "base": "MANTA",
+    "quote": "BTC",
+    "display_name": "MANTA / Bitcoin",
+    "description": "MANTA to Bitcoin spot trading pair",
+    "tags": [
+      "manta",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "MANTAFDUSD": {
+    "normalized_id": "MANTA/USD",
+    "base": "MANTA",
+    "quote": "USD",
+    "display_name": "MANTA / US Dollar",
+    "description": "MANTA to US Dollar spot trading pair",
+    "tags": [
+      "manta",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MANTATRY": {
+    "normalized_id": "MANTA/TRY",
+    "base": "MANTA",
+    "quote": "TRY",
+    "display_name": "MANTA / Turkish Lira",
+    "description": "MANTA to Turkish Lira spot trading pair",
+    "tags": [
+      "manta",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "MANTAUSDC": {
+    "normalized_id": "MANTA/USD",
+    "base": "MANTA",
+    "quote": "USD",
+    "display_name": "MANTA / US Dollar",
+    "description": "MANTA to US Dollar spot trading pair",
+    "tags": [
+      "manta",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MANTAUSDT": {
+    "normalized_id": "MANTA/USD",
+    "base": "MANTA",
+    "quote": "USD",
+    "display_name": "MANTA / US Dollar",
+    "description": "MANTA to US Dollar spot trading pair",
+    "tags": [
+      "manta",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MASKTRY": {
+    "normalized_id": "MASK/TRY",
+    "base": "MASK",
+    "quote": "TRY",
+    "display_name": "MASK / Turkish Lira",
+    "description": "MASK to Turkish Lira spot trading pair",
+    "tags": [
+      "mask",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "MASKUSDC": {
+    "normalized_id": "MASK/USD",
+    "base": "MASK",
+    "quote": "USD",
+    "display_name": "MASK / US Dollar",
+    "description": "MASK to US Dollar spot trading pair",
+    "tags": [
+      "mask",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MASKUSDT": {
+    "normalized_id": "MASK/USD",
+    "base": "MASK",
+    "quote": "USD",
+    "display_name": "MASK / US Dollar",
+    "description": "MASK to US Dollar spot trading pair",
+    "tags": [
+      "mask",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MAVBTC": {
+    "normalized_id": "MAV/BTC",
+    "base": "MAV",
+    "quote": "BTC",
+    "display_name": "MAV / Bitcoin",
+    "description": "MAV to Bitcoin spot trading pair",
+    "tags": [
+      "mav",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "MAVTRY": {
+    "normalized_id": "MAV/TRY",
+    "base": "MAV",
+    "quote": "TRY",
+    "display_name": "MAV / Turkish Lira",
+    "description": "MAV to Turkish Lira spot trading pair",
+    "tags": [
+      "mav",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "MAVUSDT": {
+    "normalized_id": "MAV/USD",
+    "base": "MAV",
+    "quote": "USD",
+    "display_name": "MAV / US Dollar",
+    "description": "MAV to US Dollar spot trading pair",
+    "tags": [
+      "mav",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MBLUSDT": {
+    "normalized_id": "MBL/USD",
+    "base": "MBL",
+    "quote": "USD",
+    "display_name": "MBL / US Dollar",
+    "description": "MBL to US Dollar spot trading pair",
+    "tags": [
+      "mbl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MBOXTRY": {
+    "normalized_id": "MBOX/TRY",
+    "base": "MBOX",
+    "quote": "TRY",
+    "display_name": "MBOX / Turkish Lira",
+    "description": "MBOX to Turkish Lira spot trading pair",
+    "tags": [
+      "mbox",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "MBOXUSDT": {
+    "normalized_id": "MBOX/USD",
+    "base": "MBOX",
+    "quote": "USD",
+    "display_name": "MBOX / US Dollar",
+    "description": "MBOX to US Dollar spot trading pair",
+    "tags": [
+      "mbox",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MDTUSDT": {
+    "normalized_id": "MDT/USD",
+    "base": "MDT",
+    "quote": "USD",
+    "display_name": "MDT / US Dollar",
+    "description": "MDT to US Dollar spot trading pair",
+    "tags": [
+      "mdt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MEBTC": {
+    "normalized_id": "ME/BTC",
+    "base": "ME",
+    "quote": "BTC",
+    "display_name": "ME / Bitcoin",
+    "description": "ME to Bitcoin spot trading pair",
+    "tags": [
+      "me",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "MEFDUSD": {
+    "normalized_id": "ME/USD",
+    "base": "ME",
+    "quote": "USD",
+    "display_name": "ME / US Dollar",
+    "description": "ME to US Dollar spot trading pair",
+    "tags": [
+      "me",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MEMEFDUSD": {
+    "normalized_id": "MEME/USD",
+    "base": "MEME",
+    "quote": "USD",
+    "display_name": "MEME / US Dollar",
+    "description": "MEME to US Dollar spot trading pair",
+    "tags": [
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MEMETRY": {
+    "normalized_id": "MEME/TRY",
+    "base": "MEME",
+    "quote": "TRY",
+    "display_name": "MEME / Turkish Lira",
+    "description": "MEME to Turkish Lira spot trading pair",
+    "tags": [
+      "meme",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "MEMEUSDC": {
+    "normalized_id": "MEME/USD",
+    "base": "MEME",
+    "quote": "USD",
+    "display_name": "MEME / US Dollar",
+    "description": "MEME to US Dollar spot trading pair",
+    "tags": [
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MEMEUSDT": {
+    "normalized_id": "MEME/USD",
+    "base": "MEME",
+    "quote": "USD",
+    "display_name": "MEME / US Dollar",
+    "description": "MEME to US Dollar spot trading pair",
+    "tags": [
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "METISTRY": {
+    "normalized_id": "METIS/TRY",
+    "base": "METIS",
+    "quote": "TRY",
+    "display_name": "METIS / Turkish Lira",
+    "description": "METIS to Turkish Lira spot trading pair",
+    "tags": [
+      "metis",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "METISUSDT": {
+    "normalized_id": "METIS/USD",
+    "base": "METIS",
+    "quote": "USD",
+    "display_name": "METIS / US Dollar",
+    "description": "METIS to US Dollar spot trading pair",
+    "tags": [
+      "metis",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "METRY": {
+    "normalized_id": "ME/TRY",
+    "base": "ME",
+    "quote": "TRY",
+    "display_name": "ME / Turkish Lira",
+    "description": "ME to Turkish Lira spot trading pair",
+    "tags": [
+      "me",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "MEUSDT": {
+    "normalized_id": "ME/USD",
+    "base": "ME",
+    "quote": "USD",
+    "display_name": "ME / US Dollar",
+    "description": "ME to US Dollar spot trading pair",
+    "tags": [
+      "me",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MINABTC": {
+    "normalized_id": "MINA/BTC",
+    "base": "MINA",
+    "quote": "BTC",
+    "display_name": "MINA / Bitcoin",
+    "description": "MINA to Bitcoin spot trading pair",
+    "tags": [
+      "mina",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "MINATRY": {
+    "normalized_id": "MINA/TRY",
+    "base": "MINA",
+    "quote": "TRY",
+    "display_name": "MINA / Turkish Lira",
+    "description": "MINA to Turkish Lira spot trading pair",
+    "tags": [
+      "mina",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "MINAUSDT": {
+    "normalized_id": "MINA/USD",
+    "base": "MINA",
+    "quote": "USD",
+    "display_name": "MINA / US Dollar",
+    "description": "MINA to US Dollar spot trading pair",
+    "tags": [
+      "mina",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MKRBTC": {
+    "normalized_id": "MKR/BTC",
+    "base": "MKR",
+    "quote": "BTC",
+    "display_name": "Maker / Bitcoin",
+    "description": "Maker to Bitcoin spot trading pair",
+    "tags": [
+      "mkr",
+      "maker",
+      "defi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "MKRTRY": {
+    "normalized_id": "MKR/TRY",
+    "base": "MKR",
+    "quote": "TRY",
+    "display_name": "Maker / Turkish Lira",
+    "description": "Maker to Turkish Lira spot trading pair",
+    "tags": [
+      "mkr",
+      "maker",
+      "defi",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "MKRUSDC": {
+    "normalized_id": "MKR/USD",
+    "base": "MKR",
+    "quote": "USD",
+    "display_name": "Maker / US Dollar",
+    "description": "Maker to US Dollar spot trading pair",
+    "tags": [
+      "mkr",
+      "maker",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MKRUSDT": {
+    "normalized_id": "MKR/USD",
+    "base": "MKR",
+    "quote": "USD",
+    "display_name": "Maker / US Dollar",
+    "description": "Maker to US Dollar spot trading pair",
+    "tags": [
+      "mkr",
+      "maker",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MLNUSDT": {
+    "normalized_id": "MLN/USD",
+    "base": "MLN",
+    "quote": "USD",
+    "display_name": "MLN / US Dollar",
+    "description": "MLN to US Dollar spot trading pair",
+    "tags": [
+      "mln",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOVEBNB": {
+    "normalized_id": "MOVE/BNB",
+    "base": "MOVE",
+    "quote": "BNB",
+    "display_name": "MOVE / Binance Coin",
+    "description": "MOVE to Binance Coin spot trading pair",
+    "tags": [
+      "move",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "MOVEBTC": {
+    "normalized_id": "MOVE/BTC",
+    "base": "MOVE",
+    "quote": "BTC",
+    "display_name": "MOVE / Bitcoin",
+    "description": "MOVE to Bitcoin spot trading pair",
+    "tags": [
+      "move",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "MOVEFDUSD": {
+    "normalized_id": "MOVE/USD",
+    "base": "MOVE",
+    "quote": "USD",
+    "display_name": "MOVE / US Dollar",
+    "description": "MOVE to US Dollar spot trading pair",
+    "tags": [
+      "move",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOVETRY": {
+    "normalized_id": "MOVE/TRY",
+    "base": "MOVE",
+    "quote": "TRY",
+    "display_name": "MOVE / Turkish Lira",
+    "description": "MOVE to Turkish Lira spot trading pair",
+    "tags": [
+      "move",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "MOVEUSDC": {
+    "normalized_id": "MOVE/USD",
+    "base": "MOVE",
+    "quote": "USD",
+    "display_name": "MOVE / US Dollar",
+    "description": "MOVE to US Dollar spot trading pair",
+    "tags": [
+      "move",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOVEUSDT": {
+    "normalized_id": "MOVE/USD",
+    "base": "MOVE",
+    "quote": "USD",
+    "display_name": "MOVE / US Dollar",
+    "description": "MOVE to US Dollar spot trading pair",
+    "tags": [
+      "move",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOVRBTC": {
+    "normalized_id": "MOVR/BTC",
+    "base": "MOVR",
+    "quote": "BTC",
+    "display_name": "MOVR / Bitcoin",
+    "description": "MOVR to Bitcoin spot trading pair",
+    "tags": [
+      "movr",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "MOVRTRY": {
+    "normalized_id": "MOVR/TRY",
+    "base": "MOVR",
+    "quote": "TRY",
+    "display_name": "MOVR / Turkish Lira",
+    "description": "MOVR to Turkish Lira spot trading pair",
+    "tags": [
+      "movr",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "MOVRUSDT": {
+    "normalized_id": "MOVR/USD",
+    "base": "MOVR",
+    "quote": "USD",
+    "display_name": "MOVR / US Dollar",
+    "description": "MOVR to US Dollar spot trading pair",
+    "tags": [
+      "movr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MTLBTC": {
+    "normalized_id": "MTL/BTC",
+    "base": "MTL",
+    "quote": "BTC",
+    "display_name": "MTL / Bitcoin",
+    "description": "MTL to Bitcoin spot trading pair",
+    "tags": [
+      "mtl",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "MTLUSDT": {
+    "normalized_id": "MTL/USD",
+    "base": "MTL",
+    "quote": "USD",
+    "display_name": "MTL / US Dollar",
+    "description": "MTL to US Dollar spot trading pair",
+    "tags": [
+      "mtl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MUBARAKTRY": {
+    "normalized_id": "MUBARAK/TRY",
+    "base": "MUBARAK",
+    "quote": "TRY",
+    "display_name": "MUBARAK / Turkish Lira",
+    "description": "MUBARAK to Turkish Lira spot trading pair",
+    "tags": [
+      "mubarak",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "MUBARAKUSDC": {
+    "normalized_id": "MUBARAK/USD",
+    "base": "MUBARAK",
+    "quote": "USD",
+    "display_name": "MUBARAK / US Dollar",
+    "description": "MUBARAK to US Dollar spot trading pair",
+    "tags": [
+      "mubarak",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MUBARAKUSDT": {
+    "normalized_id": "MUBARAK/USD",
+    "base": "MUBARAK",
+    "quote": "USD",
+    "display_name": "MUBARAK / US Dollar",
+    "description": "MUBARAK to US Dollar spot trading pair",
+    "tags": [
+      "mubarak",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEARBNB": {
+    "normalized_id": "NEAR/BNB",
+    "base": "NEAR",
+    "quote": "BNB",
+    "display_name": "NEAR Protocol / Binance Coin",
+    "description": "NEAR Protocol to Binance Coin spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "NEARBRL": {
+    "normalized_id": "NEAR/BRL",
+    "base": "NEAR",
+    "quote": "BRL",
+    "display_name": "NEAR Protocol / Brazilian Real",
+    "description": "NEAR Protocol to Brazilian Real spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "NEARBTC": {
+    "normalized_id": "NEAR/BTC",
+    "base": "NEAR",
+    "quote": "BTC",
+    "display_name": "NEAR Protocol / Bitcoin",
+    "description": "NEAR Protocol to Bitcoin spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "NEARETH": {
+    "normalized_id": "NEAR/ETH",
+    "base": "NEAR",
+    "quote": "ETH",
+    "display_name": "NEAR Protocol / Ethereum",
+    "description": "NEAR Protocol to Ethereum spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "NEAREUR": {
+    "normalized_id": "NEAR/EUR",
+    "base": "NEAR",
+    "quote": "EUR",
+    "display_name": "NEAR Protocol / Euro",
+    "description": "NEAR Protocol to Euro spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "NEARFDUSD": {
+    "normalized_id": "NEAR/USD",
+    "base": "NEAR",
+    "quote": "USD",
+    "display_name": "NEAR Protocol / US Dollar",
+    "description": "NEAR Protocol to US Dollar spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEARJPY": {
+    "normalized_id": "NEAR/JPY",
+    "base": "NEAR",
+    "quote": "JPY",
+    "display_name": "NEAR Protocol / Japanese Yen",
+    "description": "NEAR Protocol to Japanese Yen spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "NEARTRY": {
+    "normalized_id": "NEAR/TRY",
+    "base": "NEAR",
+    "quote": "TRY",
+    "display_name": "NEAR Protocol / Turkish Lira",
+    "description": "NEAR Protocol to Turkish Lira spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "NEARUSDC": {
+    "normalized_id": "NEAR/USD",
+    "base": "NEAR",
+    "quote": "USD",
+    "display_name": "NEAR Protocol / US Dollar",
+    "description": "NEAR Protocol to US Dollar spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEARUSDT": {
+    "normalized_id": "NEAR/USD",
+    "base": "NEAR",
+    "quote": "USD",
+    "display_name": "NEAR Protocol / US Dollar",
+    "description": "NEAR Protocol to US Dollar spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEIROFDUSD": {
+    "normalized_id": "NEIRO/USD",
+    "base": "NEIRO",
+    "quote": "USD",
+    "display_name": "NEIRO / US Dollar",
+    "description": "NEIRO to US Dollar spot trading pair",
+    "tags": [
+      "neiro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEIROJPY": {
+    "normalized_id": "NEIRO/JPY",
+    "base": "NEIRO",
+    "quote": "JPY",
+    "display_name": "NEIRO / Japanese Yen",
+    "description": "NEIRO to Japanese Yen spot trading pair",
+    "tags": [
+      "neiro",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "NEIROTRY": {
+    "normalized_id": "NEIRO/TRY",
+    "base": "NEIRO",
+    "quote": "TRY",
+    "display_name": "NEIRO / Turkish Lira",
+    "description": "NEIRO to Turkish Lira spot trading pair",
+    "tags": [
+      "neiro",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "NEIROUSDC": {
+    "normalized_id": "NEIRO/USD",
+    "base": "NEIRO",
+    "quote": "USD",
+    "display_name": "NEIRO / US Dollar",
+    "description": "NEIRO to US Dollar spot trading pair",
+    "tags": [
+      "neiro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEIROUSDT": {
+    "normalized_id": "NEIRO/USD",
+    "base": "NEIRO",
+    "quote": "USD",
+    "display_name": "NEIRO / US Dollar",
+    "description": "NEIRO to US Dollar spot trading pair",
+    "tags": [
+      "neiro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEOBTC": {
+    "normalized_id": "NEO/BTC",
+    "base": "NEO",
+    "quote": "BTC",
+    "display_name": "NEO / Bitcoin",
+    "description": "NEO to Bitcoin spot trading pair",
+    "tags": [
+      "neo",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "NEOTRY": {
+    "normalized_id": "NEO/TRY",
+    "base": "NEO",
+    "quote": "TRY",
+    "display_name": "NEO / Turkish Lira",
+    "description": "NEO to Turkish Lira spot trading pair",
+    "tags": [
+      "neo",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "NEOUSDC": {
+    "normalized_id": "NEO/USD",
+    "base": "NEO",
+    "quote": "USD",
+    "display_name": "NEO / US Dollar",
+    "description": "NEO to US Dollar spot trading pair",
+    "tags": [
+      "neo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEOUSDT": {
+    "normalized_id": "NEO/USD",
+    "base": "NEO",
+    "quote": "USD",
+    "display_name": "NEO / US Dollar",
+    "description": "NEO to US Dollar spot trading pair",
+    "tags": [
+      "neo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEWTBNB": {
+    "normalized_id": "NEWT/BNB",
+    "base": "NEWT",
+    "quote": "BNB",
+    "display_name": "NEWT / Binance Coin",
+    "description": "NEWT to Binance Coin spot trading pair",
+    "tags": [
+      "newt",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "NEWTFDUSD": {
+    "normalized_id": "NEWT/USD",
+    "base": "NEWT",
+    "quote": "USD",
+    "display_name": "NEWT / US Dollar",
+    "description": "NEWT to US Dollar spot trading pair",
+    "tags": [
+      "newt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEWTTRY": {
+    "normalized_id": "NEWT/TRY",
+    "base": "NEWT",
+    "quote": "TRY",
+    "display_name": "NEWT / Turkish Lira",
+    "description": "NEWT to Turkish Lira spot trading pair",
+    "tags": [
+      "newt",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "NEWTUSDC": {
+    "normalized_id": "NEWT/USD",
+    "base": "NEWT",
+    "quote": "USD",
+    "display_name": "NEWT / US Dollar",
+    "description": "NEWT to US Dollar spot trading pair",
+    "tags": [
+      "newt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEWTUSDT": {
+    "normalized_id": "NEWT/USD",
+    "base": "NEWT",
+    "quote": "USD",
+    "display_name": "NEWT / US Dollar",
+    "description": "NEWT to US Dollar spot trading pair",
+    "tags": [
+      "newt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEXOBTC": {
+    "normalized_id": "NEXO/BTC",
+    "base": "NEXO",
+    "quote": "BTC",
+    "display_name": "NEXO / Bitcoin",
+    "description": "NEXO to Bitcoin spot trading pair",
+    "tags": [
+      "nexo",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "NEXOUSDT": {
+    "normalized_id": "NEXO/USD",
+    "base": "NEXO",
+    "quote": "USD",
+    "display_name": "NEXO / US Dollar",
+    "description": "NEXO to US Dollar spot trading pair",
+    "tags": [
+      "nexo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NFPBTC": {
+    "normalized_id": "NFP/BTC",
+    "base": "NFP",
+    "quote": "BTC",
+    "display_name": "NFP / Bitcoin",
+    "description": "NFP to Bitcoin spot trading pair",
+    "tags": [
+      "nfp",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "NFPFDUSD": {
+    "normalized_id": "NFP/USD",
+    "base": "NFP",
+    "quote": "USD",
+    "display_name": "NFP / US Dollar",
+    "description": "NFP to US Dollar spot trading pair",
+    "tags": [
+      "nfp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NFPTRY": {
+    "normalized_id": "NFP/TRY",
+    "base": "NFP",
+    "quote": "TRY",
+    "display_name": "NFP / Turkish Lira",
+    "description": "NFP to Turkish Lira spot trading pair",
+    "tags": [
+      "nfp",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "NFPUSDT": {
+    "normalized_id": "NFP/USD",
+    "base": "NFP",
+    "quote": "USD",
+    "display_name": "NFP / US Dollar",
+    "description": "NFP to US Dollar spot trading pair",
+    "tags": [
+      "nfp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NILBNB": {
+    "normalized_id": "NIL/BNB",
+    "base": "NIL",
+    "quote": "BNB",
+    "display_name": "NIL / Binance Coin",
+    "description": "NIL to Binance Coin spot trading pair",
+    "tags": [
+      "nil",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "NILFDUSD": {
+    "normalized_id": "NIL/USD",
+    "base": "NIL",
+    "quote": "USD",
+    "display_name": "NIL / US Dollar",
+    "description": "NIL to US Dollar spot trading pair",
+    "tags": [
+      "nil",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NILTRY": {
+    "normalized_id": "NIL/TRY",
+    "base": "NIL",
+    "quote": "TRY",
+    "display_name": "NIL / Turkish Lira",
+    "description": "NIL to Turkish Lira spot trading pair",
+    "tags": [
+      "nil",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "NILUSDC": {
+    "normalized_id": "NIL/USD",
+    "base": "NIL",
+    "quote": "USD",
+    "display_name": "NIL / US Dollar",
+    "description": "NIL to US Dollar spot trading pair",
+    "tags": [
+      "nil",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NILUSDT": {
+    "normalized_id": "NIL/USD",
+    "base": "NIL",
+    "quote": "USD",
+    "display_name": "NIL / US Dollar",
+    "description": "NIL to US Dollar spot trading pair",
+    "tags": [
+      "nil",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NKNUSDT": {
+    "normalized_id": "NKN/USD",
+    "base": "NKN",
+    "quote": "USD",
+    "display_name": "NKN / US Dollar",
+    "description": "NKN to US Dollar spot trading pair",
+    "tags": [
+      "nkn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NMRBTC": {
+    "normalized_id": "NMR/BTC",
+    "base": "NMR",
+    "quote": "BTC",
+    "display_name": "NMR / Bitcoin",
+    "description": "NMR to Bitcoin spot trading pair",
+    "tags": [
+      "nmr",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "NMRUSDT": {
+    "normalized_id": "NMR/USD",
+    "base": "NMR",
+    "quote": "USD",
+    "display_name": "NMR / US Dollar",
+    "description": "NMR to US Dollar spot trading pair",
+    "tags": [
+      "nmr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NOTFDUSD": {
+    "normalized_id": "NOT/USD",
+    "base": "NOT",
+    "quote": "USD",
+    "display_name": "NOT / US Dollar",
+    "description": "NOT to US Dollar spot trading pair",
+    "tags": [
+      "not",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NOTTRY": {
+    "normalized_id": "NOT/TRY",
+    "base": "NOT",
+    "quote": "TRY",
+    "display_name": "NOT / Turkish Lira",
+    "description": "NOT to Turkish Lira spot trading pair",
+    "tags": [
+      "not",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "NOTUSDC": {
+    "normalized_id": "NOT/USD",
+    "base": "NOT",
+    "quote": "USD",
+    "display_name": "NOT / US Dollar",
+    "description": "NOT to US Dollar spot trading pair",
+    "tags": [
+      "not",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NOTUSDT": {
+    "normalized_id": "NOT/USD",
+    "base": "NOT",
+    "quote": "USD",
+    "display_name": "NOT / US Dollar",
+    "description": "NOT to US Dollar spot trading pair",
+    "tags": [
+      "not",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NTRNBNB": {
+    "normalized_id": "NTRN/BNB",
+    "base": "NTRN",
+    "quote": "BNB",
+    "display_name": "NTRN / Binance Coin",
+    "description": "NTRN to Binance Coin spot trading pair",
+    "tags": [
+      "ntrn",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "NTRNTRY": {
+    "normalized_id": "NTRN/TRY",
+    "base": "NTRN",
+    "quote": "TRY",
+    "display_name": "NTRN / Turkish Lira",
+    "description": "NTRN to Turkish Lira spot trading pair",
+    "tags": [
+      "ntrn",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "NTRNUSDT": {
+    "normalized_id": "NTRN/USD",
+    "base": "NTRN",
+    "quote": "USD",
+    "display_name": "NTRN / US Dollar",
+    "description": "NTRN to US Dollar spot trading pair",
+    "tags": [
+      "ntrn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NXPCBNB": {
+    "normalized_id": "NXPC/BNB",
+    "base": "NXPC",
+    "quote": "BNB",
+    "display_name": "NXPC / Binance Coin",
+    "description": "NXPC to Binance Coin spot trading pair",
+    "tags": [
+      "nxpc",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "NXPCFDUSD": {
+    "normalized_id": "NXPC/USD",
+    "base": "NXPC",
+    "quote": "USD",
+    "display_name": "NXPC / US Dollar",
+    "description": "NXPC to US Dollar spot trading pair",
+    "tags": [
+      "nxpc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NXPCTRY": {
+    "normalized_id": "NXPC/TRY",
+    "base": "NXPC",
+    "quote": "TRY",
+    "display_name": "NXPC / Turkish Lira",
+    "description": "NXPC to Turkish Lira spot trading pair",
+    "tags": [
+      "nxpc",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "NXPCUSDC": {
+    "normalized_id": "NXPC/USD",
+    "base": "NXPC",
+    "quote": "USD",
+    "display_name": "NXPC / US Dollar",
+    "description": "NXPC to US Dollar spot trading pair",
+    "tags": [
+      "nxpc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NXPCUSDT": {
+    "normalized_id": "NXPC/USD",
+    "base": "NXPC",
+    "quote": "USD",
+    "display_name": "NXPC / US Dollar",
+    "description": "NXPC to US Dollar spot trading pair",
+    "tags": [
+      "nxpc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OGBTC": {
+    "normalized_id": "OG/BTC",
+    "base": "OG",
+    "quote": "BTC",
+    "display_name": "OG / Bitcoin",
+    "description": "OG to Bitcoin spot trading pair",
+    "tags": [
+      "og",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "OGNBTC": {
+    "normalized_id": "OGN/BTC",
+    "base": "OGN",
+    "quote": "BTC",
+    "display_name": "OGN / Bitcoin",
+    "description": "OGN to Bitcoin spot trading pair",
+    "tags": [
+      "ogn",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "OGNTRY": {
+    "normalized_id": "OGN/TRY",
+    "base": "OGN",
+    "quote": "TRY",
+    "display_name": "OGN / Turkish Lira",
+    "description": "OGN to Turkish Lira spot trading pair",
+    "tags": [
+      "ogn",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "OGNUSDT": {
+    "normalized_id": "OGN/USD",
+    "base": "OGN",
+    "quote": "USD",
+    "display_name": "OGN / US Dollar",
+    "description": "OGN to US Dollar spot trading pair",
+    "tags": [
+      "ogn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OGTRY": {
+    "normalized_id": "OG/TRY",
+    "base": "OG",
+    "quote": "TRY",
+    "display_name": "OG / Turkish Lira",
+    "description": "OG to Turkish Lira spot trading pair",
+    "tags": [
+      "og",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "OGUSDT": {
+    "normalized_id": "OG/USD",
+    "base": "OG",
+    "quote": "USD",
+    "display_name": "OG / US Dollar",
+    "description": "OG to US Dollar spot trading pair",
+    "tags": [
+      "og",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OMBTC": {
+    "normalized_id": "OM/BTC",
+    "base": "OM",
+    "quote": "BTC",
+    "display_name": "OM / Bitcoin",
+    "description": "OM to Bitcoin spot trading pair",
+    "tags": [
+      "om",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "OMNIBTC": {
+    "normalized_id": "OMNI/BTC",
+    "base": "OMNI",
+    "quote": "BTC",
+    "display_name": "OMNI / Bitcoin",
+    "description": "OMNI to Bitcoin spot trading pair",
+    "tags": [
+      "omni",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "OMNIFDUSD": {
+    "normalized_id": "OMNI/USD",
+    "base": "OMNI",
+    "quote": "USD",
+    "display_name": "OMNI / US Dollar",
+    "description": "OMNI to US Dollar spot trading pair",
+    "tags": [
+      "omni",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OMNITRY": {
+    "normalized_id": "OMNI/TRY",
+    "base": "OMNI",
+    "quote": "TRY",
+    "display_name": "OMNI / Turkish Lira",
+    "description": "OMNI to Turkish Lira spot trading pair",
+    "tags": [
+      "omni",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "OMNIUSDC": {
+    "normalized_id": "OMNI/USD",
+    "base": "OMNI",
+    "quote": "USD",
+    "display_name": "OMNI / US Dollar",
+    "description": "OMNI to US Dollar spot trading pair",
+    "tags": [
+      "omni",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OMNIUSDT": {
+    "normalized_id": "OMNI/USD",
+    "base": "OMNI",
+    "quote": "USD",
+    "display_name": "OMNI / US Dollar",
+    "description": "OMNI to US Dollar spot trading pair",
+    "tags": [
+      "omni",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OMTRY": {
+    "normalized_id": "OM/TRY",
+    "base": "OM",
+    "quote": "TRY",
+    "display_name": "OM / Turkish Lira",
+    "description": "OM to Turkish Lira spot trading pair",
+    "tags": [
+      "om",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "OMUSDC": {
+    "normalized_id": "OM/USD",
+    "base": "OM",
+    "quote": "USD",
+    "display_name": "OM / US Dollar",
+    "description": "OM to US Dollar spot trading pair",
+    "tags": [
+      "om",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OMUSDT": {
+    "normalized_id": "OM/USD",
+    "base": "OM",
+    "quote": "USD",
+    "display_name": "OM / US Dollar",
+    "description": "OM to US Dollar spot trading pair",
+    "tags": [
+      "om",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ONDOTRY": {
+    "normalized_id": "ONDO/TRY",
+    "base": "ONDO",
+    "quote": "TRY",
+    "display_name": "ONDO / Turkish Lira",
+    "description": "ONDO to Turkish Lira spot trading pair",
+    "tags": [
+      "ondo",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ONDOUSDC": {
+    "normalized_id": "ONDO/USD",
+    "base": "ONDO",
+    "quote": "USD",
+    "display_name": "ONDO / US Dollar",
+    "description": "ONDO to US Dollar spot trading pair",
+    "tags": [
+      "ondo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ONDOUSDT": {
+    "normalized_id": "ONDO/USD",
+    "base": "ONDO",
+    "quote": "USD",
+    "display_name": "ONDO / US Dollar",
+    "description": "ONDO to US Dollar spot trading pair",
+    "tags": [
+      "ondo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ONETRY": {
+    "normalized_id": "ONE/TRY",
+    "base": "ONE",
+    "quote": "TRY",
+    "display_name": "ONE / Turkish Lira",
+    "description": "ONE to Turkish Lira spot trading pair",
+    "tags": [
+      "one",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ONEUSDT": {
+    "normalized_id": "ONE/USD",
+    "base": "ONE",
+    "quote": "USD",
+    "display_name": "ONE / US Dollar",
+    "description": "ONE to US Dollar spot trading pair",
+    "tags": [
+      "one",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ONGBTC": {
+    "normalized_id": "ONG/BTC",
+    "base": "ONG",
+    "quote": "BTC",
+    "display_name": "ONG / Bitcoin",
+    "description": "ONG to Bitcoin spot trading pair",
+    "tags": [
+      "ong",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ONGUSDT": {
+    "normalized_id": "ONG/USD",
+    "base": "ONG",
+    "quote": "USD",
+    "display_name": "ONG / US Dollar",
+    "description": "ONG to US Dollar spot trading pair",
+    "tags": [
+      "ong",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ONTBTC": {
+    "normalized_id": "ONT/BTC",
+    "base": "ONT",
+    "quote": "BTC",
+    "display_name": "ONT / Bitcoin",
+    "description": "ONT to Bitcoin spot trading pair",
+    "tags": [
+      "ont",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ONTTRY": {
+    "normalized_id": "ONT/TRY",
+    "base": "ONT",
+    "quote": "TRY",
+    "display_name": "ONT / Turkish Lira",
+    "description": "ONT to Turkish Lira spot trading pair",
+    "tags": [
+      "ont",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ONTUSDC": {
+    "normalized_id": "ONT/USD",
+    "base": "ONT",
+    "quote": "USD",
+    "display_name": "ONT / US Dollar",
+    "description": "ONT to US Dollar spot trading pair",
+    "tags": [
+      "ont",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ONTUSDT": {
+    "normalized_id": "ONT/USD",
+    "base": "ONT",
+    "quote": "USD",
+    "display_name": "ONT / US Dollar",
+    "description": "ONT to US Dollar spot trading pair",
+    "tags": [
+      "ont",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OPBTC": {
+    "normalized_id": "OP/BTC",
+    "base": "OP",
+    "quote": "BTC",
+    "display_name": "Optimism / Bitcoin",
+    "description": "Optimism to Bitcoin spot trading pair",
+    "tags": [
+      "op",
+      "optimism",
+      "layer2",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "OPETH": {
+    "normalized_id": "OP/ETH",
+    "base": "OP",
+    "quote": "ETH",
+    "display_name": "Optimism / Ethereum",
+    "description": "Optimism to Ethereum spot trading pair",
+    "tags": [
+      "op",
+      "optimism",
+      "layer2",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "OPEUR": {
+    "normalized_id": "OP/EUR",
+    "base": "OP",
+    "quote": "EUR",
+    "display_name": "Optimism / Euro",
+    "description": "Optimism to Euro spot trading pair",
+    "tags": [
+      "op",
+      "optimism",
+      "layer2",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "OPFDUSD": {
+    "normalized_id": "OP/USD",
+    "base": "OP",
+    "quote": "USD",
+    "display_name": "Optimism / US Dollar",
+    "description": "Optimism to US Dollar spot trading pair",
+    "tags": [
+      "op",
+      "optimism",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OPTRY": {
+    "normalized_id": "OP/TRY",
+    "base": "OP",
+    "quote": "TRY",
+    "display_name": "Optimism / Turkish Lira",
+    "description": "Optimism to Turkish Lira spot trading pair",
+    "tags": [
+      "op",
+      "optimism",
+      "layer2",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "OPUSDC": {
+    "normalized_id": "OP/USD",
+    "base": "OP",
+    "quote": "USD",
+    "display_name": "Optimism / US Dollar",
+    "description": "Optimism to US Dollar spot trading pair",
+    "tags": [
+      "op",
+      "optimism",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OPUSDT": {
+    "normalized_id": "OP/USD",
+    "base": "OP",
+    "quote": "USD",
+    "display_name": "Optimism / US Dollar",
+    "description": "Optimism to US Dollar spot trading pair",
+    "tags": [
+      "op",
+      "optimism",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ORCATRY": {
+    "normalized_id": "ORCA/TRY",
+    "base": "ORCA",
+    "quote": "TRY",
+    "display_name": "ORCA / Turkish Lira",
+    "description": "ORCA to Turkish Lira spot trading pair",
+    "tags": [
+      "orca",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ORCAUSDC": {
+    "normalized_id": "ORCA/USD",
+    "base": "ORCA",
+    "quote": "USD",
+    "display_name": "ORCA / US Dollar",
+    "description": "ORCA to US Dollar spot trading pair",
+    "tags": [
+      "orca",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ORCAUSDT": {
+    "normalized_id": "ORCA/USD",
+    "base": "ORCA",
+    "quote": "USD",
+    "display_name": "ORCA / US Dollar",
+    "description": "ORCA to US Dollar spot trading pair",
+    "tags": [
+      "orca",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ORDIBTC": {
+    "normalized_id": "ORDI/BTC",
+    "base": "ORDI",
+    "quote": "BTC",
+    "display_name": "ORDI / Bitcoin",
+    "description": "ORDI to Bitcoin spot trading pair",
+    "tags": [
+      "ordi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ORDIFDUSD": {
+    "normalized_id": "ORDI/USD",
+    "base": "ORDI",
+    "quote": "USD",
+    "display_name": "ORDI / US Dollar",
+    "description": "ORDI to US Dollar spot trading pair",
+    "tags": [
+      "ordi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ORDITRY": {
+    "normalized_id": "ORDI/TRY",
+    "base": "ORDI",
+    "quote": "TRY",
+    "display_name": "ORDI / Turkish Lira",
+    "description": "ORDI to Turkish Lira spot trading pair",
+    "tags": [
+      "ordi",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ORDIUSDC": {
+    "normalized_id": "ORDI/USD",
+    "base": "ORDI",
+    "quote": "USD",
+    "display_name": "ORDI / US Dollar",
+    "description": "ORDI to US Dollar spot trading pair",
+    "tags": [
+      "ordi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ORDIUSDT": {
+    "normalized_id": "ORDI/USD",
+    "base": "ORDI",
+    "quote": "USD",
+    "display_name": "ORDI / US Dollar",
+    "description": "ORDI to US Dollar spot trading pair",
+    "tags": [
+      "ordi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OSMOUSDC": {
+    "normalized_id": "OSMO/USD",
+    "base": "OSMO",
+    "quote": "USD",
+    "display_name": "OSMO / US Dollar",
+    "description": "OSMO to US Dollar spot trading pair",
+    "tags": [
+      "osmo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OSMOUSDT": {
+    "normalized_id": "OSMO/USD",
+    "base": "OSMO",
+    "quote": "USD",
+    "display_name": "OSMO / US Dollar",
+    "description": "OSMO to US Dollar spot trading pair",
+    "tags": [
+      "osmo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OXTBTC": {
+    "normalized_id": "OXT/BTC",
+    "base": "OXT",
+    "quote": "BTC",
+    "display_name": "OXT / Bitcoin",
+    "description": "OXT to Bitcoin spot trading pair",
+    "tags": [
+      "oxt",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "OXTUSDT": {
+    "normalized_id": "OXT/USD",
+    "base": "OXT",
+    "quote": "USD",
+    "display_name": "OXT / US Dollar",
+    "description": "OXT to US Dollar spot trading pair",
+    "tags": [
+      "oxt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PARTIBNB": {
+    "normalized_id": "PARTI/BNB",
+    "base": "PARTI",
+    "quote": "BNB",
+    "display_name": "PARTI / Binance Coin",
+    "description": "PARTI to Binance Coin spot trading pair",
+    "tags": [
+      "parti",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "PARTIFDUSD": {
+    "normalized_id": "PARTI/USD",
+    "base": "PARTI",
+    "quote": "USD",
+    "display_name": "PARTI / US Dollar",
+    "description": "PARTI to US Dollar spot trading pair",
+    "tags": [
+      "parti",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PARTITRY": {
+    "normalized_id": "PARTI/TRY",
+    "base": "PARTI",
+    "quote": "TRY",
+    "display_name": "PARTI / Turkish Lira",
+    "description": "PARTI to Turkish Lira spot trading pair",
+    "tags": [
+      "parti",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PARTIUSDC": {
+    "normalized_id": "PARTI/USD",
+    "base": "PARTI",
+    "quote": "USD",
+    "display_name": "PARTI / US Dollar",
+    "description": "PARTI to US Dollar spot trading pair",
+    "tags": [
+      "parti",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PARTIUSDT": {
+    "normalized_id": "PARTI/USD",
+    "base": "PARTI",
+    "quote": "USD",
+    "display_name": "PARTI / US Dollar",
+    "description": "PARTI to US Dollar spot trading pair",
+    "tags": [
+      "parti",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PAXGBTC": {
+    "normalized_id": "PAXG/BTC",
+    "base": "PAXG",
+    "quote": "BTC",
+    "display_name": "PAXG / Bitcoin",
+    "description": "PAXG to Bitcoin spot trading pair",
+    "tags": [
+      "paxg",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "PAXGTRY": {
+    "normalized_id": "PAXG/TRY",
+    "base": "PAXG",
+    "quote": "TRY",
+    "display_name": "PAXG / Turkish Lira",
+    "description": "PAXG to Turkish Lira spot trading pair",
+    "tags": [
+      "paxg",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PAXGUSDC": {
+    "normalized_id": "PAXG/USD",
+    "base": "PAXG",
+    "quote": "USD",
+    "display_name": "PAXG / US Dollar",
+    "description": "PAXG to US Dollar spot trading pair",
+    "tags": [
+      "paxg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PAXGUSDT": {
+    "normalized_id": "PAXG/USD",
+    "base": "PAXG",
+    "quote": "USD",
+    "display_name": "PAXG / US Dollar",
+    "description": "PAXG to US Dollar spot trading pair",
+    "tags": [
+      "paxg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENDLEBTC": {
+    "normalized_id": "PENDLE/BTC",
+    "base": "PENDLE",
+    "quote": "BTC",
+    "display_name": "PENDLE / Bitcoin",
+    "description": "PENDLE to Bitcoin spot trading pair",
+    "tags": [
+      "pendle",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "PENDLEFDUSD": {
+    "normalized_id": "PENDLE/USD",
+    "base": "PENDLE",
+    "quote": "USD",
+    "display_name": "PENDLE / US Dollar",
+    "description": "PENDLE to US Dollar spot trading pair",
+    "tags": [
+      "pendle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENDLETRY": {
+    "normalized_id": "PENDLE/TRY",
+    "base": "PENDLE",
+    "quote": "TRY",
+    "display_name": "PENDLE / Turkish Lira",
+    "description": "PENDLE to Turkish Lira spot trading pair",
+    "tags": [
+      "pendle",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PENDLEUSDC": {
+    "normalized_id": "PENDLE/USD",
+    "base": "PENDLE",
+    "quote": "USD",
+    "display_name": "PENDLE / US Dollar",
+    "description": "PENDLE to US Dollar spot trading pair",
+    "tags": [
+      "pendle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENDLEUSDT": {
+    "normalized_id": "PENDLE/USD",
+    "base": "PENDLE",
+    "quote": "USD",
+    "display_name": "PENDLE / US Dollar",
+    "description": "PENDLE to US Dollar spot trading pair",
+    "tags": [
+      "pendle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENGUFDUSD": {
+    "normalized_id": "PENGU/USD",
+    "base": "PENGU",
+    "quote": "USD",
+    "display_name": "PENGU / US Dollar",
+    "description": "PENGU to US Dollar spot trading pair",
+    "tags": [
+      "pengu",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENGUTRY": {
+    "normalized_id": "PENGU/TRY",
+    "base": "PENGU",
+    "quote": "TRY",
+    "display_name": "PENGU / Turkish Lira",
+    "description": "PENGU to Turkish Lira spot trading pair",
+    "tags": [
+      "pengu",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PENGUUSDC": {
+    "normalized_id": "PENGU/USD",
+    "base": "PENGU",
+    "quote": "USD",
+    "display_name": "PENGU / US Dollar",
+    "description": "PENGU to US Dollar spot trading pair",
+    "tags": [
+      "pengu",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENGUUSDT": {
+    "normalized_id": "PENGU/USD",
+    "base": "PENGU",
+    "quote": "USD",
+    "display_name": "PENGU / US Dollar",
+    "description": "PENGU to US Dollar spot trading pair",
+    "tags": [
+      "pengu",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PEOPLEBTC": {
+    "normalized_id": "PEOPLE/BTC",
+    "base": "PEOPLE",
+    "quote": "BTC",
+    "display_name": "PEOPLE / Bitcoin",
+    "description": "PEOPLE to Bitcoin spot trading pair",
+    "tags": [
+      "people",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "PEOPLEFDUSD": {
+    "normalized_id": "PEOPLE/USD",
+    "base": "PEOPLE",
+    "quote": "USD",
+    "display_name": "PEOPLE / US Dollar",
+    "description": "PEOPLE to US Dollar spot trading pair",
+    "tags": [
+      "people",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PEOPLETRY": {
+    "normalized_id": "PEOPLE/TRY",
+    "base": "PEOPLE",
+    "quote": "TRY",
+    "display_name": "PEOPLE / Turkish Lira",
+    "description": "PEOPLE to Turkish Lira spot trading pair",
+    "tags": [
+      "people",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PEOPLEUSDC": {
+    "normalized_id": "PEOPLE/USD",
+    "base": "PEOPLE",
+    "quote": "USD",
+    "display_name": "PEOPLE / US Dollar",
+    "description": "PEOPLE to US Dollar spot trading pair",
+    "tags": [
+      "people",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PEOPLEUSDT": {
+    "normalized_id": "PEOPLE/USD",
+    "base": "PEOPLE",
+    "quote": "USD",
+    "display_name": "PEOPLE / US Dollar",
+    "description": "PEOPLE to US Dollar spot trading pair",
+    "tags": [
+      "people",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PEPEBRL": {
+    "normalized_id": "PEPE/BRL",
+    "base": "PEPE",
+    "quote": "BRL",
+    "display_name": "Pepe / Brazilian Real",
+    "description": "Pepe to Brazilian Real spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "PEPEEUR": {
+    "normalized_id": "PEPE/EUR",
+    "base": "PEPE",
+    "quote": "EUR",
+    "display_name": "Pepe / Euro",
+    "description": "Pepe to Euro spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PEPEFDUSD": {
+    "normalized_id": "PEPE/USD",
+    "base": "PEPE",
+    "quote": "USD",
+    "display_name": "Pepe / US Dollar",
+    "description": "Pepe to US Dollar spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PEPEJPY": {
+    "normalized_id": "PEPE/JPY",
+    "base": "PEPE",
+    "quote": "JPY",
+    "display_name": "Pepe / Japanese Yen",
+    "description": "Pepe to Japanese Yen spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "PEPETRY": {
+    "normalized_id": "PEPE/TRY",
+    "base": "PEPE",
+    "quote": "TRY",
+    "display_name": "Pepe / Turkish Lira",
+    "description": "Pepe to Turkish Lira spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PEPEUSDC": {
+    "normalized_id": "PEPE/USD",
+    "base": "PEPE",
+    "quote": "USD",
+    "display_name": "Pepe / US Dollar",
+    "description": "Pepe to US Dollar spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PEPEUSDT": {
+    "normalized_id": "PEPE/USD",
+    "base": "PEPE",
+    "quote": "USD",
+    "display_name": "Pepe / US Dollar",
+    "description": "Pepe to US Dollar spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PERPUSDT": {
+    "normalized_id": "PERP/USD",
+    "base": "PERP",
+    "quote": "USD",
+    "display_name": "PERP / US Dollar",
+    "description": "PERP to US Dollar spot trading pair",
+    "tags": [
+      "perp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PHABTC": {
+    "normalized_id": "PHA/BTC",
+    "base": "PHA",
+    "quote": "BTC",
+    "display_name": "PHA / Bitcoin",
+    "description": "PHA to Bitcoin spot trading pair",
+    "tags": [
+      "pha",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "PHATRY": {
+    "normalized_id": "PHA/TRY",
+    "base": "PHA",
+    "quote": "TRY",
+    "display_name": "PHA / Turkish Lira",
+    "description": "PHA to Turkish Lira spot trading pair",
+    "tags": [
+      "pha",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PHAUSDC": {
+    "normalized_id": "PHA/USD",
+    "base": "PHA",
+    "quote": "USD",
+    "display_name": "PHA / US Dollar",
+    "description": "PHA to US Dollar spot trading pair",
+    "tags": [
+      "pha",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PHAUSDT": {
+    "normalized_id": "PHA/USD",
+    "base": "PHA",
+    "quote": "USD",
+    "display_name": "PHA / US Dollar",
+    "description": "PHA to US Dollar spot trading pair",
+    "tags": [
+      "pha",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PHBBTC": {
+    "normalized_id": "PHB/BTC",
+    "base": "PHB",
+    "quote": "BTC",
+    "display_name": "PHB / Bitcoin",
+    "description": "PHB to Bitcoin spot trading pair",
+    "tags": [
+      "phb",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "PHBTRY": {
+    "normalized_id": "PHB/TRY",
+    "base": "PHB",
+    "quote": "TRY",
+    "display_name": "PHB / Turkish Lira",
+    "description": "PHB to Turkish Lira spot trading pair",
+    "tags": [
+      "phb",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PHBUSDT": {
+    "normalized_id": "PHB/USD",
+    "base": "PHB",
+    "quote": "USD",
+    "display_name": "PHB / US Dollar",
+    "description": "PHB to US Dollar spot trading pair",
+    "tags": [
+      "phb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PIVXBTC": {
+    "normalized_id": "PIVX/BTC",
+    "base": "PIVX",
+    "quote": "BTC",
+    "display_name": "PIVX / Bitcoin",
+    "description": "PIVX to Bitcoin spot trading pair",
+    "tags": [
+      "pivx",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "PIVXUSDT": {
+    "normalized_id": "PIVX/USD",
+    "base": "PIVX",
+    "quote": "USD",
+    "display_name": "PIVX / US Dollar",
+    "description": "PIVX to US Dollar spot trading pair",
+    "tags": [
+      "pivx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PIXELTRY": {
+    "normalized_id": "PIXEL/TRY",
+    "base": "PIXEL",
+    "quote": "TRY",
+    "display_name": "PIXEL / Turkish Lira",
+    "description": "PIXEL to Turkish Lira spot trading pair",
+    "tags": [
+      "pixel",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PIXELUSDC": {
+    "normalized_id": "PIXEL/USD",
+    "base": "PIXEL",
+    "quote": "USD",
+    "display_name": "PIXEL / US Dollar",
+    "description": "PIXEL to US Dollar spot trading pair",
+    "tags": [
+      "pixel",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PIXELUSDT": {
+    "normalized_id": "PIXEL/USD",
+    "base": "PIXEL",
+    "quote": "USD",
+    "display_name": "PIXEL / US Dollar",
+    "description": "PIXEL to US Dollar spot trading pair",
+    "tags": [
+      "pixel",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PNUTBRL": {
+    "normalized_id": "PNUT/BRL",
+    "base": "PNUT",
+    "quote": "BRL",
+    "display_name": "PNUT / Brazilian Real",
+    "description": "PNUT to Brazilian Real spot trading pair",
+    "tags": [
+      "pnut",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "PNUTBTC": {
+    "normalized_id": "PNUT/BTC",
+    "base": "PNUT",
+    "quote": "BTC",
+    "display_name": "PNUT / Bitcoin",
+    "description": "PNUT to Bitcoin spot trading pair",
+    "tags": [
+      "pnut",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "PNUTEUR": {
+    "normalized_id": "PNUT/EUR",
+    "base": "PNUT",
+    "quote": "EUR",
+    "display_name": "PNUT / Euro",
+    "description": "PNUT to Euro spot trading pair",
+    "tags": [
+      "pnut",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PNUTFDUSD": {
+    "normalized_id": "PNUT/USD",
+    "base": "PNUT",
+    "quote": "USD",
+    "display_name": "PNUT / US Dollar",
+    "description": "PNUT to US Dollar spot trading pair",
+    "tags": [
+      "pnut",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PNUTTRY": {
+    "normalized_id": "PNUT/TRY",
+    "base": "PNUT",
+    "quote": "TRY",
+    "display_name": "PNUT / Turkish Lira",
+    "description": "PNUT to Turkish Lira spot trading pair",
+    "tags": [
+      "pnut",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PNUTUSDC": {
+    "normalized_id": "PNUT/USD",
+    "base": "PNUT",
+    "quote": "USD",
+    "display_name": "PNUT / US Dollar",
+    "description": "PNUT to US Dollar spot trading pair",
+    "tags": [
+      "pnut",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PNUTUSDT": {
+    "normalized_id": "PNUT/USD",
+    "base": "PNUT",
+    "quote": "USD",
+    "display_name": "PNUT / US Dollar",
+    "description": "PNUT to US Dollar spot trading pair",
+    "tags": [
+      "pnut",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POLBNB": {
+    "normalized_id": "POL/BNB",
+    "base": "POL",
+    "quote": "BNB",
+    "display_name": "POL / Binance Coin",
+    "description": "POL to Binance Coin spot trading pair",
+    "tags": [
+      "pol",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "POLBRL": {
+    "normalized_id": "POL/BRL",
+    "base": "POL",
+    "quote": "BRL",
+    "display_name": "POL / Brazilian Real",
+    "description": "POL to Brazilian Real spot trading pair",
+    "tags": [
+      "pol",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "POLBTC": {
+    "normalized_id": "POL/BTC",
+    "base": "POL",
+    "quote": "BTC",
+    "display_name": "POL / Bitcoin",
+    "description": "POL to Bitcoin spot trading pair",
+    "tags": [
+      "pol",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "POLETH": {
+    "normalized_id": "POL/ETH",
+    "base": "POL",
+    "quote": "ETH",
+    "display_name": "POL / Ethereum",
+    "description": "POL to Ethereum spot trading pair",
+    "tags": [
+      "pol",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "POLEUR": {
+    "normalized_id": "POL/EUR",
+    "base": "POL",
+    "quote": "EUR",
+    "display_name": "POL / Euro",
+    "description": "POL to Euro spot trading pair",
+    "tags": [
+      "pol",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "POLFDUSD": {
+    "normalized_id": "POL/USD",
+    "base": "POL",
+    "quote": "USD",
+    "display_name": "POL / US Dollar",
+    "description": "POL to US Dollar spot trading pair",
+    "tags": [
+      "pol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POLJPY": {
+    "normalized_id": "POL/JPY",
+    "base": "POL",
+    "quote": "JPY",
+    "display_name": "POL / Japanese Yen",
+    "description": "POL to Japanese Yen spot trading pair",
+    "tags": [
+      "pol",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "POLTRY": {
+    "normalized_id": "POL/TRY",
+    "base": "POL",
+    "quote": "TRY",
+    "display_name": "POL / Turkish Lira",
+    "description": "POL to Turkish Lira spot trading pair",
+    "tags": [
+      "pol",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "POLUSDC": {
+    "normalized_id": "POL/USD",
+    "base": "POL",
+    "quote": "USD",
+    "display_name": "POL / US Dollar",
+    "description": "POL to US Dollar spot trading pair",
+    "tags": [
+      "pol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POLUSDT": {
+    "normalized_id": "POL/USD",
+    "base": "POL",
+    "quote": "USD",
+    "display_name": "POL / US Dollar",
+    "description": "POL to US Dollar spot trading pair",
+    "tags": [
+      "pol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POLYXBTC": {
+    "normalized_id": "POLYX/BTC",
+    "base": "POLYX",
+    "quote": "BTC",
+    "display_name": "POLYX / Bitcoin",
+    "description": "POLYX to Bitcoin spot trading pair",
+    "tags": [
+      "polyx",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "POLYXTRY": {
+    "normalized_id": "POLYX/TRY",
+    "base": "POLYX",
+    "quote": "TRY",
+    "display_name": "POLYX / Turkish Lira",
+    "description": "POLYX to Turkish Lira spot trading pair",
+    "tags": [
+      "polyx",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "POLYXUSDT": {
+    "normalized_id": "POLYX/USD",
+    "base": "POLYX",
+    "quote": "USD",
+    "display_name": "POLYX / US Dollar",
+    "description": "POLYX to US Dollar spot trading pair",
+    "tags": [
+      "polyx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PONDUSDT": {
+    "normalized_id": "POND/USD",
+    "base": "POND",
+    "quote": "USD",
+    "display_name": "POND / US Dollar",
+    "description": "POND to US Dollar spot trading pair",
+    "tags": [
+      "pond",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PORTALBNB": {
+    "normalized_id": "PORTAL/BNB",
+    "base": "PORTAL",
+    "quote": "BNB",
+    "display_name": "PORTAL / Binance Coin",
+    "description": "PORTAL to Binance Coin spot trading pair",
+    "tags": [
+      "portal",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "PORTALBTC": {
+    "normalized_id": "PORTAL/BTC",
+    "base": "PORTAL",
+    "quote": "BTC",
+    "display_name": "PORTAL / Bitcoin",
+    "description": "PORTAL to Bitcoin spot trading pair",
+    "tags": [
+      "portal",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "PORTALFDUSD": {
+    "normalized_id": "PORTAL/USD",
+    "base": "PORTAL",
+    "quote": "USD",
+    "display_name": "PORTAL / US Dollar",
+    "description": "PORTAL to US Dollar spot trading pair",
+    "tags": [
+      "portal",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PORTALTRY": {
+    "normalized_id": "PORTAL/TRY",
+    "base": "PORTAL",
+    "quote": "TRY",
+    "display_name": "PORTAL / Turkish Lira",
+    "description": "PORTAL to Turkish Lira spot trading pair",
+    "tags": [
+      "portal",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PORTALUSDT": {
+    "normalized_id": "PORTAL/USD",
+    "base": "PORTAL",
+    "quote": "USD",
+    "display_name": "PORTAL / US Dollar",
+    "description": "PORTAL to US Dollar spot trading pair",
+    "tags": [
+      "portal",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PORTOTRY": {
+    "normalized_id": "PORTO/TRY",
+    "base": "PORTO",
+    "quote": "TRY",
+    "display_name": "PORTO / Turkish Lira",
+    "description": "PORTO to Turkish Lira spot trading pair",
+    "tags": [
+      "porto",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PORTOUSDT": {
+    "normalized_id": "PORTO/USD",
+    "base": "PORTO",
+    "quote": "USD",
+    "display_name": "PORTO / US Dollar",
+    "description": "PORTO to US Dollar spot trading pair",
+    "tags": [
+      "porto",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POWRBTC": {
+    "normalized_id": "POWR/BTC",
+    "base": "POWR",
+    "quote": "BTC",
+    "display_name": "POWR / Bitcoin",
+    "description": "POWR to Bitcoin spot trading pair",
+    "tags": [
+      "powr",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "POWRETH": {
+    "normalized_id": "POWR/ETH",
+    "base": "POWR",
+    "quote": "ETH",
+    "display_name": "POWR / Ethereum",
+    "description": "POWR to Ethereum spot trading pair",
+    "tags": [
+      "powr",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "POWRUSDT": {
+    "normalized_id": "POWR/USD",
+    "base": "POWR",
+    "quote": "USD",
+    "display_name": "POWR / US Dollar",
+    "description": "POWR to US Dollar spot trading pair",
+    "tags": [
+      "powr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PROMUSDT": {
+    "normalized_id": "PROM/USD",
+    "base": "PROM",
+    "quote": "USD",
+    "display_name": "PROM / US Dollar",
+    "description": "PROM to US Dollar spot trading pair",
+    "tags": [
+      "prom",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PROVEBNB": {
+    "normalized_id": "PROVE/BNB",
+    "base": "PROVE",
+    "quote": "BNB",
+    "display_name": "PROVE / Binance Coin",
+    "description": "PROVE to Binance Coin spot trading pair",
+    "tags": [
+      "prove",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "PROVEFDUSD": {
+    "normalized_id": "PROVE/USD",
+    "base": "PROVE",
+    "quote": "USD",
+    "display_name": "PROVE / US Dollar",
+    "description": "PROVE to US Dollar spot trading pair",
+    "tags": [
+      "prove",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PROVETRY": {
+    "normalized_id": "PROVE/TRY",
+    "base": "PROVE",
+    "quote": "TRY",
+    "display_name": "PROVE / Turkish Lira",
+    "description": "PROVE to Turkish Lira spot trading pair",
+    "tags": [
+      "prove",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PROVEUSDC": {
+    "normalized_id": "PROVE/USD",
+    "base": "PROVE",
+    "quote": "USD",
+    "display_name": "PROVE / US Dollar",
+    "description": "PROVE to US Dollar spot trading pair",
+    "tags": [
+      "prove",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PROVEUSDT": {
+    "normalized_id": "PROVE/USD",
+    "base": "PROVE",
+    "quote": "USD",
+    "display_name": "PROVE / US Dollar",
+    "description": "PROVE to US Dollar spot trading pair",
+    "tags": [
+      "prove",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PSGTRY": {
+    "normalized_id": "PSG/TRY",
+    "base": "PSG",
+    "quote": "TRY",
+    "display_name": "PSG / Turkish Lira",
+    "description": "PSG to Turkish Lira spot trading pair",
+    "tags": [
+      "psg",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PSGUSDT": {
+    "normalized_id": "PSG/USD",
+    "base": "PSG",
+    "quote": "USD",
+    "display_name": "PSG / US Dollar",
+    "description": "PSG to US Dollar spot trading pair",
+    "tags": [
+      "psg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PUNDIXUSDC": {
+    "normalized_id": "PUNDIX/USD",
+    "base": "PUNDIX",
+    "quote": "USD",
+    "display_name": "PUNDIX / US Dollar",
+    "description": "PUNDIX to US Dollar spot trading pair",
+    "tags": [
+      "pundix",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PUNDIXUSDT": {
+    "normalized_id": "PUNDIX/USD",
+    "base": "PUNDIX",
+    "quote": "USD",
+    "display_name": "PUNDIX / US Dollar",
+    "description": "PUNDIX to US Dollar spot trading pair",
+    "tags": [
+      "pundix",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PYRBTC": {
+    "normalized_id": "PYR/BTC",
+    "base": "PYR",
+    "quote": "BTC",
+    "display_name": "PYR / Bitcoin",
+    "description": "PYR to Bitcoin spot trading pair",
+    "tags": [
+      "pyr",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "PYRUSDT": {
+    "normalized_id": "PYR/USD",
+    "base": "PYR",
+    "quote": "USD",
+    "display_name": "PYR / US Dollar",
+    "description": "PYR to US Dollar spot trading pair",
+    "tags": [
+      "pyr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PYTHBTC": {
+    "normalized_id": "PYTH/BTC",
+    "base": "PYTH",
+    "quote": "BTC",
+    "display_name": "Pyth Network / Bitcoin",
+    "description": "Pyth Network to Bitcoin spot trading pair",
+    "tags": [
+      "pyth",
+      "pyth network",
+      "oracle",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "PYTHFDUSD": {
+    "normalized_id": "PYTH/USD",
+    "base": "PYTH",
+    "quote": "USD",
+    "display_name": "Pyth Network / US Dollar",
+    "description": "Pyth Network to US Dollar spot trading pair",
+    "tags": [
+      "pyth",
+      "pyth network",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PYTHTRY": {
+    "normalized_id": "PYTH/TRY",
+    "base": "PYTH",
+    "quote": "TRY",
+    "display_name": "Pyth Network / Turkish Lira",
+    "description": "Pyth Network to Turkish Lira spot trading pair",
+    "tags": [
+      "pyth",
+      "pyth network",
+      "oracle",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PYTHUSDC": {
+    "normalized_id": "PYTH/USD",
+    "base": "PYTH",
+    "quote": "USD",
+    "display_name": "Pyth Network / US Dollar",
+    "description": "Pyth Network to US Dollar spot trading pair",
+    "tags": [
+      "pyth",
+      "pyth network",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PYTHUSDT": {
+    "normalized_id": "PYTH/USD",
+    "base": "PYTH",
+    "quote": "USD",
+    "display_name": "Pyth Network / US Dollar",
+    "description": "Pyth Network to US Dollar spot trading pair",
+    "tags": [
+      "pyth",
+      "pyth network",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "QIUSDT": {
+    "normalized_id": "QI/USD",
+    "base": "QI",
+    "quote": "USD",
+    "display_name": "QI / US Dollar",
+    "description": "QI to US Dollar spot trading pair",
+    "tags": [
+      "qi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "QKCUSDT": {
+    "normalized_id": "QKC/USD",
+    "base": "QKC",
+    "quote": "USD",
+    "display_name": "QKC / US Dollar",
+    "description": "QKC to US Dollar spot trading pair",
+    "tags": [
+      "qkc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "QNTBTC": {
+    "normalized_id": "QNT/BTC",
+    "base": "QNT",
+    "quote": "BTC",
+    "display_name": "Quant / Bitcoin",
+    "description": "Quant to Bitcoin spot trading pair",
+    "tags": [
+      "qnt",
+      "quant",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "QNTUSDC": {
+    "normalized_id": "QNT/USD",
+    "base": "QNT",
+    "quote": "USD",
+    "display_name": "Quant / US Dollar",
+    "description": "Quant to US Dollar spot trading pair",
+    "tags": [
+      "qnt",
+      "quant",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "QNTUSDT": {
+    "normalized_id": "QNT/USD",
+    "base": "QNT",
+    "quote": "USD",
+    "display_name": "Quant / US Dollar",
+    "description": "Quant to US Dollar spot trading pair",
+    "tags": [
+      "qnt",
+      "quant",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "QTUMBTC": {
+    "normalized_id": "QTUM/BTC",
+    "base": "QTUM",
+    "quote": "BTC",
+    "display_name": "QTUM / Bitcoin",
+    "description": "QTUM to Bitcoin spot trading pair",
+    "tags": [
+      "qtum",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "QTUMETH": {
+    "normalized_id": "QTUM/ETH",
+    "base": "QTUM",
+    "quote": "ETH",
+    "display_name": "QTUM / Ethereum",
+    "description": "QTUM to Ethereum spot trading pair",
+    "tags": [
+      "qtum",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "QTUMTRY": {
+    "normalized_id": "QTUM/TRY",
+    "base": "QTUM",
+    "quote": "TRY",
+    "display_name": "QTUM / Turkish Lira",
+    "description": "QTUM to Turkish Lira spot trading pair",
+    "tags": [
+      "qtum",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "QTUMUSDT": {
+    "normalized_id": "QTUM/USD",
+    "base": "QTUM",
+    "quote": "USD",
+    "display_name": "QTUM / US Dollar",
+    "description": "QTUM to US Dollar spot trading pair",
+    "tags": [
+      "qtum",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "QUICKUSDT": {
+    "normalized_id": "QUICK/USD",
+    "base": "QUICK",
+    "quote": "USD",
+    "display_name": "QUICK / US Dollar",
+    "description": "QUICK to US Dollar spot trading pair",
+    "tags": [
+      "quick",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RADTRY": {
+    "normalized_id": "RAD/TRY",
+    "base": "RAD",
+    "quote": "TRY",
+    "display_name": "RAD / Turkish Lira",
+    "description": "RAD to Turkish Lira spot trading pair",
+    "tags": [
+      "rad",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "RADUSDT": {
+    "normalized_id": "RAD/USD",
+    "base": "RAD",
+    "quote": "USD",
+    "display_name": "RAD / US Dollar",
+    "description": "RAD to US Dollar spot trading pair",
+    "tags": [
+      "rad",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RAREBTC": {
+    "normalized_id": "RARE/BTC",
+    "base": "RARE",
+    "quote": "BTC",
+    "display_name": "RARE / Bitcoin",
+    "description": "RARE to Bitcoin spot trading pair",
+    "tags": [
+      "rare",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "RARETRY": {
+    "normalized_id": "RARE/TRY",
+    "base": "RARE",
+    "quote": "TRY",
+    "display_name": "RARE / Turkish Lira",
+    "description": "RARE to Turkish Lira spot trading pair",
+    "tags": [
+      "rare",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "RAREUSDC": {
+    "normalized_id": "RARE/USD",
+    "base": "RARE",
+    "quote": "USD",
+    "display_name": "RARE / US Dollar",
+    "description": "RARE to US Dollar spot trading pair",
+    "tags": [
+      "rare",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RAREUSDT": {
+    "normalized_id": "RARE/USD",
+    "base": "RARE",
+    "quote": "USD",
+    "display_name": "RARE / US Dollar",
+    "description": "RARE to US Dollar spot trading pair",
+    "tags": [
+      "rare",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RAYFDUSD": {
+    "normalized_id": "RAY/USD",
+    "base": "RAY",
+    "quote": "USD",
+    "display_name": "RAY / US Dollar",
+    "description": "RAY to US Dollar spot trading pair",
+    "tags": [
+      "ray",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RAYTRY": {
+    "normalized_id": "RAY/TRY",
+    "base": "RAY",
+    "quote": "TRY",
+    "display_name": "RAY / Turkish Lira",
+    "description": "RAY to Turkish Lira spot trading pair",
+    "tags": [
+      "ray",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "RAYUSDC": {
+    "normalized_id": "RAY/USD",
+    "base": "RAY",
+    "quote": "USD",
+    "display_name": "RAY / US Dollar",
+    "description": "RAY to US Dollar spot trading pair",
+    "tags": [
+      "ray",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RAYUSDT": {
+    "normalized_id": "RAY/USD",
+    "base": "RAY",
+    "quote": "USD",
+    "display_name": "RAY / US Dollar",
+    "description": "RAY to US Dollar spot trading pair",
+    "tags": [
+      "ray",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RDNTTRY": {
+    "normalized_id": "RDNT/TRY",
+    "base": "RDNT",
+    "quote": "TRY",
+    "display_name": "RDNT / Turkish Lira",
+    "description": "RDNT to Turkish Lira spot trading pair",
+    "tags": [
+      "rdnt",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "RDNTUSDT": {
+    "normalized_id": "RDNT/USD",
+    "base": "RDNT",
+    "quote": "USD",
+    "display_name": "RDNT / US Dollar",
+    "description": "RDNT to US Dollar spot trading pair",
+    "tags": [
+      "rdnt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "REDBTC": {
+    "normalized_id": "RED/BTC",
+    "base": "RED",
+    "quote": "BTC",
+    "display_name": "RED / Bitcoin",
+    "description": "RED to Bitcoin spot trading pair",
+    "tags": [
+      "red",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "REDFDUSD": {
+    "normalized_id": "RED/USD",
+    "base": "RED",
+    "quote": "USD",
+    "display_name": "RED / US Dollar",
+    "description": "RED to US Dollar spot trading pair",
+    "tags": [
+      "red",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "REDTRY": {
+    "normalized_id": "RED/TRY",
+    "base": "RED",
+    "quote": "TRY",
+    "display_name": "RED / Turkish Lira",
+    "description": "RED to Turkish Lira spot trading pair",
+    "tags": [
+      "red",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "REDUSDC": {
+    "normalized_id": "RED/USD",
+    "base": "RED",
+    "quote": "USD",
+    "display_name": "RED / US Dollar",
+    "description": "RED to US Dollar spot trading pair",
+    "tags": [
+      "red",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "REDUSDT": {
+    "normalized_id": "RED/USD",
+    "base": "RED",
+    "quote": "USD",
+    "display_name": "RED / US Dollar",
+    "description": "RED to US Dollar spot trading pair",
+    "tags": [
+      "red",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "REIUSDT": {
+    "normalized_id": "REI/USD",
+    "base": "REI",
+    "quote": "USD",
+    "display_name": "REI / US Dollar",
+    "description": "REI to US Dollar spot trading pair",
+    "tags": [
+      "rei",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RENDERBRL": {
+    "normalized_id": "RENDER/BRL",
+    "base": "RENDER",
+    "quote": "BRL",
+    "display_name": "RENDER / Brazilian Real",
+    "description": "RENDER to Brazilian Real spot trading pair",
+    "tags": [
+      "render",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "RENDERBTC": {
+    "normalized_id": "RENDER/BTC",
+    "base": "RENDER",
+    "quote": "BTC",
+    "display_name": "RENDER / Bitcoin",
+    "description": "RENDER to Bitcoin spot trading pair",
+    "tags": [
+      "render",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "RENDEREUR": {
+    "normalized_id": "RENDER/EUR",
+    "base": "RENDER",
+    "quote": "EUR",
+    "display_name": "RENDER / Euro",
+    "description": "RENDER to Euro spot trading pair",
+    "tags": [
+      "render",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RENDERFDUSD": {
+    "normalized_id": "RENDER/USD",
+    "base": "RENDER",
+    "quote": "USD",
+    "display_name": "RENDER / US Dollar",
+    "description": "RENDER to US Dollar spot trading pair",
+    "tags": [
+      "render",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RENDERTRY": {
+    "normalized_id": "RENDER/TRY",
+    "base": "RENDER",
+    "quote": "TRY",
+    "display_name": "RENDER / Turkish Lira",
+    "description": "RENDER to Turkish Lira spot trading pair",
+    "tags": [
+      "render",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "RENDERUSDC": {
+    "normalized_id": "RENDER/USD",
+    "base": "RENDER",
+    "quote": "USD",
+    "display_name": "RENDER / US Dollar",
+    "description": "RENDER to US Dollar spot trading pair",
+    "tags": [
+      "render",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RENDERUSDT": {
+    "normalized_id": "RENDER/USD",
+    "base": "RENDER",
+    "quote": "USD",
+    "display_name": "RENDER / US Dollar",
+    "description": "RENDER to US Dollar spot trading pair",
+    "tags": [
+      "render",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "REQBTC": {
+    "normalized_id": "REQ/BTC",
+    "base": "REQ",
+    "quote": "BTC",
+    "display_name": "REQ / Bitcoin",
+    "description": "REQ to Bitcoin spot trading pair",
+    "tags": [
+      "req",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "REQUSDT": {
+    "normalized_id": "REQ/USD",
+    "base": "REQ",
+    "quote": "USD",
+    "display_name": "REQ / US Dollar",
+    "description": "REQ to US Dollar spot trading pair",
+    "tags": [
+      "req",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RESOLVBNB": {
+    "normalized_id": "RESOLV/BNB",
+    "base": "RESOLV",
+    "quote": "BNB",
+    "display_name": "RESOLV / Binance Coin",
+    "description": "RESOLV to Binance Coin spot trading pair",
+    "tags": [
+      "resolv",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "RESOLVFDUSD": {
+    "normalized_id": "RESOLV/USD",
+    "base": "RESOLV",
+    "quote": "USD",
+    "display_name": "RESOLV / US Dollar",
+    "description": "RESOLV to US Dollar spot trading pair",
+    "tags": [
+      "resolv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RESOLVTRY": {
+    "normalized_id": "RESOLV/TRY",
+    "base": "RESOLV",
+    "quote": "TRY",
+    "display_name": "RESOLV / Turkish Lira",
+    "description": "RESOLV to Turkish Lira spot trading pair",
+    "tags": [
+      "resolv",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "RESOLVUSDC": {
+    "normalized_id": "RESOLV/USD",
+    "base": "RESOLV",
+    "quote": "USD",
+    "display_name": "RESOLV / US Dollar",
+    "description": "RESOLV to US Dollar spot trading pair",
+    "tags": [
+      "resolv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RESOLVUSDT": {
+    "normalized_id": "RESOLV/USD",
+    "base": "RESOLV",
+    "quote": "USD",
+    "display_name": "RESOLV / US Dollar",
+    "description": "RESOLV to US Dollar spot trading pair",
+    "tags": [
+      "resolv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "REZTRY": {
+    "normalized_id": "REZ/TRY",
+    "base": "REZ",
+    "quote": "TRY",
+    "display_name": "REZ / Turkish Lira",
+    "description": "REZ to Turkish Lira spot trading pair",
+    "tags": [
+      "rez",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "REZUSDC": {
+    "normalized_id": "REZ/USD",
+    "base": "REZ",
+    "quote": "USD",
+    "display_name": "REZ / US Dollar",
+    "description": "REZ to US Dollar spot trading pair",
+    "tags": [
+      "rez",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "REZUSDT": {
+    "normalized_id": "REZ/USD",
+    "base": "REZ",
+    "quote": "USD",
+    "display_name": "REZ / US Dollar",
+    "description": "REZ to US Dollar spot trading pair",
+    "tags": [
+      "rez",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RIFBTC": {
+    "normalized_id": "RIF/BTC",
+    "base": "RIF",
+    "quote": "BTC",
+    "display_name": "RIF / Bitcoin",
+    "description": "RIF to Bitcoin spot trading pair",
+    "tags": [
+      "rif",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "RIFUSDT": {
+    "normalized_id": "RIF/USD",
+    "base": "RIF",
+    "quote": "USD",
+    "display_name": "RIF / US Dollar",
+    "description": "RIF to US Dollar spot trading pair",
+    "tags": [
+      "rif",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RLCBTC": {
+    "normalized_id": "RLC/BTC",
+    "base": "RLC",
+    "quote": "BTC",
+    "display_name": "RLC / Bitcoin",
+    "description": "RLC to Bitcoin spot trading pair",
+    "tags": [
+      "rlc",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "RLCETH": {
+    "normalized_id": "RLC/ETH",
+    "base": "RLC",
+    "quote": "ETH",
+    "display_name": "RLC / Ethereum",
+    "description": "RLC to Ethereum spot trading pair",
+    "tags": [
+      "rlc",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "RLCUSDT": {
+    "normalized_id": "RLC/USD",
+    "base": "RLC",
+    "quote": "USD",
+    "display_name": "RLC / US Dollar",
+    "description": "RLC to US Dollar spot trading pair",
+    "tags": [
+      "rlc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RONINBTC": {
+    "normalized_id": "RONIN/BTC",
+    "base": "RONIN",
+    "quote": "BTC",
+    "display_name": "RONIN / Bitcoin",
+    "description": "RONIN to Bitcoin spot trading pair",
+    "tags": [
+      "ronin",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "RONINFDUSD": {
+    "normalized_id": "RONIN/USD",
+    "base": "RONIN",
+    "quote": "USD",
+    "display_name": "RONIN / US Dollar",
+    "description": "RONIN to US Dollar spot trading pair",
+    "tags": [
+      "ronin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RONINTRY": {
+    "normalized_id": "RONIN/TRY",
+    "base": "RONIN",
+    "quote": "TRY",
+    "display_name": "RONIN / Turkish Lira",
+    "description": "RONIN to Turkish Lira spot trading pair",
+    "tags": [
+      "ronin",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "RONINUSDT": {
+    "normalized_id": "RONIN/USD",
+    "base": "RONIN",
+    "quote": "USD",
+    "display_name": "RONIN / US Dollar",
+    "description": "RONIN to US Dollar spot trading pair",
+    "tags": [
+      "ronin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ROSEBTC": {
+    "normalized_id": "ROSE/BTC",
+    "base": "ROSE",
+    "quote": "BTC",
+    "display_name": "ROSE / Bitcoin",
+    "description": "ROSE to Bitcoin spot trading pair",
+    "tags": [
+      "rose",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ROSETRY": {
+    "normalized_id": "ROSE/TRY",
+    "base": "ROSE",
+    "quote": "TRY",
+    "display_name": "ROSE / Turkish Lira",
+    "description": "ROSE to Turkish Lira spot trading pair",
+    "tags": [
+      "rose",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ROSEUSDC": {
+    "normalized_id": "ROSE/USD",
+    "base": "ROSE",
+    "quote": "USD",
+    "display_name": "ROSE / US Dollar",
+    "description": "ROSE to US Dollar spot trading pair",
+    "tags": [
+      "rose",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ROSEUSDT": {
+    "normalized_id": "ROSE/USD",
+    "base": "ROSE",
+    "quote": "USD",
+    "display_name": "ROSE / US Dollar",
+    "description": "ROSE to US Dollar spot trading pair",
+    "tags": [
+      "rose",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RPLUSDC": {
+    "normalized_id": "RPL/USD",
+    "base": "RPL",
+    "quote": "USD",
+    "display_name": "RPL / US Dollar",
+    "description": "RPL to US Dollar spot trading pair",
+    "tags": [
+      "rpl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RPLUSDT": {
+    "normalized_id": "RPL/USD",
+    "base": "RPL",
+    "quote": "USD",
+    "display_name": "RPL / US Dollar",
+    "description": "RPL to US Dollar spot trading pair",
+    "tags": [
+      "rpl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RSRTRY": {
+    "normalized_id": "RSR/TRY",
+    "base": "RSR",
+    "quote": "TRY",
+    "display_name": "RSR / Turkish Lira",
+    "description": "RSR to Turkish Lira spot trading pair",
+    "tags": [
+      "rsr",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "RSRUSDC": {
+    "normalized_id": "RSR/USD",
+    "base": "RSR",
+    "quote": "USD",
+    "display_name": "RSR / US Dollar",
+    "description": "RSR to US Dollar spot trading pair",
+    "tags": [
+      "rsr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RSRUSDT": {
+    "normalized_id": "RSR/USD",
+    "base": "RSR",
+    "quote": "USD",
+    "display_name": "RSR / US Dollar",
+    "description": "RSR to US Dollar spot trading pair",
+    "tags": [
+      "rsr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RUNEBTC": {
+    "normalized_id": "RUNE/BTC",
+    "base": "RUNE",
+    "quote": "BTC",
+    "display_name": "RUNE / Bitcoin",
+    "description": "RUNE to Bitcoin spot trading pair",
+    "tags": [
+      "rune",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "RUNEETH": {
+    "normalized_id": "RUNE/ETH",
+    "base": "RUNE",
+    "quote": "ETH",
+    "display_name": "RUNE / Ethereum",
+    "description": "RUNE to Ethereum spot trading pair",
+    "tags": [
+      "rune",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "RUNEFDUSD": {
+    "normalized_id": "RUNE/USD",
+    "base": "RUNE",
+    "quote": "USD",
+    "display_name": "RUNE / US Dollar",
+    "description": "RUNE to US Dollar spot trading pair",
+    "tags": [
+      "rune",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RUNEUSDC": {
+    "normalized_id": "RUNE/USD",
+    "base": "RUNE",
+    "quote": "USD",
+    "display_name": "RUNE / US Dollar",
+    "description": "RUNE to US Dollar spot trading pair",
+    "tags": [
+      "rune",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RUNEUSDT": {
+    "normalized_id": "RUNE/USD",
+    "base": "RUNE",
+    "quote": "USD",
+    "display_name": "RUNE / US Dollar",
+    "description": "RUNE to US Dollar spot trading pair",
+    "tags": [
+      "rune",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RVNBTC": {
+    "normalized_id": "RVN/BTC",
+    "base": "RVN",
+    "quote": "BTC",
+    "display_name": "RVN / Bitcoin",
+    "description": "RVN to Bitcoin spot trading pair",
+    "tags": [
+      "rvn",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "RVNTRY": {
+    "normalized_id": "RVN/TRY",
+    "base": "RVN",
+    "quote": "TRY",
+    "display_name": "RVN / Turkish Lira",
+    "description": "RVN to Turkish Lira spot trading pair",
+    "tags": [
+      "rvn",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "RVNUSDC": {
+    "normalized_id": "RVN/USD",
+    "base": "RVN",
+    "quote": "USD",
+    "display_name": "RVN / US Dollar",
+    "description": "RVN to US Dollar spot trading pair",
+    "tags": [
+      "rvn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RVNUSDT": {
+    "normalized_id": "RVN/USD",
+    "base": "RVN",
+    "quote": "USD",
+    "display_name": "RVN / US Dollar",
+    "description": "RVN to US Dollar spot trading pair",
+    "tags": [
+      "rvn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAGABNB": {
+    "normalized_id": "SAGA/BNB",
+    "base": "SAGA",
+    "quote": "BNB",
+    "display_name": "SAGA / Binance Coin",
+    "description": "SAGA to Binance Coin spot trading pair",
+    "tags": [
+      "saga",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "SAGABTC": {
+    "normalized_id": "SAGA/BTC",
+    "base": "SAGA",
+    "quote": "BTC",
+    "display_name": "SAGA / Bitcoin",
+    "description": "SAGA to Bitcoin spot trading pair",
+    "tags": [
+      "saga",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SAGAFDUSD": {
+    "normalized_id": "SAGA/USD",
+    "base": "SAGA",
+    "quote": "USD",
+    "display_name": "SAGA / US Dollar",
+    "description": "SAGA to US Dollar spot trading pair",
+    "tags": [
+      "saga",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAGATRY": {
+    "normalized_id": "SAGA/TRY",
+    "base": "SAGA",
+    "quote": "TRY",
+    "display_name": "SAGA / Turkish Lira",
+    "description": "SAGA to Turkish Lira spot trading pair",
+    "tags": [
+      "saga",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SAGAUSDC": {
+    "normalized_id": "SAGA/USD",
+    "base": "SAGA",
+    "quote": "USD",
+    "display_name": "SAGA / US Dollar",
+    "description": "SAGA to US Dollar spot trading pair",
+    "tags": [
+      "saga",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAGAUSDT": {
+    "normalized_id": "SAGA/USD",
+    "base": "SAGA",
+    "quote": "USD",
+    "display_name": "SAGA / US Dollar",
+    "description": "SAGA to US Dollar spot trading pair",
+    "tags": [
+      "saga",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAHARABNB": {
+    "normalized_id": "SAHARA/BNB",
+    "base": "SAHARA",
+    "quote": "BNB",
+    "display_name": "SAHARA / Binance Coin",
+    "description": "SAHARA to Binance Coin spot trading pair",
+    "tags": [
+      "sahara",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "SAHARAFDUSD": {
+    "normalized_id": "SAHARA/USD",
+    "base": "SAHARA",
+    "quote": "USD",
+    "display_name": "SAHARA / US Dollar",
+    "description": "SAHARA to US Dollar spot trading pair",
+    "tags": [
+      "sahara",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAHARATRY": {
+    "normalized_id": "SAHARA/TRY",
+    "base": "SAHARA",
+    "quote": "TRY",
+    "display_name": "SAHARA / Turkish Lira",
+    "description": "SAHARA to Turkish Lira spot trading pair",
+    "tags": [
+      "sahara",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SAHARAUSDC": {
+    "normalized_id": "SAHARA/USD",
+    "base": "SAHARA",
+    "quote": "USD",
+    "display_name": "SAHARA / US Dollar",
+    "description": "SAHARA to US Dollar spot trading pair",
+    "tags": [
+      "sahara",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAHARAUSDT": {
+    "normalized_id": "SAHARA/USD",
+    "base": "SAHARA",
+    "quote": "USD",
+    "display_name": "SAHARA / US Dollar",
+    "description": "SAHARA to US Dollar spot trading pair",
+    "tags": [
+      "sahara",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SANDBTC": {
+    "normalized_id": "SAND/BTC",
+    "base": "SAND",
+    "quote": "BTC",
+    "display_name": "The Sandbox / Bitcoin",
+    "description": "The Sandbox to Bitcoin spot trading pair",
+    "tags": [
+      "sand",
+      "the sandbox",
+      "gaming",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SANDFDUSD": {
+    "normalized_id": "SAND/USD",
+    "base": "SAND",
+    "quote": "USD",
+    "display_name": "The Sandbox / US Dollar",
+    "description": "The Sandbox to US Dollar spot trading pair",
+    "tags": [
+      "sand",
+      "the sandbox",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SANDTRY": {
+    "normalized_id": "SAND/TRY",
+    "base": "SAND",
+    "quote": "TRY",
+    "display_name": "The Sandbox / Turkish Lira",
+    "description": "The Sandbox to Turkish Lira spot trading pair",
+    "tags": [
+      "sand",
+      "the sandbox",
+      "gaming",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SANDUSDC": {
+    "normalized_id": "SAND/USD",
+    "base": "SAND",
+    "quote": "USD",
+    "display_name": "The Sandbox / US Dollar",
+    "description": "The Sandbox to US Dollar spot trading pair",
+    "tags": [
+      "sand",
+      "the sandbox",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SANDUSDT": {
+    "normalized_id": "SAND/USD",
+    "base": "SAND",
+    "quote": "USD",
+    "display_name": "The Sandbox / US Dollar",
+    "description": "The Sandbox to US Dollar spot trading pair",
+    "tags": [
+      "sand",
+      "the sandbox",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SANTOSBTC": {
+    "normalized_id": "SANTOS/BTC",
+    "base": "SANTOS",
+    "quote": "BTC",
+    "display_name": "SANTOS / Bitcoin",
+    "description": "SANTOS to Bitcoin spot trading pair",
+    "tags": [
+      "santos",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SANTOSTRY": {
+    "normalized_id": "SANTOS/TRY",
+    "base": "SANTOS",
+    "quote": "TRY",
+    "display_name": "SANTOS / Turkish Lira",
+    "description": "SANTOS to Turkish Lira spot trading pair",
+    "tags": [
+      "santos",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SANTOSUSDT": {
+    "normalized_id": "SANTOS/USD",
+    "base": "SANTOS",
+    "quote": "USD",
+    "display_name": "SANTOS / US Dollar",
+    "description": "SANTOS to US Dollar spot trading pair",
+    "tags": [
+      "santos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SBNB": {
+    "normalized_id": "S/BNB",
+    "base": "S",
+    "quote": "BNB",
+    "display_name": "S / Binance Coin",
+    "description": "S to Binance Coin spot trading pair",
+    "tags": [
+      "s",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "SBTC": {
+    "normalized_id": "S/BTC",
+    "base": "S",
+    "quote": "BTC",
+    "display_name": "S / Bitcoin",
+    "description": "S to Bitcoin spot trading pair",
+    "tags": [
+      "s",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SCETH": {
+    "normalized_id": "SC/ETH",
+    "base": "SC",
+    "quote": "ETH",
+    "display_name": "SC / Ethereum",
+    "description": "SC to Ethereum spot trading pair",
+    "tags": [
+      "sc",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "SCRBTC": {
+    "normalized_id": "SCR/BTC",
+    "base": "SCR",
+    "quote": "BTC",
+    "display_name": "SCR / Bitcoin",
+    "description": "SCR to Bitcoin spot trading pair",
+    "tags": [
+      "scr",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SCRFDUSD": {
+    "normalized_id": "SCR/USD",
+    "base": "SCR",
+    "quote": "USD",
+    "display_name": "SCR / US Dollar",
+    "description": "SCR to US Dollar spot trading pair",
+    "tags": [
+      "scr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SCRTBTC": {
+    "normalized_id": "SCRT/BTC",
+    "base": "SCRT",
+    "quote": "BTC",
+    "display_name": "SCRT / Bitcoin",
+    "description": "SCRT to Bitcoin spot trading pair",
+    "tags": [
+      "scrt",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SCRTRY": {
+    "normalized_id": "SCR/TRY",
+    "base": "SCR",
+    "quote": "TRY",
+    "display_name": "SCR / Turkish Lira",
+    "description": "SCR to Turkish Lira spot trading pair",
+    "tags": [
+      "scr",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SCRTUSDT": {
+    "normalized_id": "SCRT/USD",
+    "base": "SCRT",
+    "quote": "USD",
+    "display_name": "SCRT / US Dollar",
+    "description": "SCRT to US Dollar spot trading pair",
+    "tags": [
+      "scrt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SCRUSDT": {
+    "normalized_id": "SCR/USD",
+    "base": "SCR",
+    "quote": "USD",
+    "display_name": "SCR / US Dollar",
+    "description": "SCR to US Dollar spot trading pair",
+    "tags": [
+      "scr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SCUSDT": {
+    "normalized_id": "SC/USD",
+    "base": "SC",
+    "quote": "USD",
+    "display_name": "SC / US Dollar",
+    "description": "SC to US Dollar spot trading pair",
+    "tags": [
+      "sc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SEIBNB": {
+    "normalized_id": "SEI/BNB",
+    "base": "SEI",
+    "quote": "BNB",
+    "display_name": "Sei / Binance Coin",
+    "description": "Sei to Binance Coin spot trading pair",
+    "tags": [
+      "sei",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "SEIBTC": {
+    "normalized_id": "SEI/BTC",
+    "base": "SEI",
+    "quote": "BTC",
+    "display_name": "Sei / Bitcoin",
+    "description": "Sei to Bitcoin spot trading pair",
+    "tags": [
+      "sei",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SEIFDUSD": {
+    "normalized_id": "SEI/USD",
+    "base": "SEI",
+    "quote": "USD",
+    "display_name": "Sei / US Dollar",
+    "description": "Sei to US Dollar spot trading pair",
+    "tags": [
+      "sei",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SEIJPY": {
+    "normalized_id": "SEI/JPY",
+    "base": "SEI",
+    "quote": "JPY",
+    "display_name": "Sei / Japanese Yen",
+    "description": "Sei to Japanese Yen spot trading pair",
+    "tags": [
+      "sei",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "SEITRY": {
+    "normalized_id": "SEI/TRY",
+    "base": "SEI",
+    "quote": "TRY",
+    "display_name": "Sei / Turkish Lira",
+    "description": "Sei to Turkish Lira spot trading pair",
+    "tags": [
+      "sei",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SEIUSDC": {
+    "normalized_id": "SEI/USD",
+    "base": "SEI",
+    "quote": "USD",
+    "display_name": "Sei / US Dollar",
+    "description": "Sei to US Dollar spot trading pair",
+    "tags": [
+      "sei",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SEIUSDT": {
+    "normalized_id": "SEI/USD",
+    "base": "SEI",
+    "quote": "USD",
+    "display_name": "Sei / US Dollar",
+    "description": "Sei to US Dollar spot trading pair",
+    "tags": [
+      "sei",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SETH": {
+    "normalized_id": "S/ETH",
+    "base": "S",
+    "quote": "ETH",
+    "display_name": "S / Ethereum",
+    "description": "S to Ethereum spot trading pair",
+    "tags": [
+      "s",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "SEUR": {
+    "normalized_id": "S/EUR",
+    "base": "S",
+    "quote": "EUR",
+    "display_name": "S / Euro",
+    "description": "S to Euro spot trading pair",
+    "tags": [
+      "s",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SFDUSD": {
+    "normalized_id": "S/USD",
+    "base": "S",
+    "quote": "USD",
+    "display_name": "S / US Dollar",
+    "description": "S to US Dollar spot trading pair",
+    "tags": [
+      "s",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SFPBTC": {
+    "normalized_id": "SFP/BTC",
+    "base": "SFP",
+    "quote": "BTC",
+    "display_name": "SFP / Bitcoin",
+    "description": "SFP to Bitcoin spot trading pair",
+    "tags": [
+      "sfp",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SFPUSDT": {
+    "normalized_id": "SFP/USD",
+    "base": "SFP",
+    "quote": "USD",
+    "display_name": "SFP / US Dollar",
+    "description": "SFP to US Dollar spot trading pair",
+    "tags": [
+      "sfp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHELLBNB": {
+    "normalized_id": "SHELL/BNB",
+    "base": "SHELL",
+    "quote": "BNB",
+    "display_name": "SHELL / Binance Coin",
+    "description": "SHELL to Binance Coin spot trading pair",
+    "tags": [
+      "shell",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "SHELLBTC": {
+    "normalized_id": "SHELL/BTC",
+    "base": "SHELL",
+    "quote": "BTC",
+    "display_name": "SHELL / Bitcoin",
+    "description": "SHELL to Bitcoin spot trading pair",
+    "tags": [
+      "shell",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SHELLFDUSD": {
+    "normalized_id": "SHELL/USD",
+    "base": "SHELL",
+    "quote": "USD",
+    "display_name": "SHELL / US Dollar",
+    "description": "SHELL to US Dollar spot trading pair",
+    "tags": [
+      "shell",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHELLTRY": {
+    "normalized_id": "SHELL/TRY",
+    "base": "SHELL",
+    "quote": "TRY",
+    "display_name": "SHELL / Turkish Lira",
+    "description": "SHELL to Turkish Lira spot trading pair",
+    "tags": [
+      "shell",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SHELLUSDC": {
+    "normalized_id": "SHELL/USD",
+    "base": "SHELL",
+    "quote": "USD",
+    "display_name": "SHELL / US Dollar",
+    "description": "SHELL to US Dollar spot trading pair",
+    "tags": [
+      "shell",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHELLUSDT": {
+    "normalized_id": "SHELL/USD",
+    "base": "SHELL",
+    "quote": "USD",
+    "display_name": "SHELL / US Dollar",
+    "description": "SHELL to US Dollar spot trading pair",
+    "tags": [
+      "shell",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHIBBRL": {
+    "normalized_id": "SHIB/BRL",
+    "base": "SHIB",
+    "quote": "BRL",
+    "display_name": "Shiba Inu / Brazilian Real",
+    "description": "Shiba Inu to Brazilian Real spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "SHIBEUR": {
+    "normalized_id": "SHIB/EUR",
+    "base": "SHIB",
+    "quote": "EUR",
+    "display_name": "Shiba Inu / Euro",
+    "description": "Shiba Inu to Euro spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SHIBFDUSD": {
+    "normalized_id": "SHIB/USD",
+    "base": "SHIB",
+    "quote": "USD",
+    "display_name": "Shiba Inu / US Dollar",
+    "description": "Shiba Inu to US Dollar spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHIBJPY": {
+    "normalized_id": "SHIB/JPY",
+    "base": "SHIB",
+    "quote": "JPY",
+    "display_name": "Shiba Inu / Japanese Yen",
+    "description": "Shiba Inu to Japanese Yen spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "SHIBTRY": {
+    "normalized_id": "SHIB/TRY",
+    "base": "SHIB",
+    "quote": "TRY",
+    "display_name": "Shiba Inu / Turkish Lira",
+    "description": "Shiba Inu to Turkish Lira spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SHIBUSDC": {
+    "normalized_id": "SHIB/USD",
+    "base": "SHIB",
+    "quote": "USD",
+    "display_name": "Shiba Inu / US Dollar",
+    "description": "Shiba Inu to US Dollar spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHIBUSDT": {
+    "normalized_id": "SHIB/USD",
+    "base": "SHIB",
+    "quote": "USD",
+    "display_name": "Shiba Inu / US Dollar",
+    "description": "Shiba Inu to US Dollar spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SIGNBNB": {
+    "normalized_id": "SIGN/BNB",
+    "base": "SIGN",
+    "quote": "BNB",
+    "display_name": "SIGN / Binance Coin",
+    "description": "SIGN to Binance Coin spot trading pair",
+    "tags": [
+      "sign",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "SIGNFDUSD": {
+    "normalized_id": "SIGN/USD",
+    "base": "SIGN",
+    "quote": "USD",
+    "display_name": "SIGN / US Dollar",
+    "description": "SIGN to US Dollar spot trading pair",
+    "tags": [
+      "sign",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SIGNTRY": {
+    "normalized_id": "SIGN/TRY",
+    "base": "SIGN",
+    "quote": "TRY",
+    "display_name": "SIGN / Turkish Lira",
+    "description": "SIGN to Turkish Lira spot trading pair",
+    "tags": [
+      "sign",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SIGNUSDC": {
+    "normalized_id": "SIGN/USD",
+    "base": "SIGN",
+    "quote": "USD",
+    "display_name": "SIGN / US Dollar",
+    "description": "SIGN to US Dollar spot trading pair",
+    "tags": [
+      "sign",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SIGNUSDT": {
+    "normalized_id": "SIGN/USD",
+    "base": "SIGN",
+    "quote": "USD",
+    "display_name": "SIGN / US Dollar",
+    "description": "SIGN to US Dollar spot trading pair",
+    "tags": [
+      "sign",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SKLBTC": {
+    "normalized_id": "SKL/BTC",
+    "base": "SKL",
+    "quote": "BTC",
+    "display_name": "SKL / Bitcoin",
+    "description": "SKL to Bitcoin spot trading pair",
+    "tags": [
+      "skl",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SKLTRY": {
+    "normalized_id": "SKL/TRY",
+    "base": "SKL",
+    "quote": "TRY",
+    "display_name": "SKL / Turkish Lira",
+    "description": "SKL to Turkish Lira spot trading pair",
+    "tags": [
+      "skl",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SKLUSDT": {
+    "normalized_id": "SKL/USD",
+    "base": "SKL",
+    "quote": "USD",
+    "display_name": "SKL / US Dollar",
+    "description": "SKL to US Dollar spot trading pair",
+    "tags": [
+      "skl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SLFBTC": {
+    "normalized_id": "SLF/BTC",
+    "base": "SLF",
+    "quote": "BTC",
+    "display_name": "SLF / Bitcoin",
+    "description": "SLF to Bitcoin spot trading pair",
+    "tags": [
+      "slf",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SLFTRY": {
+    "normalized_id": "SLF/TRY",
+    "base": "SLF",
+    "quote": "TRY",
+    "display_name": "SLF / Turkish Lira",
+    "description": "SLF to Turkish Lira spot trading pair",
+    "tags": [
+      "slf",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SLFUSDC": {
+    "normalized_id": "SLF/USD",
+    "base": "SLF",
+    "quote": "USD",
+    "display_name": "SLF / US Dollar",
+    "description": "SLF to US Dollar spot trading pair",
+    "tags": [
+      "slf",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SLFUSDT": {
+    "normalized_id": "SLF/USD",
+    "base": "SLF",
+    "quote": "USD",
+    "display_name": "SLF / US Dollar",
+    "description": "SLF to US Dollar spot trading pair",
+    "tags": [
+      "slf",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SLPETH": {
+    "normalized_id": "SLP/ETH",
+    "base": "SLP",
+    "quote": "ETH",
+    "display_name": "SLP / Ethereum",
+    "description": "SLP to Ethereum spot trading pair",
+    "tags": [
+      "slp",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "SLPTRY": {
+    "normalized_id": "SLP/TRY",
+    "base": "SLP",
+    "quote": "TRY",
+    "display_name": "SLP / Turkish Lira",
+    "description": "SLP to Turkish Lira spot trading pair",
+    "tags": [
+      "slp",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SLPUSDT": {
+    "normalized_id": "SLP/USD",
+    "base": "SLP",
+    "quote": "USD",
+    "display_name": "SLP / US Dollar",
+    "description": "SLP to US Dollar spot trading pair",
+    "tags": [
+      "slp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SNXBTC": {
+    "normalized_id": "SNX/BTC",
+    "base": "SNX",
+    "quote": "BTC",
+    "display_name": "Synthetix / Bitcoin",
+    "description": "Synthetix to Bitcoin spot trading pair",
+    "tags": [
+      "snx",
+      "synthetix",
+      "defi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SNXTRY": {
+    "normalized_id": "SNX/TRY",
+    "base": "SNX",
+    "quote": "TRY",
+    "display_name": "Synthetix / Turkish Lira",
+    "description": "Synthetix to Turkish Lira spot trading pair",
+    "tags": [
+      "snx",
+      "synthetix",
+      "defi",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SNXUSDT": {
+    "normalized_id": "SNX/USD",
+    "base": "SNX",
+    "quote": "USD",
+    "display_name": "Synthetix / US Dollar",
+    "description": "Synthetix to US Dollar spot trading pair",
+    "tags": [
+      "snx",
+      "synthetix",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOLBNB": {
+    "normalized_id": "SOL/BNB",
+    "base": "SOL",
+    "quote": "BNB",
+    "display_name": "Solana / Binance Coin",
+    "description": "Solana to Binance Coin spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "SOLBRL": {
+    "normalized_id": "SOL/BRL",
+    "base": "SOL",
+    "quote": "BRL",
+    "display_name": "Solana / Brazilian Real",
+    "description": "Solana to Brazilian Real spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "SOLBTC": {
+    "normalized_id": "SOL/BTC",
+    "base": "SOL",
+    "quote": "BTC",
+    "display_name": "Solana / Bitcoin",
+    "description": "Solana to Bitcoin spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SOLETH": {
+    "normalized_id": "SOL/ETH",
+    "base": "SOL",
+    "quote": "ETH",
+    "display_name": "Solana / Ethereum",
+    "description": "Solana to Ethereum spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "SOLEUR": {
+    "normalized_id": "SOL/EUR",
+    "base": "SOL",
+    "quote": "EUR",
+    "display_name": "Solana / Euro",
+    "description": "Solana to Euro spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SOLFDUSD": {
+    "normalized_id": "SOL/USD",
+    "base": "SOL",
+    "quote": "USD",
+    "display_name": "Solana / US Dollar",
+    "description": "Solana to US Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOLJPY": {
+    "normalized_id": "SOL/JPY",
+    "base": "SOL",
+    "quote": "JPY",
+    "display_name": "Solana / Japanese Yen",
+    "description": "Solana to Japanese Yen spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "SOLTRY": {
+    "normalized_id": "SOL/TRY",
+    "base": "SOL",
+    "quote": "TRY",
+    "display_name": "Solana / Turkish Lira",
+    "description": "Solana to Turkish Lira spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SOLUSDC": {
+    "normalized_id": "SOL/USD",
+    "base": "SOL",
+    "quote": "USD",
+    "display_name": "Solana / US Dollar",
+    "description": "Solana to US Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOLUSDT": {
+    "normalized_id": "SOL/USD",
+    "base": "SOL",
+    "quote": "USD",
+    "display_name": "Solana / US Dollar",
+    "description": "Solana to US Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOLVBNB": {
+    "normalized_id": "SOLV/BNB",
+    "base": "SOLV",
+    "quote": "BNB",
+    "display_name": "SOLV / Binance Coin",
+    "description": "SOLV to Binance Coin spot trading pair",
+    "tags": [
+      "solv",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "SOLVFDUSD": {
+    "normalized_id": "SOLV/USD",
+    "base": "SOLV",
+    "quote": "USD",
+    "display_name": "SOLV / US Dollar",
+    "description": "SOLV to US Dollar spot trading pair",
+    "tags": [
+      "solv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOLVTRY": {
+    "normalized_id": "SOLV/TRY",
+    "base": "SOLV",
+    "quote": "TRY",
+    "display_name": "SOLV / Turkish Lira",
+    "description": "SOLV to Turkish Lira spot trading pair",
+    "tags": [
+      "solv",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SOLVUSDT": {
+    "normalized_id": "SOLV/USD",
+    "base": "SOLV",
+    "quote": "USD",
+    "display_name": "SOLV / US Dollar",
+    "description": "SOLV to US Dollar spot trading pair",
+    "tags": [
+      "solv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOPHBNB": {
+    "normalized_id": "SOPH/BNB",
+    "base": "SOPH",
+    "quote": "BNB",
+    "display_name": "SOPH / Binance Coin",
+    "description": "SOPH to Binance Coin spot trading pair",
+    "tags": [
+      "soph",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "SOPHFDUSD": {
+    "normalized_id": "SOPH/USD",
+    "base": "SOPH",
+    "quote": "USD",
+    "display_name": "SOPH / US Dollar",
+    "description": "SOPH to US Dollar spot trading pair",
+    "tags": [
+      "soph",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOPHTRY": {
+    "normalized_id": "SOPH/TRY",
+    "base": "SOPH",
+    "quote": "TRY",
+    "display_name": "SOPH / Turkish Lira",
+    "description": "SOPH to Turkish Lira spot trading pair",
+    "tags": [
+      "soph",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SOPHUSDC": {
+    "normalized_id": "SOPH/USD",
+    "base": "SOPH",
+    "quote": "USD",
+    "display_name": "SOPH / US Dollar",
+    "description": "SOPH to US Dollar spot trading pair",
+    "tags": [
+      "soph",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOPHUSDT": {
+    "normalized_id": "SOPH/USD",
+    "base": "SOPH",
+    "quote": "USD",
+    "display_name": "SOPH / US Dollar",
+    "description": "SOPH to US Dollar spot trading pair",
+    "tags": [
+      "soph",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SPELLTRY": {
+    "normalized_id": "SPELL/TRY",
+    "base": "SPELL",
+    "quote": "TRY",
+    "display_name": "SPELL / Turkish Lira",
+    "description": "SPELL to Turkish Lira spot trading pair",
+    "tags": [
+      "spell",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SPELLUSDT": {
+    "normalized_id": "SPELL/USD",
+    "base": "SPELL",
+    "quote": "USD",
+    "display_name": "SPELL / US Dollar",
+    "description": "SPELL to US Dollar spot trading pair",
+    "tags": [
+      "spell",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SPKBNB": {
+    "normalized_id": "SPK/BNB",
+    "base": "SPK",
+    "quote": "BNB",
+    "display_name": "SPK / Binance Coin",
+    "description": "SPK to Binance Coin spot trading pair",
+    "tags": [
+      "spk",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "SPKFDUSD": {
+    "normalized_id": "SPK/USD",
+    "base": "SPK",
+    "quote": "USD",
+    "display_name": "SPK / US Dollar",
+    "description": "SPK to US Dollar spot trading pair",
+    "tags": [
+      "spk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SPKTRY": {
+    "normalized_id": "SPK/TRY",
+    "base": "SPK",
+    "quote": "TRY",
+    "display_name": "SPK / Turkish Lira",
+    "description": "SPK to Turkish Lira spot trading pair",
+    "tags": [
+      "spk",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SPKUSDC": {
+    "normalized_id": "SPK/USD",
+    "base": "SPK",
+    "quote": "USD",
+    "display_name": "SPK / US Dollar",
+    "description": "SPK to US Dollar spot trading pair",
+    "tags": [
+      "spk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SPKUSDT": {
+    "normalized_id": "SPK/USD",
+    "base": "SPK",
+    "quote": "USD",
+    "display_name": "SPK / US Dollar",
+    "description": "SPK to US Dollar spot trading pair",
+    "tags": [
+      "spk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SSVBTC": {
+    "normalized_id": "SSV/BTC",
+    "base": "SSV",
+    "quote": "BTC",
+    "display_name": "SSV / Bitcoin",
+    "description": "SSV to Bitcoin spot trading pair",
+    "tags": [
+      "ssv",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SSVETH": {
+    "normalized_id": "SSV/ETH",
+    "base": "SSV",
+    "quote": "ETH",
+    "display_name": "SSV / Ethereum",
+    "description": "SSV to Ethereum spot trading pair",
+    "tags": [
+      "ssv",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "SSVUSDT": {
+    "normalized_id": "SSV/USD",
+    "base": "SSV",
+    "quote": "USD",
+    "display_name": "SSV / US Dollar",
+    "description": "SSV to US Dollar spot trading pair",
+    "tags": [
+      "ssv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STEEMBTC": {
+    "normalized_id": "STEEM/BTC",
+    "base": "STEEM",
+    "quote": "BTC",
+    "display_name": "STEEM / Bitcoin",
+    "description": "STEEM to Bitcoin spot trading pair",
+    "tags": [
+      "steem",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "STEEMETH": {
+    "normalized_id": "STEEM/ETH",
+    "base": "STEEM",
+    "quote": "ETH",
+    "display_name": "STEEM / Ethereum",
+    "description": "STEEM to Ethereum spot trading pair",
+    "tags": [
+      "steem",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "STEEMUSDC": {
+    "normalized_id": "STEEM/USD",
+    "base": "STEEM",
+    "quote": "USD",
+    "display_name": "STEEM / US Dollar",
+    "description": "STEEM to US Dollar spot trading pair",
+    "tags": [
+      "steem",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STEEMUSDT": {
+    "normalized_id": "STEEM/USD",
+    "base": "STEEM",
+    "quote": "USD",
+    "display_name": "STEEM / US Dollar",
+    "description": "STEEM to US Dollar spot trading pair",
+    "tags": [
+      "steem",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STGBTC": {
+    "normalized_id": "STG/BTC",
+    "base": "STG",
+    "quote": "BTC",
+    "display_name": "STG / Bitcoin",
+    "description": "STG to Bitcoin spot trading pair",
+    "tags": [
+      "stg",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "STGUSDT": {
+    "normalized_id": "STG/USD",
+    "base": "STG",
+    "quote": "USD",
+    "display_name": "STG / US Dollar",
+    "description": "STG to US Dollar spot trading pair",
+    "tags": [
+      "stg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STOFDUSD": {
+    "normalized_id": "STO/USD",
+    "base": "STO",
+    "quote": "USD",
+    "display_name": "STO / US Dollar",
+    "description": "STO to US Dollar spot trading pair",
+    "tags": [
+      "sto",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STORJBTC": {
+    "normalized_id": "STORJ/BTC",
+    "base": "STORJ",
+    "quote": "BTC",
+    "display_name": "STORJ / Bitcoin",
+    "description": "STORJ to Bitcoin spot trading pair",
+    "tags": [
+      "storj",
+      "storage",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "STORJTRY": {
+    "normalized_id": "STORJ/TRY",
+    "base": "STORJ",
+    "quote": "TRY",
+    "display_name": "STORJ / Turkish Lira",
+    "description": "STORJ to Turkish Lira spot trading pair",
+    "tags": [
+      "storj",
+      "storage",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "STORJUSDT": {
+    "normalized_id": "STORJ/USD",
+    "base": "STORJ",
+    "quote": "USD",
+    "display_name": "STORJ / US Dollar",
+    "description": "STORJ to US Dollar spot trading pair",
+    "tags": [
+      "storj",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STOTRY": {
+    "normalized_id": "STO/TRY",
+    "base": "STO",
+    "quote": "TRY",
+    "display_name": "STO / Turkish Lira",
+    "description": "STO to Turkish Lira spot trading pair",
+    "tags": [
+      "sto",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "STOUSDC": {
+    "normalized_id": "STO/USD",
+    "base": "STO",
+    "quote": "USD",
+    "display_name": "STO / US Dollar",
+    "description": "STO to US Dollar spot trading pair",
+    "tags": [
+      "sto",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STOUSDT": {
+    "normalized_id": "STO/USD",
+    "base": "STO",
+    "quote": "USD",
+    "display_name": "STO / US Dollar",
+    "description": "STO to US Dollar spot trading pair",
+    "tags": [
+      "sto",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STRAXTRY": {
+    "normalized_id": "STRAX/TRY",
+    "base": "STRAX",
+    "quote": "TRY",
+    "display_name": "STRAX / Turkish Lira",
+    "description": "STRAX to Turkish Lira spot trading pair",
+    "tags": [
+      "strax",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "STRAXUSDT": {
+    "normalized_id": "STRAX/USD",
+    "base": "STRAX",
+    "quote": "USD",
+    "display_name": "STRAX / US Dollar",
+    "description": "STRAX to US Dollar spot trading pair",
+    "tags": [
+      "strax",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STRKFDUSD": {
+    "normalized_id": "STRK/USD",
+    "base": "STRK",
+    "quote": "USD",
+    "display_name": "STRK / US Dollar",
+    "description": "STRK to US Dollar spot trading pair",
+    "tags": [
+      "strk",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STRKTRY": {
+    "normalized_id": "STRK/TRY",
+    "base": "STRK",
+    "quote": "TRY",
+    "display_name": "STRK / Turkish Lira",
+    "description": "STRK to Turkish Lira spot trading pair",
+    "tags": [
+      "strk",
+      "layer2",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "STRKUSDC": {
+    "normalized_id": "STRK/USD",
+    "base": "STRK",
+    "quote": "USD",
+    "display_name": "STRK / US Dollar",
+    "description": "STRK to US Dollar spot trading pair",
+    "tags": [
+      "strk",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STRKUSDT": {
+    "normalized_id": "STRK/USD",
+    "base": "STRK",
+    "quote": "USD",
+    "display_name": "STRK / US Dollar",
+    "description": "STRK to US Dollar spot trading pair",
+    "tags": [
+      "strk",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STRY": {
+    "normalized_id": "S/TRY",
+    "base": "S",
+    "quote": "TRY",
+    "display_name": "S / Turkish Lira",
+    "description": "S to Turkish Lira spot trading pair",
+    "tags": [
+      "s",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "STXBTC": {
+    "normalized_id": "STX/BTC",
+    "base": "STX",
+    "quote": "BTC",
+    "display_name": "STX / Bitcoin",
+    "description": "STX to Bitcoin spot trading pair",
+    "tags": [
+      "stx",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "STXFDUSD": {
+    "normalized_id": "STX/USD",
+    "base": "STX",
+    "quote": "USD",
+    "display_name": "STX / US Dollar",
+    "description": "STX to US Dollar spot trading pair",
+    "tags": [
+      "stx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STXTRY": {
+    "normalized_id": "STX/TRY",
+    "base": "STX",
+    "quote": "TRY",
+    "display_name": "STX / Turkish Lira",
+    "description": "STX to Turkish Lira spot trading pair",
+    "tags": [
+      "stx",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "STXUSDC": {
+    "normalized_id": "STX/USD",
+    "base": "STX",
+    "quote": "USD",
+    "display_name": "STX / US Dollar",
+    "description": "STX to US Dollar spot trading pair",
+    "tags": [
+      "stx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STXUSDT": {
+    "normalized_id": "STX/USD",
+    "base": "STX",
+    "quote": "USD",
+    "display_name": "STX / US Dollar",
+    "description": "STX to US Dollar spot trading pair",
+    "tags": [
+      "stx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUIBNB": {
+    "normalized_id": "SUI/BNB",
+    "base": "SUI",
+    "quote": "BNB",
+    "display_name": "Sui / Binance Coin",
+    "description": "Sui to Binance Coin spot trading pair",
+    "tags": [
+      "sui",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "SUIBRL": {
+    "normalized_id": "SUI/BRL",
+    "base": "SUI",
+    "quote": "BRL",
+    "display_name": "Sui / Brazilian Real",
+    "description": "Sui to Brazilian Real spot trading pair",
+    "tags": [
+      "sui",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "SUIBTC": {
+    "normalized_id": "SUI/BTC",
+    "base": "SUI",
+    "quote": "BTC",
+    "display_name": "Sui / Bitcoin",
+    "description": "Sui to Bitcoin spot trading pair",
+    "tags": [
+      "sui",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SUIEUR": {
+    "normalized_id": "SUI/EUR",
+    "base": "SUI",
+    "quote": "EUR",
+    "display_name": "Sui / Euro",
+    "description": "Sui to Euro spot trading pair",
+    "tags": [
+      "sui",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SUIFDUSD": {
+    "normalized_id": "SUI/USD",
+    "base": "SUI",
+    "quote": "USD",
+    "display_name": "Sui / US Dollar",
+    "description": "Sui to US Dollar spot trading pair",
+    "tags": [
+      "sui",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUIJPY": {
+    "normalized_id": "SUI/JPY",
+    "base": "SUI",
+    "quote": "JPY",
+    "display_name": "Sui / Japanese Yen",
+    "description": "Sui to Japanese Yen spot trading pair",
+    "tags": [
+      "sui",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "SUITRY": {
+    "normalized_id": "SUI/TRY",
+    "base": "SUI",
+    "quote": "TRY",
+    "display_name": "Sui / Turkish Lira",
+    "description": "Sui to Turkish Lira spot trading pair",
+    "tags": [
+      "sui",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SUIUSDC": {
+    "normalized_id": "SUI/USD",
+    "base": "SUI",
+    "quote": "USD",
+    "display_name": "Sui / US Dollar",
+    "description": "Sui to US Dollar spot trading pair",
+    "tags": [
+      "sui",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUIUSDT": {
+    "normalized_id": "SUI/USD",
+    "base": "SUI",
+    "quote": "USD",
+    "display_name": "Sui / US Dollar",
+    "description": "Sui to US Dollar spot trading pair",
+    "tags": [
+      "sui",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUNTRY": {
+    "normalized_id": "SUN/TRY",
+    "base": "SUN",
+    "quote": "TRY",
+    "display_name": "SUN / Turkish Lira",
+    "description": "SUN to Turkish Lira spot trading pair",
+    "tags": [
+      "sun",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SUNUSDT": {
+    "normalized_id": "SUN/USD",
+    "base": "SUN",
+    "quote": "USD",
+    "display_name": "SUN / US Dollar",
+    "description": "SUN to US Dollar spot trading pair",
+    "tags": [
+      "sun",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUPERBTC": {
+    "normalized_id": "SUPER/BTC",
+    "base": "SUPER",
+    "quote": "BTC",
+    "display_name": "SUPER / Bitcoin",
+    "description": "SUPER to Bitcoin spot trading pair",
+    "tags": [
+      "super",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SUPERTRY": {
+    "normalized_id": "SUPER/TRY",
+    "base": "SUPER",
+    "quote": "TRY",
+    "display_name": "SUPER / Turkish Lira",
+    "description": "SUPER to Turkish Lira spot trading pair",
+    "tags": [
+      "super",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SUPERUSDT": {
+    "normalized_id": "SUPER/USD",
+    "base": "SUPER",
+    "quote": "USD",
+    "display_name": "SUPER / US Dollar",
+    "description": "SUPER to US Dollar spot trading pair",
+    "tags": [
+      "super",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUSDC": {
+    "normalized_id": "S/USD",
+    "base": "S",
+    "quote": "USD",
+    "display_name": "S / US Dollar",
+    "description": "S to US Dollar spot trading pair",
+    "tags": [
+      "s",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUSDT": {
+    "normalized_id": "S/USD",
+    "base": "S",
+    "quote": "USD",
+    "display_name": "S / US Dollar",
+    "description": "S to US Dollar spot trading pair",
+    "tags": [
+      "s",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUSHIBTC": {
+    "normalized_id": "SUSHI/BTC",
+    "base": "SUSHI",
+    "quote": "BTC",
+    "display_name": "SUSHI / Bitcoin",
+    "description": "SUSHI to Bitcoin spot trading pair",
+    "tags": [
+      "sushi",
+      "defi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SUSHITRY": {
+    "normalized_id": "SUSHI/TRY",
+    "base": "SUSHI",
+    "quote": "TRY",
+    "display_name": "SUSHI / Turkish Lira",
+    "description": "SUSHI to Turkish Lira spot trading pair",
+    "tags": [
+      "sushi",
+      "defi",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SUSHIUSDC": {
+    "normalized_id": "SUSHI/USD",
+    "base": "SUSHI",
+    "quote": "USD",
+    "display_name": "SUSHI / US Dollar",
+    "description": "SUSHI to US Dollar spot trading pair",
+    "tags": [
+      "sushi",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUSHIUSDT": {
+    "normalized_id": "SUSHI/USD",
+    "base": "SUSHI",
+    "quote": "USD",
+    "display_name": "SUSHI / US Dollar",
+    "description": "SUSHI to US Dollar spot trading pair",
+    "tags": [
+      "sushi",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SXPBTC": {
+    "normalized_id": "SXP/BTC",
+    "base": "SXP",
+    "quote": "BTC",
+    "display_name": "SXP / Bitcoin",
+    "description": "SXP to Bitcoin spot trading pair",
+    "tags": [
+      "sxp",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SXPTRY": {
+    "normalized_id": "SXP/TRY",
+    "base": "SXP",
+    "quote": "TRY",
+    "display_name": "SXP / Turkish Lira",
+    "description": "SXP to Turkish Lira spot trading pair",
+    "tags": [
+      "sxp",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SXPUSDT": {
+    "normalized_id": "SXP/USD",
+    "base": "SXP",
+    "quote": "USD",
+    "display_name": "SXP / US Dollar",
+    "description": "SXP to US Dollar spot trading pair",
+    "tags": [
+      "sxp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SXTBNB": {
+    "normalized_id": "SXT/BNB",
+    "base": "SXT",
+    "quote": "BNB",
+    "display_name": "SXT / Binance Coin",
+    "description": "SXT to Binance Coin spot trading pair",
+    "tags": [
+      "sxt",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "SXTFDUSD": {
+    "normalized_id": "SXT/USD",
+    "base": "SXT",
+    "quote": "USD",
+    "display_name": "SXT / US Dollar",
+    "description": "SXT to US Dollar spot trading pair",
+    "tags": [
+      "sxt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SXTTRY": {
+    "normalized_id": "SXT/TRY",
+    "base": "SXT",
+    "quote": "TRY",
+    "display_name": "SXT / Turkish Lira",
+    "description": "SXT to Turkish Lira spot trading pair",
+    "tags": [
+      "sxt",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SXTUSDC": {
+    "normalized_id": "SXT/USD",
+    "base": "SXT",
+    "quote": "USD",
+    "display_name": "SXT / US Dollar",
+    "description": "SXT to US Dollar spot trading pair",
+    "tags": [
+      "sxt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SXTUSDT": {
+    "normalized_id": "SXT/USD",
+    "base": "SXT",
+    "quote": "USD",
+    "display_name": "SXT / US Dollar",
+    "description": "SXT to US Dollar spot trading pair",
+    "tags": [
+      "sxt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SYNUSDC": {
+    "normalized_id": "SYN/USD",
+    "base": "SYN",
+    "quote": "USD",
+    "display_name": "SYN / US Dollar",
+    "description": "SYN to US Dollar spot trading pair",
+    "tags": [
+      "syn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SYNUSDT": {
+    "normalized_id": "SYN/USD",
+    "base": "SYN",
+    "quote": "USD",
+    "display_name": "SYN / US Dollar",
+    "description": "SYN to US Dollar spot trading pair",
+    "tags": [
+      "syn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SYRUPTRY": {
+    "normalized_id": "SYRUP/TRY",
+    "base": "SYRUP",
+    "quote": "TRY",
+    "display_name": "SYRUP / Turkish Lira",
+    "description": "SYRUP to Turkish Lira spot trading pair",
+    "tags": [
+      "syrup",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SYRUPUSDC": {
+    "normalized_id": "SYRUP/USD",
+    "base": "SYRUP",
+    "quote": "USD",
+    "display_name": "SYRUP / US Dollar",
+    "description": "SYRUP to US Dollar spot trading pair",
+    "tags": [
+      "syrup",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SYRUPUSDT": {
+    "normalized_id": "SYRUP/USD",
+    "base": "SYRUP",
+    "quote": "USD",
+    "display_name": "SYRUP / US Dollar",
+    "description": "SYRUP to US Dollar spot trading pair",
+    "tags": [
+      "syrup",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SYSBTC": {
+    "normalized_id": "SYS/BTC",
+    "base": "SYS",
+    "quote": "BTC",
+    "display_name": "SYS / Bitcoin",
+    "description": "SYS to Bitcoin spot trading pair",
+    "tags": [
+      "sys",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SYSUSDT": {
+    "normalized_id": "SYS/USD",
+    "base": "SYS",
+    "quote": "USD",
+    "display_name": "SYS / US Dollar",
+    "description": "SYS to US Dollar spot trading pair",
+    "tags": [
+      "sys",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TAOBTC": {
+    "normalized_id": "TAO/BTC",
+    "base": "TAO",
+    "quote": "BTC",
+    "display_name": "TAO / Bitcoin",
+    "description": "TAO to Bitcoin spot trading pair",
+    "tags": [
+      "tao",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "TAOFDUSD": {
+    "normalized_id": "TAO/USD",
+    "base": "TAO",
+    "quote": "USD",
+    "display_name": "TAO / US Dollar",
+    "description": "TAO to US Dollar spot trading pair",
+    "tags": [
+      "tao",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TAOTRY": {
+    "normalized_id": "TAO/TRY",
+    "base": "TAO",
+    "quote": "TRY",
+    "display_name": "TAO / Turkish Lira",
+    "description": "TAO to Turkish Lira spot trading pair",
+    "tags": [
+      "tao",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "TAOUSDC": {
+    "normalized_id": "TAO/USD",
+    "base": "TAO",
+    "quote": "USD",
+    "display_name": "TAO / US Dollar",
+    "description": "TAO to US Dollar spot trading pair",
+    "tags": [
+      "tao",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TAOUSDT": {
+    "normalized_id": "TAO/USD",
+    "base": "TAO",
+    "quote": "USD",
+    "display_name": "TAO / US Dollar",
+    "description": "TAO to US Dollar spot trading pair",
+    "tags": [
+      "tao",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TFUELBTC": {
+    "normalized_id": "TFUEL/BTC",
+    "base": "TFUEL",
+    "quote": "BTC",
+    "display_name": "TFUEL / Bitcoin",
+    "description": "TFUEL to Bitcoin spot trading pair",
+    "tags": [
+      "tfuel",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "TFUELUSDT": {
+    "normalized_id": "TFUEL/USD",
+    "base": "TFUEL",
+    "quote": "USD",
+    "display_name": "TFUEL / US Dollar",
+    "description": "TFUEL to US Dollar spot trading pair",
+    "tags": [
+      "tfuel",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "THEFDUSD": {
+    "normalized_id": "THE/USD",
+    "base": "THE",
+    "quote": "USD",
+    "display_name": "THE / US Dollar",
+    "description": "THE to US Dollar spot trading pair",
+    "tags": [
+      "the",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "THETABTC": {
+    "normalized_id": "THETA/BTC",
+    "base": "THETA",
+    "quote": "BTC",
+    "display_name": "Theta / Bitcoin",
+    "description": "Theta to Bitcoin spot trading pair",
+    "tags": [
+      "theta",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "THETATRY": {
+    "normalized_id": "THETA/TRY",
+    "base": "THETA",
+    "quote": "TRY",
+    "display_name": "Theta / Turkish Lira",
+    "description": "Theta to Turkish Lira spot trading pair",
+    "tags": [
+      "theta",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "THETAUSDC": {
+    "normalized_id": "THETA/USD",
+    "base": "THETA",
+    "quote": "USD",
+    "display_name": "Theta / US Dollar",
+    "description": "Theta to US Dollar spot trading pair",
+    "tags": [
+      "theta",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "THETAUSDT": {
+    "normalized_id": "THETA/USD",
+    "base": "THETA",
+    "quote": "USD",
+    "display_name": "Theta / US Dollar",
+    "description": "Theta to US Dollar spot trading pair",
+    "tags": [
+      "theta",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "THETRY": {
+    "normalized_id": "THE/TRY",
+    "base": "THE",
+    "quote": "TRY",
+    "display_name": "THE / Turkish Lira",
+    "description": "THE to Turkish Lira spot trading pair",
+    "tags": [
+      "the",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "THEUSDC": {
+    "normalized_id": "THE/USD",
+    "base": "THE",
+    "quote": "USD",
+    "display_name": "THE / US Dollar",
+    "description": "THE to US Dollar spot trading pair",
+    "tags": [
+      "the",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "THEUSDT": {
+    "normalized_id": "THE/USD",
+    "base": "THE",
+    "quote": "USD",
+    "display_name": "THE / US Dollar",
+    "description": "THE to US Dollar spot trading pair",
+    "tags": [
+      "the",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TIABTC": {
+    "normalized_id": "TIA/BTC",
+    "base": "TIA",
+    "quote": "BTC",
+    "display_name": "Celestia / Bitcoin",
+    "description": "Celestia to Bitcoin spot trading pair",
+    "tags": [
+      "tia",
+      "celestia",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "TIAFDUSD": {
+    "normalized_id": "TIA/USD",
+    "base": "TIA",
+    "quote": "USD",
+    "display_name": "Celestia / US Dollar",
+    "description": "Celestia to US Dollar spot trading pair",
+    "tags": [
+      "tia",
+      "celestia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TIATRY": {
+    "normalized_id": "TIA/TRY",
+    "base": "TIA",
+    "quote": "TRY",
+    "display_name": "Celestia / Turkish Lira",
+    "description": "Celestia to Turkish Lira spot trading pair",
+    "tags": [
+      "tia",
+      "celestia",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "TIAUSDC": {
+    "normalized_id": "TIA/USD",
+    "base": "TIA",
+    "quote": "USD",
+    "display_name": "Celestia / US Dollar",
+    "description": "Celestia to US Dollar spot trading pair",
+    "tags": [
+      "tia",
+      "celestia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TIAUSDT": {
+    "normalized_id": "TIA/USD",
+    "base": "TIA",
+    "quote": "USD",
+    "display_name": "Celestia / US Dollar",
+    "description": "Celestia to US Dollar spot trading pair",
+    "tags": [
+      "tia",
+      "celestia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TKOUSDT": {
+    "normalized_id": "TKO/USD",
+    "base": "TKO",
+    "quote": "USD",
+    "display_name": "TKO / US Dollar",
+    "description": "TKO to US Dollar spot trading pair",
+    "tags": [
+      "tko",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TLMTRY": {
+    "normalized_id": "TLM/TRY",
+    "base": "TLM",
+    "quote": "TRY",
+    "display_name": "TLM / Turkish Lira",
+    "description": "TLM to Turkish Lira spot trading pair",
+    "tags": [
+      "tlm",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "TLMUSDC": {
+    "normalized_id": "TLM/USD",
+    "base": "TLM",
+    "quote": "USD",
+    "display_name": "TLM / US Dollar",
+    "description": "TLM to US Dollar spot trading pair",
+    "tags": [
+      "tlm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TLMUSDT": {
+    "normalized_id": "TLM/USD",
+    "base": "TLM",
+    "quote": "USD",
+    "display_name": "TLM / US Dollar",
+    "description": "TLM to US Dollar spot trading pair",
+    "tags": [
+      "tlm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TNSRTRY": {
+    "normalized_id": "TNSR/TRY",
+    "base": "TNSR",
+    "quote": "TRY",
+    "display_name": "TNSR / Turkish Lira",
+    "description": "TNSR to Turkish Lira spot trading pair",
+    "tags": [
+      "tnsr",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "TNSRUSDC": {
+    "normalized_id": "TNSR/USD",
+    "base": "TNSR",
+    "quote": "USD",
+    "display_name": "TNSR / US Dollar",
+    "description": "TNSR to US Dollar spot trading pair",
+    "tags": [
+      "tnsr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TNSRUSDT": {
+    "normalized_id": "TNSR/USD",
+    "base": "TNSR",
+    "quote": "USD",
+    "display_name": "TNSR / US Dollar",
+    "description": "TNSR to US Dollar spot trading pair",
+    "tags": [
+      "tnsr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TONBTC": {
+    "normalized_id": "TON/BTC",
+    "base": "TON",
+    "quote": "BTC",
+    "display_name": "Toncoin / Bitcoin",
+    "description": "Toncoin to Bitcoin spot trading pair",
+    "tags": [
+      "ton",
+      "toncoin",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "TONFDUSD": {
+    "normalized_id": "TON/USD",
+    "base": "TON",
+    "quote": "USD",
+    "display_name": "Toncoin / US Dollar",
+    "description": "Toncoin to US Dollar spot trading pair",
+    "tags": [
+      "ton",
+      "toncoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TONTRY": {
+    "normalized_id": "TON/TRY",
+    "base": "TON",
+    "quote": "TRY",
+    "display_name": "Toncoin / Turkish Lira",
+    "description": "Toncoin to Turkish Lira spot trading pair",
+    "tags": [
+      "ton",
+      "toncoin",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "TONUSDC": {
+    "normalized_id": "TON/USD",
+    "base": "TON",
+    "quote": "USD",
+    "display_name": "Toncoin / US Dollar",
+    "description": "Toncoin to US Dollar spot trading pair",
+    "tags": [
+      "ton",
+      "toncoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TONUSDT": {
+    "normalized_id": "TON/USD",
+    "base": "TON",
+    "quote": "USD",
+    "display_name": "Toncoin / US Dollar",
+    "description": "Toncoin to US Dollar spot trading pair",
+    "tags": [
+      "ton",
+      "toncoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TOWNSBNB": {
+    "normalized_id": "TOWNS/BNB",
+    "base": "TOWNS",
+    "quote": "BNB",
+    "display_name": "TOWNS / Binance Coin",
+    "description": "TOWNS to Binance Coin spot trading pair",
+    "tags": [
+      "towns",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "TOWNSFDUSD": {
+    "normalized_id": "TOWNS/USD",
+    "base": "TOWNS",
+    "quote": "USD",
+    "display_name": "TOWNS / US Dollar",
+    "description": "TOWNS to US Dollar spot trading pair",
+    "tags": [
+      "towns",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TOWNSTRY": {
+    "normalized_id": "TOWNS/TRY",
+    "base": "TOWNS",
+    "quote": "TRY",
+    "display_name": "TOWNS / Turkish Lira",
+    "description": "TOWNS to Turkish Lira spot trading pair",
+    "tags": [
+      "towns",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "TOWNSUSDC": {
+    "normalized_id": "TOWNS/USD",
+    "base": "TOWNS",
+    "quote": "USD",
+    "display_name": "TOWNS / US Dollar",
+    "description": "TOWNS to US Dollar spot trading pair",
+    "tags": [
+      "towns",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TOWNSUSDT": {
+    "normalized_id": "TOWNS/USD",
+    "base": "TOWNS",
+    "quote": "USD",
+    "display_name": "TOWNS / US Dollar",
+    "description": "TOWNS to US Dollar spot trading pair",
+    "tags": [
+      "towns",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRBBTC": {
+    "normalized_id": "TRB/BTC",
+    "base": "TRB",
+    "quote": "BTC",
+    "display_name": "TRB / Bitcoin",
+    "description": "TRB to Bitcoin spot trading pair",
+    "tags": [
+      "trb",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "TRBTRY": {
+    "normalized_id": "TRB/TRY",
+    "base": "TRB",
+    "quote": "TRY",
+    "display_name": "TRB / Turkish Lira",
+    "description": "TRB to Turkish Lira spot trading pair",
+    "tags": [
+      "trb",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "TRBUSDC": {
+    "normalized_id": "TRB/USD",
+    "base": "TRB",
+    "quote": "USD",
+    "display_name": "TRB / US Dollar",
+    "description": "TRB to US Dollar spot trading pair",
+    "tags": [
+      "trb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRBUSDT": {
+    "normalized_id": "TRB/USD",
+    "base": "TRB",
+    "quote": "USD",
+    "display_name": "TRB / US Dollar",
+    "description": "TRB to US Dollar spot trading pair",
+    "tags": [
+      "trb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TREEBNB": {
+    "normalized_id": "TREE/BNB",
+    "base": "TREE",
+    "quote": "BNB",
+    "display_name": "TREE / Binance Coin",
+    "description": "TREE to Binance Coin spot trading pair",
+    "tags": [
+      "tree",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "TREEFDUSD": {
+    "normalized_id": "TREE/USD",
+    "base": "TREE",
+    "quote": "USD",
+    "display_name": "TREE / US Dollar",
+    "description": "TREE to US Dollar spot trading pair",
+    "tags": [
+      "tree",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TREETRY": {
+    "normalized_id": "TREE/TRY",
+    "base": "TREE",
+    "quote": "TRY",
+    "display_name": "TREE / Turkish Lira",
+    "description": "TREE to Turkish Lira spot trading pair",
+    "tags": [
+      "tree",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "TREEUSDC": {
+    "normalized_id": "TREE/USD",
+    "base": "TREE",
+    "quote": "USD",
+    "display_name": "TREE / US Dollar",
+    "description": "TREE to US Dollar spot trading pair",
+    "tags": [
+      "tree",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TREEUSDT": {
+    "normalized_id": "TREE/USD",
+    "base": "TREE",
+    "quote": "USD",
+    "display_name": "TREE / US Dollar",
+    "description": "TREE to US Dollar spot trading pair",
+    "tags": [
+      "tree",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRUMPBRL": {
+    "normalized_id": "TRUMP/BRL",
+    "base": "TRUMP",
+    "quote": "BRL",
+    "display_name": "TRUMP / Brazilian Real",
+    "description": "TRUMP to Brazilian Real spot trading pair",
+    "tags": [
+      "trump",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "TRUMPEUR": {
+    "normalized_id": "TRUMP/EUR",
+    "base": "TRUMP",
+    "quote": "EUR",
+    "display_name": "TRUMP / Euro",
+    "description": "TRUMP to Euro spot trading pair",
+    "tags": [
+      "trump",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TRUMPFDUSD": {
+    "normalized_id": "TRUMP/USD",
+    "base": "TRUMP",
+    "quote": "USD",
+    "display_name": "TRUMP / US Dollar",
+    "description": "TRUMP to US Dollar spot trading pair",
+    "tags": [
+      "trump",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRUMPTRY": {
+    "normalized_id": "TRUMP/TRY",
+    "base": "TRUMP",
+    "quote": "TRY",
+    "display_name": "TRUMP / Turkish Lira",
+    "description": "TRUMP to Turkish Lira spot trading pair",
+    "tags": [
+      "trump",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "TRUMPUSDC": {
+    "normalized_id": "TRUMP/USD",
+    "base": "TRUMP",
+    "quote": "USD",
+    "display_name": "TRUMP / US Dollar",
+    "description": "TRUMP to US Dollar spot trading pair",
+    "tags": [
+      "trump",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRUMPUSDT": {
+    "normalized_id": "TRUMP/USD",
+    "base": "TRUMP",
+    "quote": "USD",
+    "display_name": "TRUMP / US Dollar",
+    "description": "TRUMP to US Dollar spot trading pair",
+    "tags": [
+      "trump",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRUTRY": {
+    "normalized_id": "TRU/TRY",
+    "base": "TRU",
+    "quote": "TRY",
+    "display_name": "TRU / Turkish Lira",
+    "description": "TRU to Turkish Lira spot trading pair",
+    "tags": [
+      "tru",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "TRUUSDT": {
+    "normalized_id": "TRU/USD",
+    "base": "TRU",
+    "quote": "USD",
+    "display_name": "TRU / US Dollar",
+    "description": "TRU to US Dollar spot trading pair",
+    "tags": [
+      "tru",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRXBNB": {
+    "normalized_id": "TRX/BNB",
+    "base": "TRX",
+    "quote": "BNB",
+    "display_name": "TRON / Binance Coin",
+    "description": "TRON to Binance Coin spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "TRXBTC": {
+    "normalized_id": "TRX/BTC",
+    "base": "TRX",
+    "quote": "BTC",
+    "display_name": "TRON / Bitcoin",
+    "description": "TRON to Bitcoin spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "TRXETH": {
+    "normalized_id": "TRX/ETH",
+    "base": "TRX",
+    "quote": "ETH",
+    "display_name": "TRON / Ethereum",
+    "description": "TRON to Ethereum spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "TRXEUR": {
+    "normalized_id": "TRX/EUR",
+    "base": "TRX",
+    "quote": "EUR",
+    "display_name": "TRON / Euro",
+    "description": "TRON to Euro spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TRXFDUSD": {
+    "normalized_id": "TRX/USD",
+    "base": "TRX",
+    "quote": "USD",
+    "display_name": "TRON / US Dollar",
+    "description": "TRON to US Dollar spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRXJPY": {
+    "normalized_id": "TRX/JPY",
+    "base": "TRX",
+    "quote": "JPY",
+    "display_name": "TRON / Japanese Yen",
+    "description": "TRON to Japanese Yen spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "TRXTRY": {
+    "normalized_id": "TRX/TRY",
+    "base": "TRX",
+    "quote": "TRY",
+    "display_name": "TRON / Turkish Lira",
+    "description": "TRON to Turkish Lira spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "TRXUSDC": {
+    "normalized_id": "TRX/USD",
+    "base": "TRX",
+    "quote": "USD",
+    "display_name": "TRON / US Dollar",
+    "description": "TRON to US Dollar spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRXUSDT": {
+    "normalized_id": "TRX/USD",
+    "base": "TRX",
+    "quote": "USD",
+    "display_name": "TRON / US Dollar",
+    "description": "TRON to US Dollar spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TSTTRY": {
+    "normalized_id": "TST/TRY",
+    "base": "TST",
+    "quote": "TRY",
+    "display_name": "TST / Turkish Lira",
+    "description": "TST to Turkish Lira spot trading pair",
+    "tags": [
+      "tst",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "TSTUSDC": {
+    "normalized_id": "TST/USD",
+    "base": "TST",
+    "quote": "USD",
+    "display_name": "TST / US Dollar",
+    "description": "TST to US Dollar spot trading pair",
+    "tags": [
+      "tst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TSTUSDT": {
+    "normalized_id": "TST/USD",
+    "base": "TST",
+    "quote": "USD",
+    "display_name": "TST / US Dollar",
+    "description": "TST to US Dollar spot trading pair",
+    "tags": [
+      "tst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TURBOTRY": {
+    "normalized_id": "TURBO/TRY",
+    "base": "TURBO",
+    "quote": "TRY",
+    "display_name": "TURBO / Turkish Lira",
+    "description": "TURBO to Turkish Lira spot trading pair",
+    "tags": [
+      "turbo",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "TURBOUSDC": {
+    "normalized_id": "TURBO/USD",
+    "base": "TURBO",
+    "quote": "USD",
+    "display_name": "TURBO / US Dollar",
+    "description": "TURBO to US Dollar spot trading pair",
+    "tags": [
+      "turbo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TURBOUSDT": {
+    "normalized_id": "TURBO/USD",
+    "base": "TURBO",
+    "quote": "USD",
+    "display_name": "TURBO / US Dollar",
+    "description": "TURBO to US Dollar spot trading pair",
+    "tags": [
+      "turbo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TUSDC": {
+    "normalized_id": "T/USD",
+    "base": "T",
+    "quote": "USD",
+    "display_name": "T / US Dollar",
+    "description": "T to US Dollar spot trading pair",
+    "tags": [
+      "t",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TUSDT": {
+    "normalized_id": "T/USD",
+    "base": "T",
+    "quote": "USD",
+    "display_name": "T / US Dollar",
+    "description": "T to US Dollar spot trading pair",
+    "tags": [
+      "t",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TUSDUSDT": {
+    "normalized_id": "TUSD/USD",
+    "base": "TUSD",
+    "quote": "USD",
+    "display_name": "TUSD / US Dollar",
+    "description": "TUSD to US Dollar spot trading pair",
+    "tags": [
+      "tusd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TUTUSDC": {
+    "normalized_id": "TUT/USD",
+    "base": "TUT",
+    "quote": "USD",
+    "display_name": "TUT / US Dollar",
+    "description": "TUT to US Dollar spot trading pair",
+    "tags": [
+      "tut",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TUTUSDT": {
+    "normalized_id": "TUT/USD",
+    "base": "TUT",
+    "quote": "USD",
+    "display_name": "TUT / US Dollar",
+    "description": "TUT to US Dollar spot trading pair",
+    "tags": [
+      "tut",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TWTTRY": {
+    "normalized_id": "TWT/TRY",
+    "base": "TWT",
+    "quote": "TRY",
+    "display_name": "TWT / Turkish Lira",
+    "description": "TWT to Turkish Lira spot trading pair",
+    "tags": [
+      "twt",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "TWTUSDT": {
+    "normalized_id": "TWT/USD",
+    "base": "TWT",
+    "quote": "USD",
+    "display_name": "TWT / US Dollar",
+    "description": "TWT to US Dollar spot trading pair",
+    "tags": [
+      "twt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UMABTC": {
+    "normalized_id": "UMA/BTC",
+    "base": "UMA",
+    "quote": "BTC",
+    "display_name": "UMA / Bitcoin",
+    "description": "UMA to Bitcoin spot trading pair",
+    "tags": [
+      "uma",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "UMATRY": {
+    "normalized_id": "UMA/TRY",
+    "base": "UMA",
+    "quote": "TRY",
+    "display_name": "UMA / Turkish Lira",
+    "description": "UMA to Turkish Lira spot trading pair",
+    "tags": [
+      "uma",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "UMAUSDT": {
+    "normalized_id": "UMA/USD",
+    "base": "UMA",
+    "quote": "USD",
+    "display_name": "UMA / US Dollar",
+    "description": "UMA to US Dollar spot trading pair",
+    "tags": [
+      "uma",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UNIBTC": {
+    "normalized_id": "UNI/BTC",
+    "base": "UNI",
+    "quote": "BTC",
+    "display_name": "Uniswap / Bitcoin",
+    "description": "Uniswap to Bitcoin spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "UNIETH": {
+    "normalized_id": "UNI/ETH",
+    "base": "UNI",
+    "quote": "ETH",
+    "display_name": "Uniswap / Ethereum",
+    "description": "Uniswap to Ethereum spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "UNIFDUSD": {
+    "normalized_id": "UNI/USD",
+    "base": "UNI",
+    "quote": "USD",
+    "display_name": "Uniswap / US Dollar",
+    "description": "Uniswap to US Dollar spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UNITRY": {
+    "normalized_id": "UNI/TRY",
+    "base": "UNI",
+    "quote": "TRY",
+    "display_name": "Uniswap / Turkish Lira",
+    "description": "Uniswap to Turkish Lira spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "UNIUSDC": {
+    "normalized_id": "UNI/USD",
+    "base": "UNI",
+    "quote": "USD",
+    "display_name": "Uniswap / US Dollar",
+    "description": "Uniswap to US Dollar spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UNIUSDT": {
+    "normalized_id": "UNI/USD",
+    "base": "UNI",
+    "quote": "USD",
+    "display_name": "Uniswap / US Dollar",
+    "description": "Uniswap to US Dollar spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USD1USDT": {
+    "normalized_id": "USD1/USD",
+    "base": "USD1",
+    "quote": "USD",
+    "display_name": "USD1 / US Dollar",
+    "description": "USD1 to US Dollar spot trading pair",
+    "tags": [
+      "usd1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDCBRL": {
+    "normalized_id": "USDC/BRL",
+    "base": "USDC",
+    "quote": "BRL",
+    "display_name": "USD Coin / Brazilian Real",
+    "description": "USD Coin to Brazilian Real spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "USDCTRY": {
+    "normalized_id": "USDC/TRY",
+    "base": "USDC",
+    "quote": "TRY",
+    "display_name": "USD Coin / Turkish Lira",
+    "description": "USD Coin to Turkish Lira spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "USDCUSDT": {
+    "normalized_id": "USDC/USD",
+    "base": "USDC",
+    "quote": "USD",
+    "display_name": "USD Coin / US Dollar",
+    "description": "USD Coin to US Dollar spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDPUSDT": {
+    "normalized_id": "USDP/USD",
+    "base": "USDP",
+    "quote": "USD",
+    "display_name": "USDP / US Dollar",
+    "description": "USDP to US Dollar spot trading pair",
+    "tags": [
+      "usdp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDTBRL": {
+    "normalized_id": "USDT/BRL",
+    "base": "USDT",
+    "quote": "BRL",
+    "display_name": "Tether / Brazilian Real",
+    "description": "Tether to Brazilian Real spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "USDTTRY": {
+    "normalized_id": "USDT/TRY",
+    "base": "USDT",
+    "quote": "TRY",
+    "display_name": "Tether / Turkish Lira",
+    "description": "Tether to Turkish Lira spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "USTCTRY": {
+    "normalized_id": "USTC/TRY",
+    "base": "USTC",
+    "quote": "TRY",
+    "display_name": "USTC / Turkish Lira",
+    "description": "USTC to Turkish Lira spot trading pair",
+    "tags": [
+      "ustc",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "USTCUSDT": {
+    "normalized_id": "USTC/USD",
+    "base": "USTC",
+    "quote": "USD",
+    "display_name": "USTC / US Dollar",
+    "description": "USTC to US Dollar spot trading pair",
+    "tags": [
+      "ustc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USUALBTC": {
+    "normalized_id": "USUAL/BTC",
+    "base": "USUAL",
+    "quote": "BTC",
+    "display_name": "USUAL / Bitcoin",
+    "description": "USUAL to Bitcoin spot trading pair",
+    "tags": [
+      "usual",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "USUALFDUSD": {
+    "normalized_id": "USUAL/USD",
+    "base": "USUAL",
+    "quote": "USD",
+    "display_name": "USUAL / US Dollar",
+    "description": "USUAL to US Dollar spot trading pair",
+    "tags": [
+      "usual",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USUALTRY": {
+    "normalized_id": "USUAL/TRY",
+    "base": "USUAL",
+    "quote": "TRY",
+    "display_name": "USUAL / Turkish Lira",
+    "description": "USUAL to Turkish Lira spot trading pair",
+    "tags": [
+      "usual",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "USUALUSDC": {
+    "normalized_id": "USUAL/USD",
+    "base": "USUAL",
+    "quote": "USD",
+    "display_name": "USUAL / US Dollar",
+    "description": "USUAL to US Dollar spot trading pair",
+    "tags": [
+      "usual",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USUALUSDT": {
+    "normalized_id": "USUAL/USD",
+    "base": "USUAL",
+    "quote": "USD",
+    "display_name": "USUAL / US Dollar",
+    "description": "USUAL to US Dollar spot trading pair",
+    "tags": [
+      "usual",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UTKUSDC": {
+    "normalized_id": "UTK/USD",
+    "base": "UTK",
+    "quote": "USD",
+    "display_name": "UTK / US Dollar",
+    "description": "UTK to US Dollar spot trading pair",
+    "tags": [
+      "utk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UTKUSDT": {
+    "normalized_id": "UTK/USD",
+    "base": "UTK",
+    "quote": "USD",
+    "display_name": "UTK / US Dollar",
+    "description": "UTK to US Dollar spot trading pair",
+    "tags": [
+      "utk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VANAFDUSD": {
+    "normalized_id": "VANA/USD",
+    "base": "VANA",
+    "quote": "USD",
+    "display_name": "VANA / US Dollar",
+    "description": "VANA to US Dollar spot trading pair",
+    "tags": [
+      "vana",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VANATRY": {
+    "normalized_id": "VANA/TRY",
+    "base": "VANA",
+    "quote": "TRY",
+    "display_name": "VANA / Turkish Lira",
+    "description": "VANA to Turkish Lira spot trading pair",
+    "tags": [
+      "vana",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "VANAUSDC": {
+    "normalized_id": "VANA/USD",
+    "base": "VANA",
+    "quote": "USD",
+    "display_name": "VANA / US Dollar",
+    "description": "VANA to US Dollar spot trading pair",
+    "tags": [
+      "vana",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VANAUSDT": {
+    "normalized_id": "VANA/USD",
+    "base": "VANA",
+    "quote": "USD",
+    "display_name": "VANA / US Dollar",
+    "description": "VANA to US Dollar spot trading pair",
+    "tags": [
+      "vana",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VANRYTRY": {
+    "normalized_id": "VANRY/TRY",
+    "base": "VANRY",
+    "quote": "TRY",
+    "display_name": "VANRY / Turkish Lira",
+    "description": "VANRY to Turkish Lira spot trading pair",
+    "tags": [
+      "vanry",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "VANRYUSDC": {
+    "normalized_id": "VANRY/USD",
+    "base": "VANRY",
+    "quote": "USD",
+    "display_name": "VANRY / US Dollar",
+    "description": "VANRY to US Dollar spot trading pair",
+    "tags": [
+      "vanry",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VANRYUSDT": {
+    "normalized_id": "VANRY/USD",
+    "base": "VANRY",
+    "quote": "USD",
+    "display_name": "VANRY / US Dollar",
+    "description": "VANRY to US Dollar spot trading pair",
+    "tags": [
+      "vanry",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VELODROMEUSDC": {
+    "normalized_id": "VELODROME/USD",
+    "base": "VELODROME",
+    "quote": "USD",
+    "display_name": "VELODROME / US Dollar",
+    "description": "VELODROME to US Dollar spot trading pair",
+    "tags": [
+      "velodrome",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VELODROMEUSDT": {
+    "normalized_id": "VELODROME/USD",
+    "base": "VELODROME",
+    "quote": "USD",
+    "display_name": "VELODROME / US Dollar",
+    "description": "VELODROME to US Dollar spot trading pair",
+    "tags": [
+      "velodrome",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VETBNB": {
+    "normalized_id": "VET/BNB",
+    "base": "VET",
+    "quote": "BNB",
+    "display_name": "VeChain / Binance Coin",
+    "description": "VeChain to Binance Coin spot trading pair",
+    "tags": [
+      "vet",
+      "vechain",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "VETBTC": {
+    "normalized_id": "VET/BTC",
+    "base": "VET",
+    "quote": "BTC",
+    "display_name": "VeChain / Bitcoin",
+    "description": "VeChain to Bitcoin spot trading pair",
+    "tags": [
+      "vet",
+      "vechain",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "VETETH": {
+    "normalized_id": "VET/ETH",
+    "base": "VET",
+    "quote": "ETH",
+    "display_name": "VeChain / Ethereum",
+    "description": "VeChain to Ethereum spot trading pair",
+    "tags": [
+      "vet",
+      "vechain",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "VETEUR": {
+    "normalized_id": "VET/EUR",
+    "base": "VET",
+    "quote": "EUR",
+    "display_name": "VeChain / Euro",
+    "description": "VeChain to Euro spot trading pair",
+    "tags": [
+      "vet",
+      "vechain",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "VETTRY": {
+    "normalized_id": "VET/TRY",
+    "base": "VET",
+    "quote": "TRY",
+    "display_name": "VeChain / Turkish Lira",
+    "description": "VeChain to Turkish Lira spot trading pair",
+    "tags": [
+      "vet",
+      "vechain",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "VETUSDC": {
+    "normalized_id": "VET/USD",
+    "base": "VET",
+    "quote": "USD",
+    "display_name": "VeChain / US Dollar",
+    "description": "VeChain to US Dollar spot trading pair",
+    "tags": [
+      "vet",
+      "vechain",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VETUSDT": {
+    "normalized_id": "VET/USD",
+    "base": "VET",
+    "quote": "USD",
+    "display_name": "VeChain / US Dollar",
+    "description": "VeChain to US Dollar spot trading pair",
+    "tags": [
+      "vet",
+      "vechain",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VICTRY": {
+    "normalized_id": "VIC/TRY",
+    "base": "VIC",
+    "quote": "TRY",
+    "display_name": "VIC / Turkish Lira",
+    "description": "VIC to Turkish Lira spot trading pair",
+    "tags": [
+      "vic",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "VICUSDT": {
+    "normalized_id": "VIC/USD",
+    "base": "VIC",
+    "quote": "USD",
+    "display_name": "VIC / US Dollar",
+    "description": "VIC to US Dollar spot trading pair",
+    "tags": [
+      "vic",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VIRTUALTRY": {
+    "normalized_id": "VIRTUAL/TRY",
+    "base": "VIRTUAL",
+    "quote": "TRY",
+    "display_name": "VIRTUAL / Turkish Lira",
+    "description": "VIRTUAL to Turkish Lira spot trading pair",
+    "tags": [
+      "virtual",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "VIRTUALUSDC": {
+    "normalized_id": "VIRTUAL/USD",
+    "base": "VIRTUAL",
+    "quote": "USD",
+    "display_name": "VIRTUAL / US Dollar",
+    "description": "VIRTUAL to US Dollar spot trading pair",
+    "tags": [
+      "virtual",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VIRTUALUSDT": {
+    "normalized_id": "VIRTUAL/USD",
+    "base": "VIRTUAL",
+    "quote": "USD",
+    "display_name": "VIRTUAL / US Dollar",
+    "description": "VIRTUAL to US Dollar spot trading pair",
+    "tags": [
+      "virtual",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VOXELUSDT": {
+    "normalized_id": "VOXEL/USD",
+    "base": "VOXEL",
+    "quote": "USD",
+    "display_name": "VOXEL / US Dollar",
+    "description": "VOXEL to US Dollar spot trading pair",
+    "tags": [
+      "voxel",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VTHOTRY": {
+    "normalized_id": "VTHO/TRY",
+    "base": "VTHO",
+    "quote": "TRY",
+    "display_name": "VTHO / Turkish Lira",
+    "description": "VTHO to Turkish Lira spot trading pair",
+    "tags": [
+      "vtho",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "VTHOUSDT": {
+    "normalized_id": "VTHO/USD",
+    "base": "VTHO",
+    "quote": "USD",
+    "display_name": "VTHO / US Dollar",
+    "description": "VTHO to US Dollar spot trading pair",
+    "tags": [
+      "vtho",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WANBTC": {
+    "normalized_id": "WAN/BTC",
+    "base": "WAN",
+    "quote": "BTC",
+    "display_name": "WAN / Bitcoin",
+    "description": "WAN to Bitcoin spot trading pair",
+    "tags": [
+      "wan",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "WANUSDT": {
+    "normalized_id": "WAN/USD",
+    "base": "WAN",
+    "quote": "USD",
+    "display_name": "WAN / US Dollar",
+    "description": "WAN to US Dollar spot trading pair",
+    "tags": [
+      "wan",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WAXPUSDT": {
+    "normalized_id": "WAXP/USD",
+    "base": "WAXP",
+    "quote": "USD",
+    "display_name": "WAXP / US Dollar",
+    "description": "WAXP to US Dollar spot trading pair",
+    "tags": [
+      "waxp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WBETHETH": {
+    "normalized_id": "WBETH/ETH",
+    "base": "WBETH",
+    "quote": "ETH",
+    "display_name": "WBETH / Ethereum",
+    "description": "WBETH to Ethereum spot trading pair",
+    "tags": [
+      "wbeth",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "WBETHUSDT": {
+    "normalized_id": "WBETH/USD",
+    "base": "WBETH",
+    "quote": "USD",
+    "display_name": "WBETH / US Dollar",
+    "description": "WBETH to US Dollar spot trading pair",
+    "tags": [
+      "wbeth",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WBTC": {
+    "normalized_id": "W/BTC",
+    "base": "W",
+    "quote": "BTC",
+    "display_name": "W / Bitcoin",
+    "description": "W to Bitcoin spot trading pair",
+    "tags": [
+      "w",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "WBTCBTC": {
+    "normalized_id": "WBTC/BTC",
+    "base": "WBTC",
+    "quote": "BTC",
+    "display_name": "WBTC / Bitcoin",
+    "description": "WBTC to Bitcoin spot trading pair",
+    "tags": [
+      "wbtc",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "WBTCETH": {
+    "normalized_id": "WBTC/ETH",
+    "base": "WBTC",
+    "quote": "ETH",
+    "display_name": "WBTC / Ethereum",
+    "description": "WBTC to Ethereum spot trading pair",
+    "tags": [
+      "wbtc",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "WBTCUSDT": {
+    "normalized_id": "WBTC/USD",
+    "base": "WBTC",
+    "quote": "USD",
+    "display_name": "WBTC / US Dollar",
+    "description": "WBTC to US Dollar spot trading pair",
+    "tags": [
+      "wbtc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WCTBNB": {
+    "normalized_id": "WCT/BNB",
+    "base": "WCT",
+    "quote": "BNB",
+    "display_name": "WCT / Binance Coin",
+    "description": "WCT to Binance Coin spot trading pair",
+    "tags": [
+      "wct",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "WCTFDUSD": {
+    "normalized_id": "WCT/USD",
+    "base": "WCT",
+    "quote": "USD",
+    "display_name": "WCT / US Dollar",
+    "description": "WCT to US Dollar spot trading pair",
+    "tags": [
+      "wct",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WCTTRY": {
+    "normalized_id": "WCT/TRY",
+    "base": "WCT",
+    "quote": "TRY",
+    "display_name": "WCT / Turkish Lira",
+    "description": "WCT to Turkish Lira spot trading pair",
+    "tags": [
+      "wct",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "WCTUSDC": {
+    "normalized_id": "WCT/USD",
+    "base": "WCT",
+    "quote": "USD",
+    "display_name": "WCT / US Dollar",
+    "description": "WCT to US Dollar spot trading pair",
+    "tags": [
+      "wct",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WCTUSDT": {
+    "normalized_id": "WCT/USD",
+    "base": "WCT",
+    "quote": "USD",
+    "display_name": "WCT / US Dollar",
+    "description": "WCT to US Dollar spot trading pair",
+    "tags": [
+      "wct",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WFDUSD": {
+    "normalized_id": "W/USD",
+    "base": "W",
+    "quote": "USD",
+    "display_name": "W / US Dollar",
+    "description": "W to US Dollar spot trading pair",
+    "tags": [
+      "w",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WIFBRL": {
+    "normalized_id": "WIF/BRL",
+    "base": "WIF",
+    "quote": "BRL",
+    "display_name": "dogwifhat / Brazilian Real",
+    "description": "dogwifhat to Brazilian Real spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "WIFBTC": {
+    "normalized_id": "WIF/BTC",
+    "base": "WIF",
+    "quote": "BTC",
+    "display_name": "dogwifhat / Bitcoin",
+    "description": "dogwifhat to Bitcoin spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "WIFEUR": {
+    "normalized_id": "WIF/EUR",
+    "base": "WIF",
+    "quote": "EUR",
+    "display_name": "dogwifhat / Euro",
+    "description": "dogwifhat to Euro spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "WIFFDUSD": {
+    "normalized_id": "WIF/USD",
+    "base": "WIF",
+    "quote": "USD",
+    "display_name": "dogwifhat / US Dollar",
+    "description": "dogwifhat to US Dollar spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WIFTRY": {
+    "normalized_id": "WIF/TRY",
+    "base": "WIF",
+    "quote": "TRY",
+    "display_name": "dogwifhat / Turkish Lira",
+    "description": "dogwifhat to Turkish Lira spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "WIFUSDC": {
+    "normalized_id": "WIF/USD",
+    "base": "WIF",
+    "quote": "USD",
+    "display_name": "dogwifhat / US Dollar",
+    "description": "dogwifhat to US Dollar spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WIFUSDT": {
+    "normalized_id": "WIF/USD",
+    "base": "WIF",
+    "quote": "USD",
+    "display_name": "dogwifhat / US Dollar",
+    "description": "dogwifhat to US Dollar spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WINEUR": {
+    "normalized_id": "WIN/EUR",
+    "base": "WIN",
+    "quote": "EUR",
+    "display_name": "WIN / Euro",
+    "description": "WIN to Euro spot trading pair",
+    "tags": [
+      "win",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "WINUSDT": {
+    "normalized_id": "WIN/USD",
+    "base": "WIN",
+    "quote": "USD",
+    "display_name": "WIN / US Dollar",
+    "description": "WIN to US Dollar spot trading pair",
+    "tags": [
+      "win",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WLDBTC": {
+    "normalized_id": "WLD/BTC",
+    "base": "WLD",
+    "quote": "BTC",
+    "display_name": "WLD / Bitcoin",
+    "description": "WLD to Bitcoin spot trading pair",
+    "tags": [
+      "wld",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "WLDEUR": {
+    "normalized_id": "WLD/EUR",
+    "base": "WLD",
+    "quote": "EUR",
+    "display_name": "WLD / Euro",
+    "description": "WLD to Euro spot trading pair",
+    "tags": [
+      "wld",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "WLDFDUSD": {
+    "normalized_id": "WLD/USD",
+    "base": "WLD",
+    "quote": "USD",
+    "display_name": "WLD / US Dollar",
+    "description": "WLD to US Dollar spot trading pair",
+    "tags": [
+      "wld",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WLDTRY": {
+    "normalized_id": "WLD/TRY",
+    "base": "WLD",
+    "quote": "TRY",
+    "display_name": "WLD / Turkish Lira",
+    "description": "WLD to Turkish Lira spot trading pair",
+    "tags": [
+      "wld",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "WLDUSDC": {
+    "normalized_id": "WLD/USD",
+    "base": "WLD",
+    "quote": "USD",
+    "display_name": "WLD / US Dollar",
+    "description": "WLD to US Dollar spot trading pair",
+    "tags": [
+      "wld",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WLDUSDT": {
+    "normalized_id": "WLD/USD",
+    "base": "WLD",
+    "quote": "USD",
+    "display_name": "WLD / US Dollar",
+    "description": "WLD to US Dollar spot trading pair",
+    "tags": [
+      "wld",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WOOUSDT": {
+    "normalized_id": "WOO/USD",
+    "base": "WOO",
+    "quote": "USD",
+    "display_name": "WOO / US Dollar",
+    "description": "WOO to US Dollar spot trading pair",
+    "tags": [
+      "woo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WTRY": {
+    "normalized_id": "W/TRY",
+    "base": "W",
+    "quote": "TRY",
+    "display_name": "W / Turkish Lira",
+    "description": "W to Turkish Lira spot trading pair",
+    "tags": [
+      "w",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "WUSDC": {
+    "normalized_id": "W/USD",
+    "base": "W",
+    "quote": "USD",
+    "display_name": "W / US Dollar",
+    "description": "W to US Dollar spot trading pair",
+    "tags": [
+      "w",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WUSDT": {
+    "normalized_id": "W/USD",
+    "base": "W",
+    "quote": "USD",
+    "display_name": "W / US Dollar",
+    "description": "W to US Dollar spot trading pair",
+    "tags": [
+      "w",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XAITRY": {
+    "normalized_id": "XAI/TRY",
+    "base": "XAI",
+    "quote": "TRY",
+    "display_name": "XAI / Turkish Lira",
+    "description": "XAI to Turkish Lira spot trading pair",
+    "tags": [
+      "xai",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "XAIUSDC": {
+    "normalized_id": "XAI/USD",
+    "base": "XAI",
+    "quote": "USD",
+    "display_name": "XAI / US Dollar",
+    "description": "XAI to US Dollar spot trading pair",
+    "tags": [
+      "xai",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XAIUSDT": {
+    "normalized_id": "XAI/USD",
+    "base": "XAI",
+    "quote": "USD",
+    "display_name": "XAI / US Dollar",
+    "description": "XAI to US Dollar spot trading pair",
+    "tags": [
+      "xai",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XECTRY": {
+    "normalized_id": "XEC/TRY",
+    "base": "XEC",
+    "quote": "TRY",
+    "display_name": "XEC / Turkish Lira",
+    "description": "XEC to Turkish Lira spot trading pair",
+    "tags": [
+      "xec",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "XECUSDT": {
+    "normalized_id": "XEC/USD",
+    "base": "XEC",
+    "quote": "USD",
+    "display_name": "XEC / US Dollar",
+    "description": "XEC to US Dollar spot trading pair",
+    "tags": [
+      "xec",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XLMBTC": {
+    "normalized_id": "XLM/BTC",
+    "base": "XLM",
+    "quote": "BTC",
+    "display_name": "Stellar / Bitcoin",
+    "description": "Stellar to Bitcoin spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "XLMETH": {
+    "normalized_id": "XLM/ETH",
+    "base": "XLM",
+    "quote": "ETH",
+    "display_name": "Stellar / Ethereum",
+    "description": "Stellar to Ethereum spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "XLMEUR": {
+    "normalized_id": "XLM/EUR",
+    "base": "XLM",
+    "quote": "EUR",
+    "display_name": "Stellar / Euro",
+    "description": "Stellar to Euro spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XLMFDUSD": {
+    "normalized_id": "XLM/USD",
+    "base": "XLM",
+    "quote": "USD",
+    "display_name": "Stellar / US Dollar",
+    "description": "Stellar to US Dollar spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XLMJPY": {
+    "normalized_id": "XLM/JPY",
+    "base": "XLM",
+    "quote": "JPY",
+    "display_name": "Stellar / Japanese Yen",
+    "description": "Stellar to Japanese Yen spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "XLMTRY": {
+    "normalized_id": "XLM/TRY",
+    "base": "XLM",
+    "quote": "TRY",
+    "display_name": "Stellar / Turkish Lira",
+    "description": "Stellar to Turkish Lira spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "XLMUSDC": {
+    "normalized_id": "XLM/USD",
+    "base": "XLM",
+    "quote": "USD",
+    "display_name": "Stellar / US Dollar",
+    "description": "Stellar to US Dollar spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XLMUSDT": {
+    "normalized_id": "XLM/USD",
+    "base": "XLM",
+    "quote": "USD",
+    "display_name": "Stellar / US Dollar",
+    "description": "Stellar to US Dollar spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XNOBTC": {
+    "normalized_id": "XNO/BTC",
+    "base": "XNO",
+    "quote": "BTC",
+    "display_name": "XNO / Bitcoin",
+    "description": "XNO to Bitcoin spot trading pair",
+    "tags": [
+      "xno",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "XNOUSDT": {
+    "normalized_id": "XNO/USD",
+    "base": "XNO",
+    "quote": "USD",
+    "display_name": "XNO / US Dollar",
+    "description": "XNO to US Dollar spot trading pair",
+    "tags": [
+      "xno",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XRPBNB": {
+    "normalized_id": "XRP/BNB",
+    "base": "XRP",
+    "quote": "BNB",
+    "display_name": "Ripple / Binance Coin",
+    "description": "Ripple to Binance Coin spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "XRPBRL": {
+    "normalized_id": "XRP/BRL",
+    "base": "XRP",
+    "quote": "BRL",
+    "display_name": "Ripple / Brazilian Real",
+    "description": "Ripple to Brazilian Real spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "XRPBTC": {
+    "normalized_id": "XRP/BTC",
+    "base": "XRP",
+    "quote": "BTC",
+    "display_name": "Ripple / Bitcoin",
+    "description": "Ripple to Bitcoin spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "XRPETH": {
+    "normalized_id": "XRP/ETH",
+    "base": "XRP",
+    "quote": "ETH",
+    "display_name": "Ripple / Ethereum",
+    "description": "Ripple to Ethereum spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "XRPEUR": {
+    "normalized_id": "XRP/EUR",
+    "base": "XRP",
+    "quote": "EUR",
+    "display_name": "Ripple / Euro",
+    "description": "Ripple to Euro spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XRPFDUSD": {
+    "normalized_id": "XRP/USD",
+    "base": "XRP",
+    "quote": "USD",
+    "display_name": "Ripple / US Dollar",
+    "description": "Ripple to US Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XRPJPY": {
+    "normalized_id": "XRP/JPY",
+    "base": "XRP",
+    "quote": "JPY",
+    "display_name": "Ripple / Japanese Yen",
+    "description": "Ripple to Japanese Yen spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "XRPTRY": {
+    "normalized_id": "XRP/TRY",
+    "base": "XRP",
+    "quote": "TRY",
+    "display_name": "Ripple / Turkish Lira",
+    "description": "Ripple to Turkish Lira spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "XRPUSDC": {
+    "normalized_id": "XRP/USD",
+    "base": "XRP",
+    "quote": "USD",
+    "display_name": "Ripple / US Dollar",
+    "description": "Ripple to US Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XRPUSDT": {
+    "normalized_id": "XRP/USD",
+    "base": "XRP",
+    "quote": "USD",
+    "display_name": "Ripple / US Dollar",
+    "description": "Ripple to US Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XTZBTC": {
+    "normalized_id": "XTZ/BTC",
+    "base": "XTZ",
+    "quote": "BTC",
+    "display_name": "Tezos / Bitcoin",
+    "description": "Tezos to Bitcoin spot trading pair",
+    "tags": [
+      "xtz",
+      "tezos",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "XTZUSDC": {
+    "normalized_id": "XTZ/USD",
+    "base": "XTZ",
+    "quote": "USD",
+    "display_name": "Tezos / US Dollar",
+    "description": "Tezos to US Dollar spot trading pair",
+    "tags": [
+      "xtz",
+      "tezos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XTZUSDT": {
+    "normalized_id": "XTZ/USD",
+    "base": "XTZ",
+    "quote": "USD",
+    "display_name": "Tezos / US Dollar",
+    "description": "Tezos to US Dollar spot trading pair",
+    "tags": [
+      "xtz",
+      "tezos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XUSDUSDT": {
+    "normalized_id": "XUSD/USD",
+    "base": "XUSD",
+    "quote": "USD",
+    "display_name": "XUSD / US Dollar",
+    "description": "XUSD to US Dollar spot trading pair",
+    "tags": [
+      "xusd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XVGETH": {
+    "normalized_id": "XVG/ETH",
+    "base": "XVG",
+    "quote": "ETH",
+    "display_name": "XVG / Ethereum",
+    "description": "XVG to Ethereum spot trading pair",
+    "tags": [
+      "xvg",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "XVGTRY": {
+    "normalized_id": "XVG/TRY",
+    "base": "XVG",
+    "quote": "TRY",
+    "display_name": "XVG / Turkish Lira",
+    "description": "XVG to Turkish Lira spot trading pair",
+    "tags": [
+      "xvg",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "XVGUSDT": {
+    "normalized_id": "XVG/USD",
+    "base": "XVG",
+    "quote": "USD",
+    "display_name": "XVG / US Dollar",
+    "description": "XVG to US Dollar spot trading pair",
+    "tags": [
+      "xvg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XVSBNB": {
+    "normalized_id": "XVS/BNB",
+    "base": "XVS",
+    "quote": "BNB",
+    "display_name": "XVS / Binance Coin",
+    "description": "XVS to Binance Coin spot trading pair",
+    "tags": [
+      "xvs",
+      "bnb"
+    ],
+    "category": "crypto"
+  },
+  "XVSBTC": {
+    "normalized_id": "XVS/BTC",
+    "base": "XVS",
+    "quote": "BTC",
+    "display_name": "XVS / Bitcoin",
+    "description": "XVS to Bitcoin spot trading pair",
+    "tags": [
+      "xvs",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "XVSUSDT": {
+    "normalized_id": "XVS/USD",
+    "base": "XVS",
+    "quote": "USD",
+    "display_name": "XVS / US Dollar",
+    "description": "XVS to US Dollar spot trading pair",
+    "tags": [
+      "xvs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "YFIBTC": {
+    "normalized_id": "YFI/BTC",
+    "base": "YFI",
+    "quote": "BTC",
+    "display_name": "YFI / Bitcoin",
+    "description": "YFI to Bitcoin spot trading pair",
+    "tags": [
+      "yfi",
+      "defi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "YFIUSDT": {
+    "normalized_id": "YFI/USD",
+    "base": "YFI",
+    "quote": "USD",
+    "display_name": "YFI / US Dollar",
+    "description": "YFI to US Dollar spot trading pair",
+    "tags": [
+      "yfi",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "YGGBTC": {
+    "normalized_id": "YGG/BTC",
+    "base": "YGG",
+    "quote": "BTC",
+    "display_name": "YGG / Bitcoin",
+    "description": "YGG to Bitcoin spot trading pair",
+    "tags": [
+      "ygg",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "YGGUSDC": {
+    "normalized_id": "YGG/USD",
+    "base": "YGG",
+    "quote": "USD",
+    "display_name": "YGG / US Dollar",
+    "description": "YGG to US Dollar spot trading pair",
+    "tags": [
+      "ygg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "YGGUSDT": {
+    "normalized_id": "YGG/USD",
+    "base": "YGG",
+    "quote": "USD",
+    "display_name": "YGG / US Dollar",
+    "description": "YGG to US Dollar spot trading pair",
+    "tags": [
+      "ygg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZECBTC": {
+    "normalized_id": "ZEC/BTC",
+    "base": "ZEC",
+    "quote": "BTC",
+    "display_name": "ZEC / Bitcoin",
+    "description": "ZEC to Bitcoin spot trading pair",
+    "tags": [
+      "zec",
+      "privacy",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ZECETH": {
+    "normalized_id": "ZEC/ETH",
+    "base": "ZEC",
+    "quote": "ETH",
+    "display_name": "ZEC / Ethereum",
+    "description": "ZEC to Ethereum spot trading pair",
+    "tags": [
+      "zec",
+      "privacy",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "ZECUSDT": {
+    "normalized_id": "ZEC/USD",
+    "base": "ZEC",
+    "quote": "USD",
+    "display_name": "ZEC / US Dollar",
+    "description": "ZEC to US Dollar spot trading pair",
+    "tags": [
+      "zec",
+      "privacy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZENBTC": {
+    "normalized_id": "ZEN/BTC",
+    "base": "ZEN",
+    "quote": "BTC",
+    "display_name": "ZEN / Bitcoin",
+    "description": "ZEN to Bitcoin spot trading pair",
+    "tags": [
+      "zen",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ZENUSDC": {
+    "normalized_id": "ZEN/USD",
+    "base": "ZEN",
+    "quote": "USD",
+    "display_name": "ZEN / US Dollar",
+    "description": "ZEN to US Dollar spot trading pair",
+    "tags": [
+      "zen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZENUSDT": {
+    "normalized_id": "ZEN/USD",
+    "base": "ZEN",
+    "quote": "USD",
+    "display_name": "ZEN / US Dollar",
+    "description": "ZEN to US Dollar spot trading pair",
+    "tags": [
+      "zen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZILETH": {
+    "normalized_id": "ZIL/ETH",
+    "base": "ZIL",
+    "quote": "ETH",
+    "display_name": "ZIL / Ethereum",
+    "description": "ZIL to Ethereum spot trading pair",
+    "tags": [
+      "zil",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "ZILTRY": {
+    "normalized_id": "ZIL/TRY",
+    "base": "ZIL",
+    "quote": "TRY",
+    "display_name": "ZIL / Turkish Lira",
+    "description": "ZIL to Turkish Lira spot trading pair",
+    "tags": [
+      "zil",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ZILUSDT": {
+    "normalized_id": "ZIL/USD",
+    "base": "ZIL",
+    "quote": "USD",
+    "display_name": "ZIL / US Dollar",
+    "description": "ZIL to US Dollar spot trading pair",
+    "tags": [
+      "zil",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZKBTC": {
+    "normalized_id": "ZK/BTC",
+    "base": "ZK",
+    "quote": "BTC",
+    "display_name": "ZK / Bitcoin",
+    "description": "ZK to Bitcoin spot trading pair",
+    "tags": [
+      "zk",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ZKFDUSD": {
+    "normalized_id": "ZK/USD",
+    "base": "ZK",
+    "quote": "USD",
+    "display_name": "ZK / US Dollar",
+    "description": "ZK to US Dollar spot trading pair",
+    "tags": [
+      "zk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZKTRY": {
+    "normalized_id": "ZK/TRY",
+    "base": "ZK",
+    "quote": "TRY",
+    "display_name": "ZK / Turkish Lira",
+    "description": "ZK to Turkish Lira spot trading pair",
+    "tags": [
+      "zk",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ZKUSDC": {
+    "normalized_id": "ZK/USD",
+    "base": "ZK",
+    "quote": "USD",
+    "display_name": "ZK / US Dollar",
+    "description": "ZK to US Dollar spot trading pair",
+    "tags": [
+      "zk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZKUSDT": {
+    "normalized_id": "ZK/USD",
+    "base": "ZK",
+    "quote": "USD",
+    "display_name": "ZK / US Dollar",
+    "description": "ZK to US Dollar spot trading pair",
+    "tags": [
+      "zk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZROBTC": {
+    "normalized_id": "ZRO/BTC",
+    "base": "ZRO",
+    "quote": "BTC",
+    "display_name": "ZRO / Bitcoin",
+    "description": "ZRO to Bitcoin spot trading pair",
+    "tags": [
+      "zro",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ZROFDUSD": {
+    "normalized_id": "ZRO/USD",
+    "base": "ZRO",
+    "quote": "USD",
+    "display_name": "ZRO / US Dollar",
+    "description": "ZRO to US Dollar spot trading pair",
+    "tags": [
+      "zro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZROTRY": {
+    "normalized_id": "ZRO/TRY",
+    "base": "ZRO",
+    "quote": "TRY",
+    "display_name": "ZRO / Turkish Lira",
+    "description": "ZRO to Turkish Lira spot trading pair",
+    "tags": [
+      "zro",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ZROUSDC": {
+    "normalized_id": "ZRO/USD",
+    "base": "ZRO",
+    "quote": "USD",
+    "display_name": "ZRO / US Dollar",
+    "description": "ZRO to US Dollar spot trading pair",
+    "tags": [
+      "zro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZROUSDT": {
+    "normalized_id": "ZRO/USD",
+    "base": "ZRO",
+    "quote": "USD",
+    "display_name": "ZRO / US Dollar",
+    "description": "ZRO to US Dollar spot trading pair",
+    "tags": [
+      "zro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZRXBTC": {
+    "normalized_id": "ZRX/BTC",
+    "base": "ZRX",
+    "quote": "BTC",
+    "display_name": "0x / Bitcoin",
+    "description": "0x to Bitcoin spot trading pair",
+    "tags": [
+      "zrx",
+      "0x",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ZRXUSDT": {
+    "normalized_id": "ZRX/USD",
+    "base": "ZRX",
+    "quote": "USD",
+    "display_name": "0x / US Dollar",
+    "description": "0x to US Dollar spot trading pair",
+    "tags": [
+      "zrx",
+      "0x",
+      "usd"
+    ],
+    "category": "crypto"
+  }
+}

--- a/server/src/symbols/configs/bitfinex.json
+++ b/server/src/symbols/configs/bitfinex.json
@@ -1,0 +1,3717 @@
+{
+  "tAAVE:USD": {
+    "normalized_id": "AAVE/USD",
+    "base": "AAVE",
+    "quote": "USD",
+    "display_name": "Aave / US Dollar",
+    "description": "Aave to US Dollar spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tAAVE:UST": {
+    "normalized_id": "AAVE/USD",
+    "base": "AAVE",
+    "quote": "USD",
+    "display_name": "Aave / US Dollar",
+    "description": "Aave to US Dollar spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tADABTC": {
+    "normalized_id": "ADA/BTC",
+    "base": "ADA",
+    "quote": "BTC",
+    "display_name": "Cardano / Bitcoin",
+    "description": "Cardano to Bitcoin spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tADAUSD": {
+    "normalized_id": "ADA/USD",
+    "base": "ADA",
+    "quote": "USD",
+    "display_name": "Cardano / US Dollar",
+    "description": "Cardano to US Dollar spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tADAUST": {
+    "normalized_id": "ADA/USD",
+    "base": "ADA",
+    "quote": "USD",
+    "display_name": "Cardano / US Dollar",
+    "description": "Cardano to US Dollar spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tAIOZ:USD": {
+    "normalized_id": "AIOZ/USD",
+    "base": "AIOZ",
+    "quote": "USD",
+    "display_name": "AIOZ / US Dollar",
+    "description": "AIOZ to US Dollar spot trading pair",
+    "tags": [
+      "aioz",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tALGUSD": {
+    "normalized_id": "ALG/USD",
+    "base": "ALG",
+    "quote": "USD",
+    "display_name": "ALG / US Dollar",
+    "description": "ALG to US Dollar spot trading pair",
+    "tags": [
+      "alg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tALT11M250830:USD": {
+    "normalized_id": "ALT11M250830/USD",
+    "base": "ALT11M250830",
+    "quote": "USD",
+    "display_name": "ALT11M250830 / US Dollar",
+    "description": "ALT11M250830 to US Dollar spot trading pair",
+    "tags": [
+      "alt11m250830",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tALT11M250830:UST": {
+    "normalized_id": "ALT11M250830/USD",
+    "base": "ALT11M250830",
+    "quote": "USD",
+    "display_name": "ALT11M250830 / US Dollar",
+    "description": "ALT11M250830 to US Dollar spot trading pair",
+    "tags": [
+      "alt11m250830",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tALT11M251029:USD": {
+    "normalized_id": "ALT11M251029/USD",
+    "base": "ALT11M251029",
+    "quote": "USD",
+    "display_name": "ALT11M251029 / US Dollar",
+    "description": "ALT11M251029 to US Dollar spot trading pair",
+    "tags": [
+      "alt11m251029",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tALT11M251029:UST": {
+    "normalized_id": "ALT11M251029/USD",
+    "base": "ALT11M251029",
+    "quote": "USD",
+    "display_name": "ALT11M251029 / US Dollar",
+    "description": "ALT11M251029 to US Dollar spot trading pair",
+    "tags": [
+      "alt11m251029",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tALT2612:USD": {
+    "normalized_id": "ALT2612/USD",
+    "base": "ALT2612",
+    "quote": "USD",
+    "display_name": "ALT2612 / US Dollar",
+    "description": "ALT2612 to US Dollar spot trading pair",
+    "tags": [
+      "alt2612",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tALT2612:UST": {
+    "normalized_id": "ALT2612/USD",
+    "base": "ALT2612",
+    "quote": "USD",
+    "display_name": "ALT2612 / US Dollar",
+    "description": "ALT2612 to US Dollar spot trading pair",
+    "tags": [
+      "alt2612",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tAMPUSD": {
+    "normalized_id": "AMP/USD",
+    "base": "AMP",
+    "quote": "USD",
+    "display_name": "AMP / US Dollar",
+    "description": "AMP to US Dollar spot trading pair",
+    "tags": [
+      "amp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tAMPUST": {
+    "normalized_id": "AMP/USD",
+    "base": "AMP",
+    "quote": "USD",
+    "display_name": "AMP / US Dollar",
+    "description": "AMP to US Dollar spot trading pair",
+    "tags": [
+      "amp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tAPENFT:USD": {
+    "normalized_id": "APENFT/USD",
+    "base": "APENFT",
+    "quote": "USD",
+    "display_name": "APENFT / US Dollar",
+    "description": "APENFT to US Dollar spot trading pair",
+    "tags": [
+      "apenft",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tAPEUSD": {
+    "normalized_id": "APE/USD",
+    "base": "APE",
+    "quote": "USD",
+    "display_name": "APE / US Dollar",
+    "description": "APE to US Dollar spot trading pair",
+    "tags": [
+      "ape",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tAPEUST": {
+    "normalized_id": "APE/USD",
+    "base": "APE",
+    "quote": "USD",
+    "display_name": "APE / US Dollar",
+    "description": "APE to US Dollar spot trading pair",
+    "tags": [
+      "ape",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tAPTUSD": {
+    "normalized_id": "APT/USD",
+    "base": "APT",
+    "quote": "USD",
+    "display_name": "Aptos / US Dollar",
+    "description": "Aptos to US Dollar spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tAPTUST": {
+    "normalized_id": "APT/USD",
+    "base": "APT",
+    "quote": "USD",
+    "display_name": "Aptos / US Dollar",
+    "description": "Aptos to US Dollar spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tARBUSD": {
+    "normalized_id": "ARB/USD",
+    "base": "ARB",
+    "quote": "USD",
+    "display_name": "Arbitrum / US Dollar",
+    "description": "Arbitrum to US Dollar spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tARBUST": {
+    "normalized_id": "ARB/USD",
+    "base": "ARB",
+    "quote": "USD",
+    "display_name": "Arbitrum / US Dollar",
+    "description": "Arbitrum to US Dollar spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tATHUSD": {
+    "normalized_id": "ATH/USD",
+    "base": "ATH",
+    "quote": "USD",
+    "display_name": "ATH / US Dollar",
+    "description": "ATH to US Dollar spot trading pair",
+    "tags": [
+      "ath",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tATHUST": {
+    "normalized_id": "ATH/USD",
+    "base": "ATH",
+    "quote": "USD",
+    "display_name": "ATH / US Dollar",
+    "description": "ATH to US Dollar spot trading pair",
+    "tags": [
+      "ath",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tATOUSD": {
+    "normalized_id": "ATO/USD",
+    "base": "ATO",
+    "quote": "USD",
+    "display_name": "ATO / US Dollar",
+    "description": "ATO to US Dollar spot trading pair",
+    "tags": [
+      "ato",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tATOUST": {
+    "normalized_id": "ATO/USD",
+    "base": "ATO",
+    "quote": "USD",
+    "display_name": "ATO / US Dollar",
+    "description": "ATO to US Dollar spot trading pair",
+    "tags": [
+      "ato",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tAUSDT:USD": {
+    "normalized_id": "AUSDT/USD",
+    "base": "AUSDT",
+    "quote": "USD",
+    "display_name": "AUSDT / US Dollar",
+    "description": "AUSDT to US Dollar spot trading pair",
+    "tags": [
+      "ausdt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tAUSDT:UST": {
+    "normalized_id": "AUSDT/USD",
+    "base": "AUSDT",
+    "quote": "USD",
+    "display_name": "AUSDT / US Dollar",
+    "description": "AUSDT to US Dollar spot trading pair",
+    "tags": [
+      "ausdt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tAVAX:BTC": {
+    "normalized_id": "AVAX/BTC",
+    "base": "AVAX",
+    "quote": "BTC",
+    "display_name": "Avalanche / Bitcoin",
+    "description": "Avalanche to Bitcoin spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tAVAX:USD": {
+    "normalized_id": "AVAX/USD",
+    "base": "AVAX",
+    "quote": "USD",
+    "display_name": "Avalanche / US Dollar",
+    "description": "Avalanche to US Dollar spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tAVAX:UST": {
+    "normalized_id": "AVAX/USD",
+    "base": "AVAX",
+    "quote": "USD",
+    "display_name": "Avalanche / US Dollar",
+    "description": "Avalanche to US Dollar spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tB2MUSD": {
+    "normalized_id": "B2M/USD",
+    "base": "B2M",
+    "quote": "USD",
+    "display_name": "B2M / US Dollar",
+    "description": "B2M to US Dollar spot trading pair",
+    "tags": [
+      "b2m",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tB2MUST": {
+    "normalized_id": "B2M/USD",
+    "base": "B2M",
+    "quote": "USD",
+    "display_name": "B2M / US Dollar",
+    "description": "B2M to US Dollar spot trading pair",
+    "tags": [
+      "b2m",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tBCHN:USD": {
+    "normalized_id": "BCHN/USD",
+    "base": "BCHN",
+    "quote": "USD",
+    "display_name": "BCHN / US Dollar",
+    "description": "BCHN to US Dollar spot trading pair",
+    "tags": [
+      "bchn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tBGBUSD": {
+    "normalized_id": "BGB/USD",
+    "base": "BGB",
+    "quote": "USD",
+    "display_name": "BGB / US Dollar",
+    "description": "BGB to US Dollar spot trading pair",
+    "tags": [
+      "bgb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tBGBUST": {
+    "normalized_id": "BGB/USD",
+    "base": "BGB",
+    "quote": "USD",
+    "display_name": "BGB / US Dollar",
+    "description": "BGB to US Dollar spot trading pair",
+    "tags": [
+      "bgb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tBMN2:BTC": {
+    "normalized_id": "BMN2/BTC",
+    "base": "BMN2",
+    "quote": "BTC",
+    "display_name": "BMN2 / Bitcoin",
+    "description": "BMN2 to Bitcoin spot trading pair",
+    "tags": [
+      "bmn2",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tBMN2:USD": {
+    "normalized_id": "BMN2/USD",
+    "base": "BMN2",
+    "quote": "USD",
+    "display_name": "BMN2 / US Dollar",
+    "description": "BMN2 to US Dollar spot trading pair",
+    "tags": [
+      "bmn2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tBONK:USD": {
+    "normalized_id": "BONK/USD",
+    "base": "BONK",
+    "quote": "USD",
+    "display_name": "Bonk / US Dollar",
+    "description": "Bonk to US Dollar spot trading pair",
+    "tags": [
+      "bonk",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tBONK:UST": {
+    "normalized_id": "BONK/USD",
+    "base": "BONK",
+    "quote": "USD",
+    "display_name": "Bonk / US Dollar",
+    "description": "Bonk to US Dollar spot trading pair",
+    "tags": [
+      "bonk",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tBTC:EURQ": {
+    "normalized_id": "BTC/EURQ",
+    "base": "BTC",
+    "quote": "EURQ",
+    "display_name": "Bitcoin / EURQ",
+    "description": "Bitcoin to EURQ spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "eurq"
+    ],
+    "category": "crypto"
+  },
+  "tBTC:EURR": {
+    "normalized_id": "BTC/EURR",
+    "base": "BTC",
+    "quote": "EURR",
+    "display_name": "Bitcoin / EURR",
+    "description": "Bitcoin to EURR spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "eurr"
+    ],
+    "category": "crypto"
+  },
+  "tBTC:USDQ": {
+    "normalized_id": "BTC/USDQ",
+    "base": "BTC",
+    "quote": "USDQ",
+    "display_name": "Bitcoin / USDQ",
+    "description": "Bitcoin to USDQ spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usdq"
+    ],
+    "category": "crypto"
+  },
+  "tBTC:USDR": {
+    "normalized_id": "BTC/USDR",
+    "base": "BTC",
+    "quote": "USDR",
+    "display_name": "Bitcoin / USDR",
+    "description": "Bitcoin to USDR spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usdr"
+    ],
+    "category": "crypto"
+  },
+  "tBTC:XAUT": {
+    "normalized_id": "BTC/XAUT",
+    "base": "BTC",
+    "quote": "XAUT",
+    "display_name": "Bitcoin / XAUT",
+    "description": "Bitcoin to XAUT spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "xaut"
+    ],
+    "category": "crypto"
+  },
+  "tBTCEUR": {
+    "normalized_id": "BTC/EUR",
+    "base": "BTC",
+    "quote": "EUR",
+    "display_name": "Bitcoin / Euro",
+    "description": "Bitcoin to Euro spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "tBTCGBP": {
+    "normalized_id": "BTC/GBP",
+    "base": "BTC",
+    "quote": "GBP",
+    "display_name": "Bitcoin / British Pound",
+    "description": "Bitcoin to British Pound spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "tBTCJPY": {
+    "normalized_id": "BTC/JPY",
+    "base": "BTC",
+    "quote": "JPY",
+    "display_name": "Bitcoin / Japanese Yen",
+    "description": "Bitcoin to Japanese Yen spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "tBTCUSD": {
+    "normalized_id": "BTC/USD",
+    "base": "BTC",
+    "quote": "USD",
+    "display_name": "Bitcoin / US Dollar",
+    "description": "Bitcoin to US Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tBTCUST": {
+    "normalized_id": "BTC/USD",
+    "base": "BTC",
+    "quote": "USD",
+    "display_name": "Bitcoin / US Dollar",
+    "description": "Bitcoin to US Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tBTTUSD": {
+    "normalized_id": "BTT/USD",
+    "base": "BTT",
+    "quote": "USD",
+    "display_name": "BTT / US Dollar",
+    "description": "BTT to US Dollar spot trading pair",
+    "tags": [
+      "btt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tCELO:USD": {
+    "normalized_id": "CELO/USD",
+    "base": "CELO",
+    "quote": "USD",
+    "display_name": "CELO / US Dollar",
+    "description": "CELO to US Dollar spot trading pair",
+    "tags": [
+      "celo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tCELO:UST": {
+    "normalized_id": "CELO/USD",
+    "base": "CELO",
+    "quote": "USD",
+    "display_name": "CELO / US Dollar",
+    "description": "CELO to US Dollar spot trading pair",
+    "tags": [
+      "celo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tCHZUSD": {
+    "normalized_id": "CHZ/USD",
+    "base": "CHZ",
+    "quote": "USD",
+    "display_name": "Chiliz / US Dollar",
+    "description": "Chiliz to US Dollar spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tCHZUST": {
+    "normalized_id": "CHZ/USD",
+    "base": "CHZ",
+    "quote": "USD",
+    "display_name": "Chiliz / US Dollar",
+    "description": "Chiliz to US Dollar spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tCNHT:USD": {
+    "normalized_id": "CNHT/USD",
+    "base": "CNHT",
+    "quote": "USD",
+    "display_name": "CNHT / US Dollar",
+    "description": "CNHT to US Dollar spot trading pair",
+    "tags": [
+      "cnht",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tCOMP:USD": {
+    "normalized_id": "COMP/USD",
+    "base": "COMP",
+    "quote": "USD",
+    "display_name": "Compound / US Dollar",
+    "description": "Compound to US Dollar spot trading pair",
+    "tags": [
+      "comp",
+      "compound",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tCOMP:UST": {
+    "normalized_id": "COMP/USD",
+    "base": "COMP",
+    "quote": "USD",
+    "display_name": "Compound / US Dollar",
+    "description": "Compound to US Dollar spot trading pair",
+    "tags": [
+      "comp",
+      "compound",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tCRVUSD": {
+    "normalized_id": "CRV/USD",
+    "base": "CRV",
+    "quote": "USD",
+    "display_name": "Curve / US Dollar",
+    "description": "Curve to US Dollar spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tCRVUST": {
+    "normalized_id": "CRV/USD",
+    "base": "CRV",
+    "quote": "USD",
+    "display_name": "Curve / US Dollar",
+    "description": "Curve to US Dollar spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tDAIUSD": {
+    "normalized_id": "DAI/USD",
+    "base": "DAI",
+    "quote": "USD",
+    "display_name": "Dai / US Dollar",
+    "description": "Dai to US Dollar spot trading pair",
+    "tags": [
+      "dai",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tDOGE:BTC": {
+    "normalized_id": "DOGE/BTC",
+    "base": "DOGE",
+    "quote": "BTC",
+    "display_name": "Dogecoin / Bitcoin",
+    "description": "Dogecoin to Bitcoin spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tDOGE:USD": {
+    "normalized_id": "DOGE/USD",
+    "base": "DOGE",
+    "quote": "USD",
+    "display_name": "Dogecoin / US Dollar",
+    "description": "Dogecoin to US Dollar spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tDOGE:UST": {
+    "normalized_id": "DOGE/USD",
+    "base": "DOGE",
+    "quote": "USD",
+    "display_name": "Dogecoin / US Dollar",
+    "description": "Dogecoin to US Dollar spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tDOTUSD": {
+    "normalized_id": "DOT/USD",
+    "base": "DOT",
+    "quote": "USD",
+    "display_name": "Polkadot / US Dollar",
+    "description": "Polkadot to US Dollar spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tDOTUST": {
+    "normalized_id": "DOT/USD",
+    "base": "DOT",
+    "quote": "USD",
+    "display_name": "Polkadot / US Dollar",
+    "description": "Polkadot to US Dollar spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tDSHBTC": {
+    "normalized_id": "DSH/BTC",
+    "base": "DSH",
+    "quote": "BTC",
+    "display_name": "DSH / Bitcoin",
+    "description": "DSH to Bitcoin spot trading pair",
+    "tags": [
+      "dsh",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tDSHUSD": {
+    "normalized_id": "DSH/USD",
+    "base": "DSH",
+    "quote": "USD",
+    "display_name": "DSH / US Dollar",
+    "description": "DSH to US Dollar spot trading pair",
+    "tags": [
+      "dsh",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tDYMUSD": {
+    "normalized_id": "DYM/USD",
+    "base": "DYM",
+    "quote": "USD",
+    "display_name": "DYM / US Dollar",
+    "description": "DYM to US Dollar spot trading pair",
+    "tags": [
+      "dym",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tDYMUST": {
+    "normalized_id": "DYM/USD",
+    "base": "DYM",
+    "quote": "USD",
+    "display_name": "DYM / US Dollar",
+    "description": "DYM to US Dollar spot trading pair",
+    "tags": [
+      "dym",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tEGLD:USD": {
+    "normalized_id": "EGLD/USD",
+    "base": "EGLD",
+    "quote": "USD",
+    "display_name": "MultiversX / US Dollar",
+    "description": "MultiversX to US Dollar spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tEGLD:UST": {
+    "normalized_id": "EGLD/USD",
+    "base": "EGLD",
+    "quote": "USD",
+    "display_name": "MultiversX / US Dollar",
+    "description": "MultiversX to US Dollar spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tEIGEN:USD": {
+    "normalized_id": "EIGEN/USD",
+    "base": "EIGEN",
+    "quote": "USD",
+    "display_name": "EIGEN / US Dollar",
+    "description": "EIGEN to US Dollar spot trading pair",
+    "tags": [
+      "eigen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tEIGEN:UST": {
+    "normalized_id": "EIGEN/USD",
+    "base": "EIGEN",
+    "quote": "USD",
+    "display_name": "EIGEN / US Dollar",
+    "description": "EIGEN to US Dollar spot trading pair",
+    "tags": [
+      "eigen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tENAUSD": {
+    "normalized_id": "ENA/USD",
+    "base": "ENA",
+    "quote": "USD",
+    "display_name": "ENA / US Dollar",
+    "description": "ENA to US Dollar spot trading pair",
+    "tags": [
+      "ena",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tENAUST": {
+    "normalized_id": "ENA/USD",
+    "base": "ENA",
+    "quote": "USD",
+    "display_name": "ENA / US Dollar",
+    "description": "ENA to US Dollar spot trading pair",
+    "tags": [
+      "ena",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tEOSBTC": {
+    "normalized_id": "EOS/BTC",
+    "base": "EOS",
+    "quote": "BTC",
+    "display_name": "EOS / Bitcoin",
+    "description": "EOS to Bitcoin spot trading pair",
+    "tags": [
+      "eos",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tEOSUSD": {
+    "normalized_id": "EOS/USD",
+    "base": "EOS",
+    "quote": "USD",
+    "display_name": "EOS / US Dollar",
+    "description": "EOS to US Dollar spot trading pair",
+    "tags": [
+      "eos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tEOSUST": {
+    "normalized_id": "EOS/USD",
+    "base": "EOS",
+    "quote": "USD",
+    "display_name": "EOS / US Dollar",
+    "description": "EOS to US Dollar spot trading pair",
+    "tags": [
+      "eos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tETCBTC": {
+    "normalized_id": "ETC/BTC",
+    "base": "ETC",
+    "quote": "BTC",
+    "display_name": "ETC / Bitcoin",
+    "description": "ETC to Bitcoin spot trading pair",
+    "tags": [
+      "etc",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tETCUSD": {
+    "normalized_id": "ETC/USD",
+    "base": "ETC",
+    "quote": "USD",
+    "display_name": "ETC / US Dollar",
+    "description": "ETC to US Dollar spot trading pair",
+    "tags": [
+      "etc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tETCUST": {
+    "normalized_id": "ETC/USD",
+    "base": "ETC",
+    "quote": "USD",
+    "display_name": "ETC / US Dollar",
+    "description": "ETC to US Dollar spot trading pair",
+    "tags": [
+      "etc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tETH2X:ETH": {
+    "normalized_id": "ETH2X/ETH",
+    "base": "ETH2X",
+    "quote": "ETH",
+    "display_name": "ETH2X / Ethereum",
+    "description": "ETH2X to Ethereum spot trading pair",
+    "tags": [
+      "eth2x",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "tETH2X:USD": {
+    "normalized_id": "ETH2X/USD",
+    "base": "ETH2X",
+    "quote": "USD",
+    "display_name": "ETH2X / US Dollar",
+    "description": "ETH2X to US Dollar spot trading pair",
+    "tags": [
+      "eth2x",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tETH2X:UST": {
+    "normalized_id": "ETH2X/USD",
+    "base": "ETH2X",
+    "quote": "USD",
+    "display_name": "ETH2X / US Dollar",
+    "description": "ETH2X to US Dollar spot trading pair",
+    "tags": [
+      "eth2x",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tETH:XAUT": {
+    "normalized_id": "ETH/XAUT",
+    "base": "ETH",
+    "quote": "XAUT",
+    "display_name": "Ethereum / XAUT",
+    "description": "Ethereum to XAUT spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "xaut"
+    ],
+    "category": "crypto"
+  },
+  "tETHBTC": {
+    "normalized_id": "ETH/BTC",
+    "base": "ETH",
+    "quote": "BTC",
+    "display_name": "Ethereum / Bitcoin",
+    "description": "Ethereum to Bitcoin spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tETHEUR": {
+    "normalized_id": "ETH/EUR",
+    "base": "ETH",
+    "quote": "EUR",
+    "display_name": "Ethereum / Euro",
+    "description": "Ethereum to Euro spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "tETHGBP": {
+    "normalized_id": "ETH/GBP",
+    "base": "ETH",
+    "quote": "GBP",
+    "display_name": "Ethereum / British Pound",
+    "description": "Ethereum to British Pound spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "tETHJPY": {
+    "normalized_id": "ETH/JPY",
+    "base": "ETH",
+    "quote": "JPY",
+    "display_name": "Ethereum / Japanese Yen",
+    "description": "Ethereum to Japanese Yen spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "tETHUSD": {
+    "normalized_id": "ETH/USD",
+    "base": "ETH",
+    "quote": "USD",
+    "display_name": "Ethereum / US Dollar",
+    "description": "Ethereum to US Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tETHUST": {
+    "normalized_id": "ETH/USD",
+    "base": "ETH",
+    "quote": "USD",
+    "display_name": "Ethereum / US Dollar",
+    "description": "Ethereum to US Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tEURQ:EUR": {
+    "normalized_id": "EURQ/EUR",
+    "base": "EURQ",
+    "quote": "EUR",
+    "display_name": "EURQ / Euro",
+    "description": "EURQ to Euro spot trading pair",
+    "tags": [
+      "eurq",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "tEURQ:USD": {
+    "normalized_id": "EURQ/USD",
+    "base": "EURQ",
+    "quote": "USD",
+    "display_name": "EURQ / US Dollar",
+    "description": "EURQ to US Dollar spot trading pair",
+    "tags": [
+      "eurq",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tEURQ:UST": {
+    "normalized_id": "EURQ/USD",
+    "base": "EURQ",
+    "quote": "USD",
+    "display_name": "EURQ / US Dollar",
+    "description": "EURQ to US Dollar spot trading pair",
+    "tags": [
+      "eurq",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tEURR:EUR": {
+    "normalized_id": "EURR/EUR",
+    "base": "EURR",
+    "quote": "EUR",
+    "display_name": "EURR / Euro",
+    "description": "EURR to Euro spot trading pair",
+    "tags": [
+      "eurr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "tEURR:USD": {
+    "normalized_id": "EURR/USD",
+    "base": "EURR",
+    "quote": "USD",
+    "display_name": "EURR / US Dollar",
+    "description": "EURR to US Dollar spot trading pair",
+    "tags": [
+      "eurr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tEURR:UST": {
+    "normalized_id": "EURR/USD",
+    "base": "EURR",
+    "quote": "USD",
+    "display_name": "EURR / US Dollar",
+    "description": "EURR to US Dollar spot trading pair",
+    "tags": [
+      "eurr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tEURUST": {
+    "normalized_id": "EUR/USD",
+    "base": "EUR",
+    "quote": "USD",
+    "display_name": "Euro / US Dollar",
+    "description": "Euro to US Dollar  trading pair",
+    "tags": [
+      "eur",
+      "euro",
+      "usd"
+    ],
+    "category": "forex"
+  },
+  "tEUTUSD": {
+    "normalized_id": "EUT/USD",
+    "base": "EUT",
+    "quote": "USD",
+    "display_name": "EUT / US Dollar",
+    "description": "EUT to US Dollar spot trading pair",
+    "tags": [
+      "eut",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tEUTUST": {
+    "normalized_id": "EUT/USD",
+    "base": "EUT",
+    "quote": "USD",
+    "display_name": "EUT / US Dollar",
+    "description": "EUT to US Dollar spot trading pair",
+    "tags": [
+      "eut",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tFETUSD": {
+    "normalized_id": "FET/USD",
+    "base": "FET",
+    "quote": "USD",
+    "display_name": "FET / US Dollar",
+    "description": "FET to US Dollar spot trading pair",
+    "tags": [
+      "fet",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tFETUST": {
+    "normalized_id": "FET/USD",
+    "base": "FET",
+    "quote": "USD",
+    "display_name": "FET / US Dollar",
+    "description": "FET to US Dollar spot trading pair",
+    "tags": [
+      "fet",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tFILUSD": {
+    "normalized_id": "FIL/USD",
+    "base": "FIL",
+    "quote": "USD",
+    "display_name": "Filecoin / US Dollar",
+    "description": "Filecoin to US Dollar spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tFILUST": {
+    "normalized_id": "FIL/USD",
+    "base": "FIL",
+    "quote": "USD",
+    "display_name": "Filecoin / US Dollar",
+    "description": "Filecoin to US Dollar spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tFLOKI:USD": {
+    "normalized_id": "FLOKI/USD",
+    "base": "FLOKI",
+    "quote": "USD",
+    "display_name": "Floki / US Dollar",
+    "description": "Floki to US Dollar spot trading pair",
+    "tags": [
+      "floki",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tFLOKI:UST": {
+    "normalized_id": "FLOKI/USD",
+    "base": "FLOKI",
+    "quote": "USD",
+    "display_name": "Floki / US Dollar",
+    "description": "Floki to US Dollar spot trading pair",
+    "tags": [
+      "floki",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tGALA:USD": {
+    "normalized_id": "GALA/USD",
+    "base": "GALA",
+    "quote": "USD",
+    "display_name": "Gala / US Dollar",
+    "description": "Gala to US Dollar spot trading pair",
+    "tags": [
+      "gala",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tGALA:UST": {
+    "normalized_id": "GALA/USD",
+    "base": "GALA",
+    "quote": "USD",
+    "display_name": "Gala / US Dollar",
+    "description": "Gala to US Dollar spot trading pair",
+    "tags": [
+      "gala",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tGBPUST": {
+    "normalized_id": "GBP/USD",
+    "base": "GBP",
+    "quote": "USD",
+    "display_name": "British Pound / US Dollar",
+    "description": "British Pound to US Dollar  trading pair",
+    "tags": [
+      "gbp",
+      "british pound",
+      "usd"
+    ],
+    "category": "forex"
+  },
+  "tGOMINING:USD": {
+    "normalized_id": "GOMINING/USD",
+    "base": "GOMINING",
+    "quote": "USD",
+    "display_name": "GOMINING / US Dollar",
+    "description": "GOMINING to US Dollar spot trading pair",
+    "tags": [
+      "gomining",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tGOMINING:UST": {
+    "normalized_id": "GOMINING/USD",
+    "base": "GOMINING",
+    "quote": "USD",
+    "display_name": "GOMINING / US Dollar",
+    "description": "GOMINING to US Dollar spot trading pair",
+    "tags": [
+      "gomining",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tGTXUSD": {
+    "normalized_id": "GTX/USD",
+    "base": "GTX",
+    "quote": "USD",
+    "display_name": "GTX / US Dollar",
+    "description": "GTX to US Dollar spot trading pair",
+    "tags": [
+      "gtx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tGTXUST": {
+    "normalized_id": "GTX/USD",
+    "base": "GTX",
+    "quote": "USD",
+    "display_name": "GTX / US Dollar",
+    "description": "GTX to US Dollar spot trading pair",
+    "tags": [
+      "gtx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tGUNUSD": {
+    "normalized_id": "GUN/USD",
+    "base": "GUN",
+    "quote": "USD",
+    "display_name": "GUN / US Dollar",
+    "description": "GUN to US Dollar spot trading pair",
+    "tags": [
+      "gun",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tGUNUST": {
+    "normalized_id": "GUN/USD",
+    "base": "GUN",
+    "quote": "USD",
+    "display_name": "GUN / US Dollar",
+    "description": "GUN to US Dollar spot trading pair",
+    "tags": [
+      "gun",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tHILSV:USD": {
+    "normalized_id": "HILSV/USD",
+    "base": "HILSV",
+    "quote": "USD",
+    "display_name": "HILSV / US Dollar",
+    "description": "HILSV to US Dollar spot trading pair",
+    "tags": [
+      "hilsv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tHIXUSD": {
+    "normalized_id": "HIX/USD",
+    "base": "HIX",
+    "quote": "USD",
+    "display_name": "HIX / US Dollar",
+    "description": "HIX to US Dollar spot trading pair",
+    "tags": [
+      "hix",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tHIXUST": {
+    "normalized_id": "HIX/USD",
+    "base": "HIX",
+    "quote": "USD",
+    "display_name": "HIX / US Dollar",
+    "description": "HIX to US Dollar spot trading pair",
+    "tags": [
+      "hix",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tHTXDAO:USD": {
+    "normalized_id": "HTXDAO/USD",
+    "base": "HTXDAO",
+    "quote": "USD",
+    "display_name": "HTXDAO / US Dollar",
+    "description": "HTXDAO to US Dollar spot trading pair",
+    "tags": [
+      "htxdao",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tHTXDAO:UST": {
+    "normalized_id": "HTXDAO/USD",
+    "base": "HTXDAO",
+    "quote": "USD",
+    "display_name": "HTXDAO / US Dollar",
+    "description": "HTXDAO to US Dollar spot trading pair",
+    "tags": [
+      "htxdao",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tICPUSD": {
+    "normalized_id": "ICP/USD",
+    "base": "ICP",
+    "quote": "USD",
+    "display_name": "Internet Computer / US Dollar",
+    "description": "Internet Computer to US Dollar spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tICPUST": {
+    "normalized_id": "ICP/USD",
+    "base": "ICP",
+    "quote": "USD",
+    "display_name": "Internet Computer / US Dollar",
+    "description": "Internet Computer to US Dollar spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tIOTBTC": {
+    "normalized_id": "IOT/BTC",
+    "base": "IOT",
+    "quote": "BTC",
+    "display_name": "IOT / Bitcoin",
+    "description": "IOT to Bitcoin spot trading pair",
+    "tags": [
+      "iot",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tIOTUSD": {
+    "normalized_id": "IOT/USD",
+    "base": "IOT",
+    "quote": "USD",
+    "display_name": "IOT / US Dollar",
+    "description": "IOT to US Dollar spot trading pair",
+    "tags": [
+      "iot",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tJASMY:USD": {
+    "normalized_id": "JASMY/USD",
+    "base": "JASMY",
+    "quote": "USD",
+    "display_name": "JASMY / US Dollar",
+    "description": "JASMY to US Dollar spot trading pair",
+    "tags": [
+      "jasmy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tJASMY:UST": {
+    "normalized_id": "JASMY/USD",
+    "base": "JASMY",
+    "quote": "USD",
+    "display_name": "JASMY / US Dollar",
+    "description": "JASMY to US Dollar spot trading pair",
+    "tags": [
+      "jasmy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tJPYUST": {
+    "normalized_id": "JPY/USD",
+    "base": "JPY",
+    "quote": "USD",
+    "display_name": "Japanese Yen / US Dollar",
+    "description": "Japanese Yen to US Dollar  trading pair",
+    "tags": [
+      "jpy",
+      "japanese yen",
+      "usd"
+    ],
+    "category": "forex"
+  },
+  "tJSTUSD": {
+    "normalized_id": "JST/USD",
+    "base": "JST",
+    "quote": "USD",
+    "display_name": "JST / US Dollar",
+    "description": "JST to US Dollar spot trading pair",
+    "tags": [
+      "jst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tJSTUST": {
+    "normalized_id": "JST/USD",
+    "base": "JST",
+    "quote": "USD",
+    "display_name": "JST / US Dollar",
+    "description": "JST to US Dollar spot trading pair",
+    "tags": [
+      "jst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tJUPUSD": {
+    "normalized_id": "JUP/USD",
+    "base": "JUP",
+    "quote": "USD",
+    "display_name": "Jupiter / US Dollar",
+    "description": "Jupiter to US Dollar spot trading pair",
+    "tags": [
+      "jup",
+      "jupiter",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tJUPUST": {
+    "normalized_id": "JUP/USD",
+    "base": "JUP",
+    "quote": "USD",
+    "display_name": "Jupiter / US Dollar",
+    "description": "Jupiter to US Dollar spot trading pair",
+    "tags": [
+      "jup",
+      "jupiter",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tJUSTICE:USD": {
+    "normalized_id": "JUSTICE/USD",
+    "base": "JUSTICE",
+    "quote": "USD",
+    "display_name": "JUSTICE / US Dollar",
+    "description": "JUSTICE to US Dollar spot trading pair",
+    "tags": [
+      "justice",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tJUSTICE:UST": {
+    "normalized_id": "JUSTICE/USD",
+    "base": "JUSTICE",
+    "quote": "USD",
+    "display_name": "JUSTICE / US Dollar",
+    "description": "JUSTICE to US Dollar spot trading pair",
+    "tags": [
+      "justice",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tJXXUSD": {
+    "normalized_id": "JXX/USD",
+    "base": "JXX",
+    "quote": "USD",
+    "display_name": "JXX / US Dollar",
+    "description": "JXX to US Dollar spot trading pair",
+    "tags": [
+      "jxx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tJXXUST": {
+    "normalized_id": "JXX/USD",
+    "base": "JXX",
+    "quote": "USD",
+    "display_name": "JXX / US Dollar",
+    "description": "JXX to US Dollar spot trading pair",
+    "tags": [
+      "jxx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tKAIA:USD": {
+    "normalized_id": "KAIA/USD",
+    "base": "KAIA",
+    "quote": "USD",
+    "display_name": "KAIA / US Dollar",
+    "description": "KAIA to US Dollar spot trading pair",
+    "tags": [
+      "kaia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tKAIA:UST": {
+    "normalized_id": "KAIA/USD",
+    "base": "KAIA",
+    "quote": "USD",
+    "display_name": "KAIA / US Dollar",
+    "description": "KAIA to US Dollar spot trading pair",
+    "tags": [
+      "kaia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tKANUSD": {
+    "normalized_id": "KAN/USD",
+    "base": "KAN",
+    "quote": "USD",
+    "display_name": "KAN / US Dollar",
+    "description": "KAN to US Dollar spot trading pair",
+    "tags": [
+      "kan",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tKANUST": {
+    "normalized_id": "KAN/USD",
+    "base": "KAN",
+    "quote": "USD",
+    "display_name": "KAN / US Dollar",
+    "description": "KAN to US Dollar spot trading pair",
+    "tags": [
+      "kan",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tKAVA:USD": {
+    "normalized_id": "KAVA/USD",
+    "base": "KAVA",
+    "quote": "USD",
+    "display_name": "KAVA / US Dollar",
+    "description": "KAVA to US Dollar spot trading pair",
+    "tags": [
+      "kava",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tKAVA:UST": {
+    "normalized_id": "KAVA/USD",
+    "base": "KAVA",
+    "quote": "USD",
+    "display_name": "KAVA / US Dollar",
+    "description": "KAVA to US Dollar spot trading pair",
+    "tags": [
+      "kava",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tLDOUSD": {
+    "normalized_id": "LDO/USD",
+    "base": "LDO",
+    "quote": "USD",
+    "display_name": "LDO / US Dollar",
+    "description": "LDO to US Dollar spot trading pair",
+    "tags": [
+      "ldo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tLDOUST": {
+    "normalized_id": "LDO/USD",
+    "base": "LDO",
+    "quote": "USD",
+    "display_name": "LDO / US Dollar",
+    "description": "LDO to US Dollar spot trading pair",
+    "tags": [
+      "ldo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tLEOBTC": {
+    "normalized_id": "LEO/BTC",
+    "base": "LEO",
+    "quote": "BTC",
+    "display_name": "LEO / Bitcoin",
+    "description": "LEO to Bitcoin spot trading pair",
+    "tags": [
+      "leo",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tLEOETH": {
+    "normalized_id": "LEO/ETH",
+    "base": "LEO",
+    "quote": "ETH",
+    "display_name": "LEO / Ethereum",
+    "description": "LEO to Ethereum spot trading pair",
+    "tags": [
+      "leo",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "tLEOUSD": {
+    "normalized_id": "LEO/USD",
+    "base": "LEO",
+    "quote": "USD",
+    "display_name": "LEO / US Dollar",
+    "description": "LEO to US Dollar spot trading pair",
+    "tags": [
+      "leo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tLEOUST": {
+    "normalized_id": "LEO/USD",
+    "base": "LEO",
+    "quote": "USD",
+    "display_name": "LEO / US Dollar",
+    "description": "LEO to US Dollar spot trading pair",
+    "tags": [
+      "leo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tLIFIII:USD": {
+    "normalized_id": "LIFIII/USD",
+    "base": "LIFIII",
+    "quote": "USD",
+    "display_name": "LIFIII / US Dollar",
+    "description": "LIFIII to US Dollar spot trading pair",
+    "tags": [
+      "lifiii",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tLIFIII:UST": {
+    "normalized_id": "LIFIII/USD",
+    "base": "LIFIII",
+    "quote": "USD",
+    "display_name": "LIFIII / US Dollar",
+    "description": "LIFIII to US Dollar spot trading pair",
+    "tags": [
+      "lifiii",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tLINK:USD": {
+    "normalized_id": "LINK/USD",
+    "base": "LINK",
+    "quote": "USD",
+    "display_name": "Chainlink / US Dollar",
+    "description": "Chainlink to US Dollar spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tLINK:UST": {
+    "normalized_id": "LINK/USD",
+    "base": "LINK",
+    "quote": "USD",
+    "display_name": "Chainlink / US Dollar",
+    "description": "Chainlink to US Dollar spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tLTCBTC": {
+    "normalized_id": "LTC/BTC",
+    "base": "LTC",
+    "quote": "BTC",
+    "display_name": "Litecoin / Bitcoin",
+    "description": "Litecoin to Bitcoin spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tLTCUSD": {
+    "normalized_id": "LTC/USD",
+    "base": "LTC",
+    "quote": "USD",
+    "display_name": "Litecoin / US Dollar",
+    "description": "Litecoin to US Dollar spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tLTCUST": {
+    "normalized_id": "LTC/USD",
+    "base": "LTC",
+    "quote": "USD",
+    "display_name": "Litecoin / US Dollar",
+    "description": "Litecoin to US Dollar spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tMEWUSD": {
+    "normalized_id": "MEW/USD",
+    "base": "MEW",
+    "quote": "USD",
+    "display_name": "MEW / US Dollar",
+    "description": "MEW to US Dollar spot trading pair",
+    "tags": [
+      "mew",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tMEWUST": {
+    "normalized_id": "MEW/USD",
+    "base": "MEW",
+    "quote": "USD",
+    "display_name": "MEW / US Dollar",
+    "description": "MEW to US Dollar spot trading pair",
+    "tags": [
+      "mew",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tMIMUSD": {
+    "normalized_id": "MIM/USD",
+    "base": "MIM",
+    "quote": "USD",
+    "display_name": "MIM / US Dollar",
+    "description": "MIM to US Dollar spot trading pair",
+    "tags": [
+      "mim",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tMIMUST": {
+    "normalized_id": "MIM/USD",
+    "base": "MIM",
+    "quote": "USD",
+    "display_name": "MIM / US Dollar",
+    "description": "MIM to US Dollar spot trading pair",
+    "tags": [
+      "mim",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tMKRUSD": {
+    "normalized_id": "MKR/USD",
+    "base": "MKR",
+    "quote": "USD",
+    "display_name": "Maker / US Dollar",
+    "description": "Maker to US Dollar spot trading pair",
+    "tags": [
+      "mkr",
+      "maker",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tMKRUST": {
+    "normalized_id": "MKR/USD",
+    "base": "MKR",
+    "quote": "USD",
+    "display_name": "Maker / US Dollar",
+    "description": "Maker to US Dollar spot trading pair",
+    "tags": [
+      "mkr",
+      "maker",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tMXNT:USD": {
+    "normalized_id": "MXNT/USD",
+    "base": "MXNT",
+    "quote": "USD",
+    "display_name": "MXNT / US Dollar",
+    "description": "MXNT to US Dollar spot trading pair",
+    "tags": [
+      "mxnt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tNEAR:USD": {
+    "normalized_id": "NEAR/USD",
+    "base": "NEAR",
+    "quote": "USD",
+    "display_name": "NEAR Protocol / US Dollar",
+    "description": "NEAR Protocol to US Dollar spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tNEAR:UST": {
+    "normalized_id": "NEAR/USD",
+    "base": "NEAR",
+    "quote": "USD",
+    "display_name": "NEAR Protocol / US Dollar",
+    "description": "NEAR Protocol to US Dollar spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tNEOUSD": {
+    "normalized_id": "NEO/USD",
+    "base": "NEO",
+    "quote": "USD",
+    "display_name": "NEO / US Dollar",
+    "description": "NEO to US Dollar spot trading pair",
+    "tags": [
+      "neo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tNEOUST": {
+    "normalized_id": "NEO/USD",
+    "base": "NEO",
+    "quote": "USD",
+    "display_name": "NEO / US Dollar",
+    "description": "NEO to US Dollar spot trading pair",
+    "tags": [
+      "neo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tNEXO:BTC": {
+    "normalized_id": "NEXO/BTC",
+    "base": "NEXO",
+    "quote": "BTC",
+    "display_name": "NEXO / Bitcoin",
+    "description": "NEXO to Bitcoin spot trading pair",
+    "tags": [
+      "nexo",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tNEXO:USD": {
+    "normalized_id": "NEXO/USD",
+    "base": "NEXO",
+    "quote": "USD",
+    "display_name": "NEXO / US Dollar",
+    "description": "NEXO to US Dollar spot trading pair",
+    "tags": [
+      "nexo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tNEXO:UST": {
+    "normalized_id": "NEXO/USD",
+    "base": "NEXO",
+    "quote": "USD",
+    "display_name": "NEXO / US Dollar",
+    "description": "NEXO to US Dollar spot trading pair",
+    "tags": [
+      "nexo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tNYMUSD": {
+    "normalized_id": "NYM/USD",
+    "base": "NYM",
+    "quote": "USD",
+    "display_name": "NYM / US Dollar",
+    "description": "NYM to US Dollar spot trading pair",
+    "tags": [
+      "nym",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tNYMUST": {
+    "normalized_id": "NYM/USD",
+    "base": "NYM",
+    "quote": "USD",
+    "display_name": "NYM / US Dollar",
+    "description": "NYM to US Dollar spot trading pair",
+    "tags": [
+      "nym",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tOMNUSD": {
+    "normalized_id": "OMN/USD",
+    "base": "OMN",
+    "quote": "USD",
+    "display_name": "OMN / US Dollar",
+    "description": "OMN to US Dollar spot trading pair",
+    "tags": [
+      "omn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tOPXUSD": {
+    "normalized_id": "OPX/USD",
+    "base": "OPX",
+    "quote": "USD",
+    "display_name": "OPX / US Dollar",
+    "description": "OPX to US Dollar spot trading pair",
+    "tags": [
+      "opx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tOPXUST": {
+    "normalized_id": "OPX/USD",
+    "base": "OPX",
+    "quote": "USD",
+    "display_name": "OPX / US Dollar",
+    "description": "OPX to US Dollar spot trading pair",
+    "tags": [
+      "opx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tPEPE:USD": {
+    "normalized_id": "PEPE/USD",
+    "base": "PEPE",
+    "quote": "USD",
+    "display_name": "Pepe / US Dollar",
+    "description": "Pepe to US Dollar spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tPEPE:UST": {
+    "normalized_id": "PEPE/USD",
+    "base": "PEPE",
+    "quote": "USD",
+    "display_name": "Pepe / US Dollar",
+    "description": "Pepe to US Dollar spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tPNKUSD": {
+    "normalized_id": "PNK/USD",
+    "base": "PNK",
+    "quote": "USD",
+    "display_name": "PNK / US Dollar",
+    "description": "PNK to US Dollar spot trading pair",
+    "tags": [
+      "pnk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tPOLUSD": {
+    "normalized_id": "POL/USD",
+    "base": "POL",
+    "quote": "USD",
+    "display_name": "POL / US Dollar",
+    "description": "POL to US Dollar spot trading pair",
+    "tags": [
+      "pol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tPOLUST": {
+    "normalized_id": "POL/USD",
+    "base": "POL",
+    "quote": "USD",
+    "display_name": "POL / US Dollar",
+    "description": "POL to US Dollar spot trading pair",
+    "tags": [
+      "pol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tRRTUSD": {
+    "normalized_id": "RRT/USD",
+    "base": "RRT",
+    "quote": "USD",
+    "display_name": "RRT / US Dollar",
+    "description": "RRT to US Dollar spot trading pair",
+    "tags": [
+      "rrt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSEIUSD": {
+    "normalized_id": "SEI/USD",
+    "base": "SEI",
+    "quote": "USD",
+    "display_name": "Sei / US Dollar",
+    "description": "Sei to US Dollar spot trading pair",
+    "tags": [
+      "sei",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSEIUST": {
+    "normalized_id": "SEI/USD",
+    "base": "SEI",
+    "quote": "USD",
+    "display_name": "Sei / US Dollar",
+    "description": "Sei to US Dollar spot trading pair",
+    "tags": [
+      "sei",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSHIB:USD": {
+    "normalized_id": "SHIB/USD",
+    "base": "SHIB",
+    "quote": "USD",
+    "display_name": "Shiba Inu / US Dollar",
+    "description": "Shiba Inu to US Dollar spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSHIB:UST": {
+    "normalized_id": "SHIB/USD",
+    "base": "SHIB",
+    "quote": "USD",
+    "display_name": "Shiba Inu / US Dollar",
+    "description": "Shiba Inu to US Dollar spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSHMUSD": {
+    "normalized_id": "SHM/USD",
+    "base": "SHM",
+    "quote": "USD",
+    "display_name": "SHM / US Dollar",
+    "description": "SHM to US Dollar spot trading pair",
+    "tags": [
+      "shm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSHMUST": {
+    "normalized_id": "SHM/USD",
+    "base": "SHM",
+    "quote": "USD",
+    "display_name": "SHM / US Dollar",
+    "description": "SHM to US Dollar spot trading pair",
+    "tags": [
+      "shm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSOLBTC": {
+    "normalized_id": "SOL/BTC",
+    "base": "SOL",
+    "quote": "BTC",
+    "display_name": "Solana / Bitcoin",
+    "description": "Solana to Bitcoin spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tSOLUSD": {
+    "normalized_id": "SOL/USD",
+    "base": "SOL",
+    "quote": "USD",
+    "display_name": "Solana / US Dollar",
+    "description": "Solana to US Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSOLUST": {
+    "normalized_id": "SOL/USD",
+    "base": "SOL",
+    "quote": "USD",
+    "display_name": "Solana / US Dollar",
+    "description": "Solana to US Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSONIC:USD": {
+    "normalized_id": "SONIC/USD",
+    "base": "SONIC",
+    "quote": "USD",
+    "display_name": "SONIC / US Dollar",
+    "description": "SONIC to US Dollar spot trading pair",
+    "tags": [
+      "sonic",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSONIC:UST": {
+    "normalized_id": "SONIC/USD",
+    "base": "SONIC",
+    "quote": "USD",
+    "display_name": "SONIC / US Dollar",
+    "description": "SONIC to US Dollar spot trading pair",
+    "tags": [
+      "sonic",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSPEC:USD": {
+    "normalized_id": "SPEC/USD",
+    "base": "SPEC",
+    "quote": "USD",
+    "display_name": "SPEC / US Dollar",
+    "description": "SPEC to US Dollar spot trading pair",
+    "tags": [
+      "spec",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSPEC:UST": {
+    "normalized_id": "SPEC/USD",
+    "base": "SPEC",
+    "quote": "USD",
+    "display_name": "SPEC / US Dollar",
+    "description": "SPEC to US Dollar spot trading pair",
+    "tags": [
+      "spec",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSPELL:USD": {
+    "normalized_id": "SPELL/USD",
+    "base": "SPELL",
+    "quote": "USD",
+    "display_name": "SPELL / US Dollar",
+    "description": "SPELL to US Dollar spot trading pair",
+    "tags": [
+      "spell",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSPELL:UST": {
+    "normalized_id": "SPELL/USD",
+    "base": "SPELL",
+    "quote": "USD",
+    "display_name": "SPELL / US Dollar",
+    "description": "SPELL to US Dollar spot trading pair",
+    "tags": [
+      "spell",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSTGUSD": {
+    "normalized_id": "STG/USD",
+    "base": "STG",
+    "quote": "USD",
+    "display_name": "STG / US Dollar",
+    "description": "STG to US Dollar spot trading pair",
+    "tags": [
+      "stg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSTGUST": {
+    "normalized_id": "STG/USD",
+    "base": "STG",
+    "quote": "USD",
+    "display_name": "STG / US Dollar",
+    "description": "STG to US Dollar spot trading pair",
+    "tags": [
+      "stg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSTRK:USD": {
+    "normalized_id": "STRK/USD",
+    "base": "STRK",
+    "quote": "USD",
+    "display_name": "STRK / US Dollar",
+    "description": "STRK to US Dollar spot trading pair",
+    "tags": [
+      "strk",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSTRK:UST": {
+    "normalized_id": "STRK/USD",
+    "base": "STRK",
+    "quote": "USD",
+    "display_name": "STRK / US Dollar",
+    "description": "STRK to US Dollar spot trading pair",
+    "tags": [
+      "strk",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSTXUSD": {
+    "normalized_id": "STX/USD",
+    "base": "STX",
+    "quote": "USD",
+    "display_name": "STX / US Dollar",
+    "description": "STX to US Dollar spot trading pair",
+    "tags": [
+      "stx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSTXUST": {
+    "normalized_id": "STX/USD",
+    "base": "STX",
+    "quote": "USD",
+    "display_name": "STX / US Dollar",
+    "description": "STX to US Dollar spot trading pair",
+    "tags": [
+      "stx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSUIUSD": {
+    "normalized_id": "SUI/USD",
+    "base": "SUI",
+    "quote": "USD",
+    "display_name": "Sui / US Dollar",
+    "description": "Sui to US Dollar spot trading pair",
+    "tags": [
+      "sui",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSUIUST": {
+    "normalized_id": "SUI/USD",
+    "base": "SUI",
+    "quote": "USD",
+    "display_name": "Sui / US Dollar",
+    "description": "Sui to US Dollar spot trading pair",
+    "tags": [
+      "sui",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSUNUSD": {
+    "normalized_id": "SUN/USD",
+    "base": "SUN",
+    "quote": "USD",
+    "display_name": "SUN / US Dollar",
+    "description": "SUN to US Dollar spot trading pair",
+    "tags": [
+      "sun",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSUNUST": {
+    "normalized_id": "SUN/USD",
+    "base": "SUN",
+    "quote": "USD",
+    "display_name": "SUN / US Dollar",
+    "description": "SUN to US Dollar spot trading pair",
+    "tags": [
+      "sun",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSUSHI:USD": {
+    "normalized_id": "SUSHI/USD",
+    "base": "SUSHI",
+    "quote": "USD",
+    "display_name": "SUSHI / US Dollar",
+    "description": "SUSHI to US Dollar spot trading pair",
+    "tags": [
+      "sushi",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSUSHI:UST": {
+    "normalized_id": "SUSHI/USD",
+    "base": "SUSHI",
+    "quote": "USD",
+    "display_name": "SUSHI / US Dollar",
+    "description": "SUSHI to US Dollar spot trading pair",
+    "tags": [
+      "sushi",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSWEAT:USD": {
+    "normalized_id": "SWEAT/USD",
+    "base": "SWEAT",
+    "quote": "USD",
+    "display_name": "SWEAT / US Dollar",
+    "description": "SWEAT to US Dollar spot trading pair",
+    "tags": [
+      "sweat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tSWEAT:UST": {
+    "normalized_id": "SWEAT/USD",
+    "base": "SWEAT",
+    "quote": "USD",
+    "display_name": "SWEAT / US Dollar",
+    "description": "SWEAT to US Dollar spot trading pair",
+    "tags": [
+      "sweat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tTESTADA:TESTUSD": {
+    "normalized_id": "TESTADA/TESTUSD",
+    "base": "TESTADA",
+    "quote": "TESTUSD",
+    "display_name": "TESTADA / TESTUSD",
+    "description": "TESTADA to TESTUSD spot trading pair",
+    "tags": [
+      "testada",
+      "testusd"
+    ],
+    "category": "crypto"
+  },
+  "tTESTALGO:TESTUSD": {
+    "normalized_id": "TESTALGO/TESTUSD",
+    "base": "TESTALGO",
+    "quote": "TESTUSD",
+    "display_name": "TESTALGO / TESTUSD",
+    "description": "TESTALGO to TESTUSD spot trading pair",
+    "tags": [
+      "testalgo",
+      "testusd"
+    ],
+    "category": "crypto"
+  },
+  "tTESTAPT:TESTUSD": {
+    "normalized_id": "TESTAPT/TESTUSD",
+    "base": "TESTAPT",
+    "quote": "TESTUSD",
+    "display_name": "TESTAPT / TESTUSD",
+    "description": "TESTAPT to TESTUSD spot trading pair",
+    "tags": [
+      "testapt",
+      "testusd"
+    ],
+    "category": "crypto"
+  },
+  "tTESTAVAX:TESTUSD": {
+    "normalized_id": "TESTAVAX/TESTUSD",
+    "base": "TESTAVAX",
+    "quote": "TESTUSD",
+    "display_name": "TESTAVAX / TESTUSD",
+    "description": "TESTAVAX to TESTUSD spot trading pair",
+    "tags": [
+      "testavax",
+      "testusd"
+    ],
+    "category": "crypto"
+  },
+  "tTESTBTC:TESTUSD": {
+    "normalized_id": "TESTBTC/TESTUSD",
+    "base": "TESTBTC",
+    "quote": "TESTUSD",
+    "display_name": "TESTBTC / TESTUSD",
+    "description": "TESTBTC to TESTUSD spot trading pair",
+    "tags": [
+      "testbtc",
+      "testusd"
+    ],
+    "category": "crypto"
+  },
+  "tTESTBTC:TESTUSDT": {
+    "normalized_id": "TESTBTC/TESTUSDT",
+    "base": "TESTBTC",
+    "quote": "TESTUSDT",
+    "display_name": "TESTBTC / TESTUSDT",
+    "description": "TESTBTC to TESTUSDT spot trading pair",
+    "tags": [
+      "testbtc",
+      "testusdt"
+    ],
+    "category": "crypto"
+  },
+  "tTESTDOGE:TESTUSD": {
+    "normalized_id": "TESTDOGE/TESTUSD",
+    "base": "TESTDOGE",
+    "quote": "TESTUSD",
+    "display_name": "TESTDOGE / TESTUSD",
+    "description": "TESTDOGE to TESTUSD spot trading pair",
+    "tags": [
+      "testdoge",
+      "testusd"
+    ],
+    "category": "crypto"
+  },
+  "tTESTDOT:TESTUSD": {
+    "normalized_id": "TESTDOT/TESTUSD",
+    "base": "TESTDOT",
+    "quote": "TESTUSD",
+    "display_name": "TESTDOT / TESTUSD",
+    "description": "TESTDOT to TESTUSD spot trading pair",
+    "tags": [
+      "testdot",
+      "testusd"
+    ],
+    "category": "crypto"
+  },
+  "tTESTEOS:TESTUSD": {
+    "normalized_id": "TESTEOS/TESTUSD",
+    "base": "TESTEOS",
+    "quote": "TESTUSD",
+    "display_name": "TESTEOS / TESTUSD",
+    "description": "TESTEOS to TESTUSD spot trading pair",
+    "tags": [
+      "testeos",
+      "testusd"
+    ],
+    "category": "crypto"
+  },
+  "tTESTETH:TESTUSD": {
+    "normalized_id": "TESTETH/TESTUSD",
+    "base": "TESTETH",
+    "quote": "TESTUSD",
+    "display_name": "TESTETH / TESTUSD",
+    "description": "TESTETH to TESTUSD spot trading pair",
+    "tags": [
+      "testeth",
+      "testusd"
+    ],
+    "category": "crypto"
+  },
+  "tTESTFIL:TESTUSD": {
+    "normalized_id": "TESTFIL/TESTUSD",
+    "base": "TESTFIL",
+    "quote": "TESTUSD",
+    "display_name": "TESTFIL / TESTUSD",
+    "description": "TESTFIL to TESTUSD spot trading pair",
+    "tags": [
+      "testfil",
+      "testusd"
+    ],
+    "category": "crypto"
+  },
+  "tTESTLTC:TESTUSD": {
+    "normalized_id": "TESTLTC/TESTUSD",
+    "base": "TESTLTC",
+    "quote": "TESTUSD",
+    "display_name": "TESTLTC / TESTUSD",
+    "description": "TESTLTC to TESTUSD spot trading pair",
+    "tags": [
+      "testltc",
+      "testusd"
+    ],
+    "category": "crypto"
+  },
+  "tTESTNEAR:TESTUSD": {
+    "normalized_id": "TESTNEAR/TESTUSD",
+    "base": "TESTNEAR",
+    "quote": "TESTUSD",
+    "display_name": "TESTNEAR / TESTUSD",
+    "description": "TESTNEAR to TESTUSD spot trading pair",
+    "tags": [
+      "testnear",
+      "testusd"
+    ],
+    "category": "crypto"
+  },
+  "tTESTSOL:TESTUSD": {
+    "normalized_id": "TESTSOL/TESTUSD",
+    "base": "TESTSOL",
+    "quote": "TESTUSD",
+    "display_name": "TESTSOL / TESTUSD",
+    "description": "TESTSOL to TESTUSD spot trading pair",
+    "tags": [
+      "testsol",
+      "testusd"
+    ],
+    "category": "crypto"
+  },
+  "tTESTXAUT:TESTUSD": {
+    "normalized_id": "TESTXAUT/TESTUSD",
+    "base": "TESTXAUT",
+    "quote": "TESTUSD",
+    "display_name": "TESTXAUT / TESTUSD",
+    "description": "TESTXAUT to TESTUSD spot trading pair",
+    "tags": [
+      "testxaut",
+      "testusd"
+    ],
+    "category": "crypto"
+  },
+  "tTESTXTZ:TESTUSD": {
+    "normalized_id": "TESTXTZ/TESTUSD",
+    "base": "TESTXTZ",
+    "quote": "TESTUSD",
+    "display_name": "TESTXTZ / TESTUSD",
+    "description": "TESTXTZ to TESTUSD spot trading pair",
+    "tags": [
+      "testxtz",
+      "testusd"
+    ],
+    "category": "crypto"
+  },
+  "tTIAUSD": {
+    "normalized_id": "TIA/USD",
+    "base": "TIA",
+    "quote": "USD",
+    "display_name": "Celestia / US Dollar",
+    "description": "Celestia to US Dollar spot trading pair",
+    "tags": [
+      "tia",
+      "celestia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tTIAUST": {
+    "normalized_id": "TIA/USD",
+    "base": "TIA",
+    "quote": "USD",
+    "display_name": "Celestia / US Dollar",
+    "description": "Celestia to US Dollar spot trading pair",
+    "tags": [
+      "tia",
+      "celestia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tTITAN1:GBP": {
+    "normalized_id": "TITAN1/GBP",
+    "base": "TITAN1",
+    "quote": "GBP",
+    "display_name": "TITAN1 / British Pound",
+    "description": "TITAN1 to British Pound spot trading pair",
+    "tags": [
+      "titan1",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "tTITAN1:USD": {
+    "normalized_id": "TITAN1/USD",
+    "base": "TITAN1",
+    "quote": "USD",
+    "display_name": "TITAN1 / US Dollar",
+    "description": "TITAN1 to US Dollar spot trading pair",
+    "tags": [
+      "titan1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tTITAN2:GBP": {
+    "normalized_id": "TITAN2/GBP",
+    "base": "TITAN2",
+    "quote": "GBP",
+    "display_name": "TITAN2 / British Pound",
+    "description": "TITAN2 to British Pound spot trading pair",
+    "tags": [
+      "titan2",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "tTITAN2:USD": {
+    "normalized_id": "TITAN2/USD",
+    "base": "TITAN2",
+    "quote": "USD",
+    "display_name": "TITAN2 / US Dollar",
+    "description": "TITAN2 to US Dollar spot trading pair",
+    "tags": [
+      "titan2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tTOKEN:USD": {
+    "normalized_id": "TOKEN/USD",
+    "base": "TOKEN",
+    "quote": "USD",
+    "display_name": "TOKEN / US Dollar",
+    "description": "TOKEN to US Dollar spot trading pair",
+    "tags": [
+      "token",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tTOKEN:UST": {
+    "normalized_id": "TOKEN/USD",
+    "base": "TOKEN",
+    "quote": "USD",
+    "display_name": "TOKEN / US Dollar",
+    "description": "TOKEN to US Dollar spot trading pair",
+    "tags": [
+      "token",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tTONUSD": {
+    "normalized_id": "TON/USD",
+    "base": "TON",
+    "quote": "USD",
+    "display_name": "Toncoin / US Dollar",
+    "description": "Toncoin to US Dollar spot trading pair",
+    "tags": [
+      "ton",
+      "toncoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tTONUST": {
+    "normalized_id": "TON/USD",
+    "base": "TON",
+    "quote": "USD",
+    "display_name": "Toncoin / US Dollar",
+    "description": "Toncoin to US Dollar spot trading pair",
+    "tags": [
+      "ton",
+      "toncoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tTRXBTC": {
+    "normalized_id": "TRX/BTC",
+    "base": "TRX",
+    "quote": "BTC",
+    "display_name": "TRON / Bitcoin",
+    "description": "TRON to Bitcoin spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tTRXEUR": {
+    "normalized_id": "TRX/EUR",
+    "base": "TRX",
+    "quote": "EUR",
+    "display_name": "TRON / Euro",
+    "description": "TRON to Euro spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "tTRXUSD": {
+    "normalized_id": "TRX/USD",
+    "base": "TRX",
+    "quote": "USD",
+    "display_name": "TRON / US Dollar",
+    "description": "TRON to US Dollar spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tTRXUST": {
+    "normalized_id": "TRX/USD",
+    "base": "TRX",
+    "quote": "USD",
+    "display_name": "TRON / US Dollar",
+    "description": "TRON to US Dollar spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tTRYUST": {
+    "normalized_id": "TRY/USD",
+    "base": "TRY",
+    "quote": "USD",
+    "display_name": "Turkish Lira / US Dollar",
+    "description": "Turkish Lira to US Dollar  trading pair",
+    "tags": [
+      "try",
+      "turkish lira",
+      "usd"
+    ],
+    "category": "forex"
+  },
+  "tTSDUSD": {
+    "normalized_id": "TSD/USD",
+    "base": "TSD",
+    "quote": "USD",
+    "display_name": "TSD / US Dollar",
+    "description": "TSD to US Dollar spot trading pair",
+    "tags": [
+      "tsd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tTSDUST": {
+    "normalized_id": "TSD/USD",
+    "base": "TSD",
+    "quote": "USD",
+    "display_name": "TSD / US Dollar",
+    "description": "TSD to US Dollar spot trading pair",
+    "tags": [
+      "tsd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUDCUSD": {
+    "normalized_id": "UDC/USD",
+    "base": "UDC",
+    "quote": "USD",
+    "display_name": "UDC / US Dollar",
+    "description": "UDC to US Dollar spot trading pair",
+    "tags": [
+      "udc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUDCUST": {
+    "normalized_id": "UDC/USD",
+    "base": "UDC",
+    "quote": "USD",
+    "display_name": "UDC / US Dollar",
+    "description": "UDC to US Dollar spot trading pair",
+    "tags": [
+      "udc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUNIUSD": {
+    "normalized_id": "UNI/USD",
+    "base": "UNI",
+    "quote": "USD",
+    "display_name": "Uniswap / US Dollar",
+    "description": "Uniswap to US Dollar spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUNIUST": {
+    "normalized_id": "UNI/USD",
+    "base": "UNI",
+    "quote": "USD",
+    "display_name": "Uniswap / US Dollar",
+    "description": "Uniswap to US Dollar spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUOSBTC": {
+    "normalized_id": "UOS/BTC",
+    "base": "UOS",
+    "quote": "BTC",
+    "display_name": "UOS / Bitcoin",
+    "description": "UOS to Bitcoin spot trading pair",
+    "tags": [
+      "uos",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tUOSUSD": {
+    "normalized_id": "UOS/USD",
+    "base": "UOS",
+    "quote": "USD",
+    "display_name": "UOS / US Dollar",
+    "description": "UOS to US Dollar spot trading pair",
+    "tags": [
+      "uos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUSDF:USD": {
+    "normalized_id": "USDF/USD",
+    "base": "USDF",
+    "quote": "USD",
+    "display_name": "USDF / US Dollar",
+    "description": "USDF to US Dollar spot trading pair",
+    "tags": [
+      "usdf",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUSDF:UST": {
+    "normalized_id": "USDF/USD",
+    "base": "USDF",
+    "quote": "USD",
+    "display_name": "USDF / US Dollar",
+    "description": "USDF to US Dollar spot trading pair",
+    "tags": [
+      "usdf",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUSDQ:USD": {
+    "normalized_id": "USDQ/USD",
+    "base": "USDQ",
+    "quote": "USD",
+    "display_name": "USDQ / US Dollar",
+    "description": "USDQ to US Dollar spot trading pair",
+    "tags": [
+      "usdq",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUSDQ:UST": {
+    "normalized_id": "USDQ/USD",
+    "base": "USDQ",
+    "quote": "USD",
+    "display_name": "USDQ / US Dollar",
+    "description": "USDQ to US Dollar spot trading pair",
+    "tags": [
+      "usdq",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUSDR:USD": {
+    "normalized_id": "USDR/USD",
+    "base": "USDR",
+    "quote": "USD",
+    "display_name": "USDR / US Dollar",
+    "description": "USDR to US Dollar spot trading pair",
+    "tags": [
+      "usdr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUSDR:UST": {
+    "normalized_id": "USDR/USD",
+    "base": "USDR",
+    "quote": "USD",
+    "display_name": "USDR / US Dollar",
+    "description": "USDR to US Dollar spot trading pair",
+    "tags": [
+      "usdr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUST:CNHT": {
+    "normalized_id": "UST/CNHT",
+    "base": "UST",
+    "quote": "CNHT",
+    "display_name": "UST / CNHT",
+    "description": "UST to CNHT spot trading pair",
+    "tags": [
+      "ust",
+      "cnht"
+    ],
+    "category": "crypto"
+  },
+  "tUST:MXNT": {
+    "normalized_id": "UST/MXNT",
+    "base": "UST",
+    "quote": "MXNT",
+    "display_name": "UST / MXNT",
+    "description": "UST to MXNT spot trading pair",
+    "tags": [
+      "ust",
+      "mxnt"
+    ],
+    "category": "crypto"
+  },
+  "tUSTBL:USD": {
+    "normalized_id": "USTBL/USD",
+    "base": "USTBL",
+    "quote": "USD",
+    "display_name": "USTBL / US Dollar",
+    "description": "USTBL to US Dollar spot trading pair",
+    "tags": [
+      "ustbl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUSTBL:UST": {
+    "normalized_id": "USTBL/USD",
+    "base": "USTBL",
+    "quote": "USD",
+    "display_name": "USTBL / US Dollar",
+    "description": "USTBL to US Dollar spot trading pair",
+    "tags": [
+      "ustbl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUSTUSD": {
+    "normalized_id": "UST/USD",
+    "base": "UST",
+    "quote": "USD",
+    "display_name": "UST / US Dollar",
+    "description": "UST to US Dollar spot trading pair",
+    "tags": [
+      "ust",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUXLINK:USD": {
+    "normalized_id": "UXLINK/USD",
+    "base": "UXLINK",
+    "quote": "USD",
+    "display_name": "UXLINK / US Dollar",
+    "description": "UXLINK to US Dollar spot trading pair",
+    "tags": [
+      "uxlink",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tUXLINK:UST": {
+    "normalized_id": "UXLINK/USD",
+    "base": "UXLINK",
+    "quote": "USD",
+    "display_name": "UXLINK / US Dollar",
+    "description": "UXLINK to US Dollar spot trading pair",
+    "tags": [
+      "uxlink",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tWBTBTC": {
+    "normalized_id": "WBT/BTC",
+    "base": "WBT",
+    "quote": "BTC",
+    "display_name": "WBT / Bitcoin",
+    "description": "WBT to Bitcoin spot trading pair",
+    "tags": [
+      "wbt",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tWBTUSD": {
+    "normalized_id": "WBT/USD",
+    "base": "WBT",
+    "quote": "USD",
+    "display_name": "WBT / US Dollar",
+    "description": "WBT to US Dollar spot trading pair",
+    "tags": [
+      "wbt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tWHBT:USD": {
+    "normalized_id": "WHBT/USD",
+    "base": "WHBT",
+    "quote": "USD",
+    "display_name": "WHBT / US Dollar",
+    "description": "WHBT to US Dollar spot trading pair",
+    "tags": [
+      "whbt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tWHBT:UST": {
+    "normalized_id": "WHBT/USD",
+    "base": "WHBT",
+    "quote": "USD",
+    "display_name": "WHBT / US Dollar",
+    "description": "WHBT to US Dollar spot trading pair",
+    "tags": [
+      "whbt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tWIFUSD": {
+    "normalized_id": "WIF/USD",
+    "base": "WIF",
+    "quote": "USD",
+    "display_name": "dogwifhat / US Dollar",
+    "description": "dogwifhat to US Dollar spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tWIFUST": {
+    "normalized_id": "WIF/USD",
+    "base": "WIF",
+    "quote": "USD",
+    "display_name": "dogwifhat / US Dollar",
+    "description": "dogwifhat to US Dollar spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tWOOUSD": {
+    "normalized_id": "WOO/USD",
+    "base": "WOO",
+    "quote": "USD",
+    "display_name": "WOO / US Dollar",
+    "description": "WOO to US Dollar spot trading pair",
+    "tags": [
+      "woo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tWOOUST": {
+    "normalized_id": "WOO/USD",
+    "base": "WOO",
+    "quote": "USD",
+    "display_name": "WOO / US Dollar",
+    "description": "WOO to US Dollar spot trading pair",
+    "tags": [
+      "woo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tXAUT:BTC": {
+    "normalized_id": "XAUT/BTC",
+    "base": "XAUT",
+    "quote": "BTC",
+    "display_name": "XAUT / Bitcoin",
+    "description": "XAUT to Bitcoin spot trading pair",
+    "tags": [
+      "xaut",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tXAUT:USD": {
+    "normalized_id": "XAUT/USD",
+    "base": "XAUT",
+    "quote": "USD",
+    "display_name": "XAUT / US Dollar",
+    "description": "XAUT to US Dollar spot trading pair",
+    "tags": [
+      "xaut",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tXAUT:UST": {
+    "normalized_id": "XAUT/USD",
+    "base": "XAUT",
+    "quote": "USD",
+    "display_name": "XAUT / US Dollar",
+    "description": "XAUT to US Dollar spot trading pair",
+    "tags": [
+      "xaut",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tXDCUSD": {
+    "normalized_id": "XDC/USD",
+    "base": "XDC",
+    "quote": "USD",
+    "display_name": "XDC / US Dollar",
+    "description": "XDC to US Dollar spot trading pair",
+    "tags": [
+      "xdc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tXDCUST": {
+    "normalized_id": "XDC/USD",
+    "base": "XDC",
+    "quote": "USD",
+    "display_name": "XDC / US Dollar",
+    "description": "XDC to US Dollar spot trading pair",
+    "tags": [
+      "xdc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tXLMBTC": {
+    "normalized_id": "XLM/BTC",
+    "base": "XLM",
+    "quote": "BTC",
+    "display_name": "Stellar / Bitcoin",
+    "description": "Stellar to Bitcoin spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tXLMUSD": {
+    "normalized_id": "XLM/USD",
+    "base": "XLM",
+    "quote": "USD",
+    "display_name": "Stellar / US Dollar",
+    "description": "Stellar to US Dollar spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tXLMUST": {
+    "normalized_id": "XLM/USD",
+    "base": "XLM",
+    "quote": "USD",
+    "display_name": "Stellar / US Dollar",
+    "description": "Stellar to US Dollar spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tXMRBTC": {
+    "normalized_id": "XMR/BTC",
+    "base": "XMR",
+    "quote": "BTC",
+    "display_name": "XMR / Bitcoin",
+    "description": "XMR to Bitcoin spot trading pair",
+    "tags": [
+      "xmr",
+      "privacy",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tXMRUSD": {
+    "normalized_id": "XMR/USD",
+    "base": "XMR",
+    "quote": "USD",
+    "display_name": "XMR / US Dollar",
+    "description": "XMR to US Dollar spot trading pair",
+    "tags": [
+      "xmr",
+      "privacy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tXMRUST": {
+    "normalized_id": "XMR/USD",
+    "base": "XMR",
+    "quote": "USD",
+    "display_name": "XMR / US Dollar",
+    "description": "XMR to US Dollar spot trading pair",
+    "tags": [
+      "xmr",
+      "privacy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tXRDBTC": {
+    "normalized_id": "XRD/BTC",
+    "base": "XRD",
+    "quote": "BTC",
+    "display_name": "XRD / Bitcoin",
+    "description": "XRD to Bitcoin spot trading pair",
+    "tags": [
+      "xrd",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tXRDUSD": {
+    "normalized_id": "XRD/USD",
+    "base": "XRD",
+    "quote": "USD",
+    "display_name": "XRD / US Dollar",
+    "description": "XRD to US Dollar spot trading pair",
+    "tags": [
+      "xrd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tXRPBTC": {
+    "normalized_id": "XRP/BTC",
+    "base": "XRP",
+    "quote": "BTC",
+    "display_name": "Ripple / Bitcoin",
+    "description": "Ripple to Bitcoin spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tXRPUSD": {
+    "normalized_id": "XRP/USD",
+    "base": "XRP",
+    "quote": "USD",
+    "display_name": "Ripple / US Dollar",
+    "description": "Ripple to US Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tXRPUST": {
+    "normalized_id": "XRP/USD",
+    "base": "XRP",
+    "quote": "USD",
+    "display_name": "Ripple / US Dollar",
+    "description": "Ripple to US Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tXTZUSD": {
+    "normalized_id": "XTZ/USD",
+    "base": "XTZ",
+    "quote": "USD",
+    "display_name": "Tezos / US Dollar",
+    "description": "Tezos to US Dollar spot trading pair",
+    "tags": [
+      "xtz",
+      "tezos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tYFIUSD": {
+    "normalized_id": "YFI/USD",
+    "base": "YFI",
+    "quote": "USD",
+    "display_name": "YFI / US Dollar",
+    "description": "YFI to US Dollar spot trading pair",
+    "tags": [
+      "yfi",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tYFIUST": {
+    "normalized_id": "YFI/USD",
+    "base": "YFI",
+    "quote": "USD",
+    "display_name": "YFI / US Dollar",
+    "description": "YFI to US Dollar spot trading pair",
+    "tags": [
+      "yfi",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tZECBTC": {
+    "normalized_id": "ZEC/BTC",
+    "base": "ZEC",
+    "quote": "BTC",
+    "display_name": "ZEC / Bitcoin",
+    "description": "ZEC to Bitcoin spot trading pair",
+    "tags": [
+      "zec",
+      "privacy",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "tZECUSD": {
+    "normalized_id": "ZEC/USD",
+    "base": "ZEC",
+    "quote": "USD",
+    "display_name": "ZEC / US Dollar",
+    "description": "ZEC to US Dollar spot trading pair",
+    "tags": [
+      "zec",
+      "privacy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tZKXUSD": {
+    "normalized_id": "ZKX/USD",
+    "base": "ZKX",
+    "quote": "USD",
+    "display_name": "ZKX / US Dollar",
+    "description": "ZKX to US Dollar spot trading pair",
+    "tags": [
+      "zkx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tZKXUST": {
+    "normalized_id": "ZKX/USD",
+    "base": "ZKX",
+    "quote": "USD",
+    "display_name": "ZKX / US Dollar",
+    "description": "ZKX to US Dollar spot trading pair",
+    "tags": [
+      "zkx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tZROUSD": {
+    "normalized_id": "ZRO/USD",
+    "base": "ZRO",
+    "quote": "USD",
+    "display_name": "ZRO / US Dollar",
+    "description": "ZRO to US Dollar spot trading pair",
+    "tags": [
+      "zro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tZROUST": {
+    "normalized_id": "ZRO/USD",
+    "base": "ZRO",
+    "quote": "USD",
+    "display_name": "ZRO / US Dollar",
+    "description": "ZRO to US Dollar spot trading pair",
+    "tags": [
+      "zro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "tZRXUSD": {
+    "normalized_id": "ZRX/USD",
+    "base": "ZRX",
+    "quote": "USD",
+    "display_name": "0x / US Dollar",
+    "description": "0x to US Dollar spot trading pair",
+    "tags": [
+      "zrx",
+      "0x",
+      "usd"
+    ],
+    "category": "crypto"
+  }
+}

--- a/server/src/symbols/configs/coinbase.json
+++ b/server/src/symbols/configs/coinbase.json
@@ -1,0 +1,5873 @@
+{
+  "00-USD": {
+    "normalized_id": "00/USD",
+    "base": "00",
+    "quote": "USD",
+    "display_name": "00 / US Dollar",
+    "description": "00 to US Dollar spot trading pair",
+    "tags": [
+      "00",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "1INCH-EUR": {
+    "normalized_id": "1INCH/EUR",
+    "base": "1INCH",
+    "quote": "EUR",
+    "display_name": "1INCH / Euro",
+    "description": "1INCH to Euro spot trading pair",
+    "tags": [
+      "1inch",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "1INCH-GBP": {
+    "normalized_id": "1INCH/GBP",
+    "base": "1INCH",
+    "quote": "GBP",
+    "display_name": "1INCH / British Pound",
+    "description": "1INCH to British Pound spot trading pair",
+    "tags": [
+      "1inch",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "1INCH-USD": {
+    "normalized_id": "1INCH/USD",
+    "base": "1INCH",
+    "quote": "USD",
+    "display_name": "1INCH / US Dollar",
+    "description": "1INCH to US Dollar spot trading pair",
+    "tags": [
+      "1inch",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "A8-USD": {
+    "normalized_id": "A8/USD",
+    "base": "A8",
+    "quote": "USD",
+    "display_name": "A8 / US Dollar",
+    "description": "A8 to US Dollar spot trading pair",
+    "tags": [
+      "a8",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AAVE-BTC": {
+    "normalized_id": "AAVE/BTC",
+    "base": "AAVE",
+    "quote": "BTC",
+    "display_name": "Aave / Bitcoin",
+    "description": "Aave to Bitcoin spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "AAVE-EUR": {
+    "normalized_id": "AAVE/EUR",
+    "base": "AAVE",
+    "quote": "EUR",
+    "display_name": "Aave / Euro",
+    "description": "Aave to Euro spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AAVE-GBP": {
+    "normalized_id": "AAVE/GBP",
+    "base": "AAVE",
+    "quote": "GBP",
+    "display_name": "Aave / British Pound",
+    "description": "Aave to British Pound spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "AAVE-USD": {
+    "normalized_id": "AAVE/USD",
+    "base": "AAVE",
+    "quote": "USD",
+    "display_name": "Aave / US Dollar",
+    "description": "Aave to US Dollar spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ABT-USD": {
+    "normalized_id": "ABT/USD",
+    "base": "ABT",
+    "quote": "USD",
+    "display_name": "ABT / US Dollar",
+    "description": "ABT to US Dollar spot trading pair",
+    "tags": [
+      "abt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACH-USD": {
+    "normalized_id": "ACH/USD",
+    "base": "ACH",
+    "quote": "USD",
+    "display_name": "ACH / US Dollar",
+    "description": "ACH to US Dollar spot trading pair",
+    "tags": [
+      "ach",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACS-USD": {
+    "normalized_id": "ACS/USD",
+    "base": "ACS",
+    "quote": "USD",
+    "display_name": "ACS / US Dollar",
+    "description": "ACS to US Dollar spot trading pair",
+    "tags": [
+      "acs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACX-USD": {
+    "normalized_id": "ACX/USD",
+    "base": "ACX",
+    "quote": "USD",
+    "display_name": "ACX / US Dollar",
+    "description": "ACX to US Dollar spot trading pair",
+    "tags": [
+      "acx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ADA-BTC": {
+    "normalized_id": "ADA/BTC",
+    "base": "ADA",
+    "quote": "BTC",
+    "display_name": "Cardano / Bitcoin",
+    "description": "Cardano to Bitcoin spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ADA-ETH": {
+    "normalized_id": "ADA/ETH",
+    "base": "ADA",
+    "quote": "ETH",
+    "display_name": "Cardano / Ethereum",
+    "description": "Cardano to Ethereum spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "ADA-EUR": {
+    "normalized_id": "ADA/EUR",
+    "base": "ADA",
+    "quote": "EUR",
+    "display_name": "Cardano / Euro",
+    "description": "Cardano to Euro spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ADA-GBP": {
+    "normalized_id": "ADA/GBP",
+    "base": "ADA",
+    "quote": "GBP",
+    "display_name": "Cardano / British Pound",
+    "description": "Cardano to British Pound spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "ADA-USD": {
+    "normalized_id": "ADA/USD",
+    "base": "ADA",
+    "quote": "USD",
+    "display_name": "Cardano / US Dollar",
+    "description": "Cardano to US Dollar spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ADA-USDT": {
+    "normalized_id": "ADA/USD",
+    "base": "ADA",
+    "quote": "USD",
+    "display_name": "Cardano / US Dollar",
+    "description": "Cardano to US Dollar spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AERGO-USD": {
+    "normalized_id": "AERGO/USD",
+    "base": "AERGO",
+    "quote": "USD",
+    "display_name": "AERGO / US Dollar",
+    "description": "AERGO to US Dollar spot trading pair",
+    "tags": [
+      "aergo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AERO-USD": {
+    "normalized_id": "AERO/USD",
+    "base": "AERO",
+    "quote": "USD",
+    "display_name": "AERO / US Dollar",
+    "description": "AERO to US Dollar spot trading pair",
+    "tags": [
+      "aero",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AGLD-USD": {
+    "normalized_id": "AGLD/USD",
+    "base": "AGLD",
+    "quote": "USD",
+    "display_name": "AGLD / US Dollar",
+    "description": "AGLD to US Dollar spot trading pair",
+    "tags": [
+      "agld",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AIOZ-USD": {
+    "normalized_id": "AIOZ/USD",
+    "base": "AIOZ",
+    "quote": "USD",
+    "display_name": "AIOZ / US Dollar",
+    "description": "AIOZ to US Dollar spot trading pair",
+    "tags": [
+      "aioz",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AKT-USD": {
+    "normalized_id": "AKT/USD",
+    "base": "AKT",
+    "quote": "USD",
+    "display_name": "AKT / US Dollar",
+    "description": "AKT to US Dollar spot trading pair",
+    "tags": [
+      "akt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALCX-USD": {
+    "normalized_id": "ALCX/USD",
+    "base": "ALCX",
+    "quote": "USD",
+    "display_name": "ALCX / US Dollar",
+    "description": "ALCX to US Dollar spot trading pair",
+    "tags": [
+      "alcx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALEO-USD": {
+    "normalized_id": "ALEO/USD",
+    "base": "ALEO",
+    "quote": "USD",
+    "display_name": "ALEO / US Dollar",
+    "description": "ALEO to US Dollar spot trading pair",
+    "tags": [
+      "aleo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALEPH-USD": {
+    "normalized_id": "ALEPH/USD",
+    "base": "ALEPH",
+    "quote": "USD",
+    "display_name": "ALEPH / US Dollar",
+    "description": "ALEPH to US Dollar spot trading pair",
+    "tags": [
+      "aleph",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALGO-BTC": {
+    "normalized_id": "ALGO/BTC",
+    "base": "ALGO",
+    "quote": "BTC",
+    "display_name": "Algorand / Bitcoin",
+    "description": "Algorand to Bitcoin spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ALGO-EUR": {
+    "normalized_id": "ALGO/EUR",
+    "base": "ALGO",
+    "quote": "EUR",
+    "display_name": "Algorand / Euro",
+    "description": "Algorand to Euro spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ALGO-GBP": {
+    "normalized_id": "ALGO/GBP",
+    "base": "ALGO",
+    "quote": "GBP",
+    "display_name": "Algorand / British Pound",
+    "description": "Algorand to British Pound spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "ALGO-USD": {
+    "normalized_id": "ALGO/USD",
+    "base": "ALGO",
+    "quote": "USD",
+    "display_name": "Algorand / US Dollar",
+    "description": "Algorand to US Dollar spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALICE-USD": {
+    "normalized_id": "ALICE/USD",
+    "base": "ALICE",
+    "quote": "USD",
+    "display_name": "ALICE / US Dollar",
+    "description": "ALICE to US Dollar spot trading pair",
+    "tags": [
+      "alice",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALT-USD": {
+    "normalized_id": "ALT/USD",
+    "base": "ALT",
+    "quote": "USD",
+    "display_name": "ALT / US Dollar",
+    "description": "ALT to US Dollar spot trading pair",
+    "tags": [
+      "alt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AMP-USD": {
+    "normalized_id": "AMP/USD",
+    "base": "AMP",
+    "quote": "USD",
+    "display_name": "AMP / US Dollar",
+    "description": "AMP to US Dollar spot trading pair",
+    "tags": [
+      "amp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ANKR-EUR": {
+    "normalized_id": "ANKR/EUR",
+    "base": "ANKR",
+    "quote": "EUR",
+    "display_name": "ANKR / Euro",
+    "description": "ANKR to Euro spot trading pair",
+    "tags": [
+      "ankr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ANKR-GBP": {
+    "normalized_id": "ANKR/GBP",
+    "base": "ANKR",
+    "quote": "GBP",
+    "display_name": "ANKR / British Pound",
+    "description": "ANKR to British Pound spot trading pair",
+    "tags": [
+      "ankr",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "ANKR-USD": {
+    "normalized_id": "ANKR/USD",
+    "base": "ANKR",
+    "quote": "USD",
+    "display_name": "ANKR / US Dollar",
+    "description": "ANKR to US Dollar spot trading pair",
+    "tags": [
+      "ankr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APE-EUR": {
+    "normalized_id": "APE/EUR",
+    "base": "APE",
+    "quote": "EUR",
+    "display_name": "APE / Euro",
+    "description": "APE to Euro spot trading pair",
+    "tags": [
+      "ape",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "APE-USD": {
+    "normalized_id": "APE/USD",
+    "base": "APE",
+    "quote": "USD",
+    "display_name": "APE / US Dollar",
+    "description": "APE to US Dollar spot trading pair",
+    "tags": [
+      "ape",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APE-USDT": {
+    "normalized_id": "APE/USD",
+    "base": "APE",
+    "quote": "USD",
+    "display_name": "APE / US Dollar",
+    "description": "APE to US Dollar spot trading pair",
+    "tags": [
+      "ape",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "API3-USD": {
+    "normalized_id": "API3/USD",
+    "base": "API3",
+    "quote": "USD",
+    "display_name": "API3 / US Dollar",
+    "description": "API3 to US Dollar spot trading pair",
+    "tags": [
+      "api3",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APT-USD": {
+    "normalized_id": "APT/USD",
+    "base": "APT",
+    "quote": "USD",
+    "display_name": "Aptos / US Dollar",
+    "description": "Aptos to US Dollar spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APT-USDT": {
+    "normalized_id": "APT/USD",
+    "base": "APT",
+    "quote": "USD",
+    "display_name": "Aptos / US Dollar",
+    "description": "Aptos to US Dollar spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARB-USD": {
+    "normalized_id": "ARB/USD",
+    "base": "ARB",
+    "quote": "USD",
+    "display_name": "Arbitrum / US Dollar",
+    "description": "Arbitrum to US Dollar spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARKM-USD": {
+    "normalized_id": "ARKM/USD",
+    "base": "ARKM",
+    "quote": "USD",
+    "display_name": "ARKM / US Dollar",
+    "description": "ARKM to US Dollar spot trading pair",
+    "tags": [
+      "arkm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARPA-USD": {
+    "normalized_id": "ARPA/USD",
+    "base": "ARPA",
+    "quote": "USD",
+    "display_name": "ARPA / US Dollar",
+    "description": "ARPA to US Dollar spot trading pair",
+    "tags": [
+      "arpa",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ASM-USD": {
+    "normalized_id": "ASM/USD",
+    "base": "ASM",
+    "quote": "USD",
+    "display_name": "ASM / US Dollar",
+    "description": "ASM to US Dollar spot trading pair",
+    "tags": [
+      "asm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AST-USD": {
+    "normalized_id": "AST/USD",
+    "base": "AST",
+    "quote": "USD",
+    "display_name": "AST / US Dollar",
+    "description": "AST to US Dollar spot trading pair",
+    "tags": [
+      "ast",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATH-USD": {
+    "normalized_id": "ATH/USD",
+    "base": "ATH",
+    "quote": "USD",
+    "display_name": "ATH / US Dollar",
+    "description": "ATH to US Dollar spot trading pair",
+    "tags": [
+      "ath",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATOM-BTC": {
+    "normalized_id": "ATOM/BTC",
+    "base": "ATOM",
+    "quote": "BTC",
+    "display_name": "Cosmos / Bitcoin",
+    "description": "Cosmos to Bitcoin spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ATOM-EUR": {
+    "normalized_id": "ATOM/EUR",
+    "base": "ATOM",
+    "quote": "EUR",
+    "display_name": "Cosmos / Euro",
+    "description": "Cosmos to Euro spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ATOM-GBP": {
+    "normalized_id": "ATOM/GBP",
+    "base": "ATOM",
+    "quote": "GBP",
+    "display_name": "Cosmos / British Pound",
+    "description": "Cosmos to British Pound spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "ATOM-USD": {
+    "normalized_id": "ATOM/USD",
+    "base": "ATOM",
+    "quote": "USD",
+    "display_name": "Cosmos / US Dollar",
+    "description": "Cosmos to US Dollar spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATOM-USDT": {
+    "normalized_id": "ATOM/USD",
+    "base": "ATOM",
+    "quote": "USD",
+    "display_name": "Cosmos / US Dollar",
+    "description": "Cosmos to US Dollar spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AUCTION-USD": {
+    "normalized_id": "AUCTION/USD",
+    "base": "AUCTION",
+    "quote": "USD",
+    "display_name": "AUCTION / US Dollar",
+    "description": "AUCTION to US Dollar spot trading pair",
+    "tags": [
+      "auction",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AUDIO-USD": {
+    "normalized_id": "AUDIO/USD",
+    "base": "AUDIO",
+    "quote": "USD",
+    "display_name": "AUDIO / US Dollar",
+    "description": "AUDIO to US Dollar spot trading pair",
+    "tags": [
+      "audio",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AURORA-USD": {
+    "normalized_id": "AURORA/USD",
+    "base": "AURORA",
+    "quote": "USD",
+    "display_name": "AURORA / US Dollar",
+    "description": "AURORA to US Dollar spot trading pair",
+    "tags": [
+      "aurora",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AVAX-BTC": {
+    "normalized_id": "AVAX/BTC",
+    "base": "AVAX",
+    "quote": "BTC",
+    "display_name": "Avalanche / Bitcoin",
+    "description": "Avalanche to Bitcoin spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "AVAX-EUR": {
+    "normalized_id": "AVAX/EUR",
+    "base": "AVAX",
+    "quote": "EUR",
+    "display_name": "Avalanche / Euro",
+    "description": "Avalanche to Euro spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AVAX-USD": {
+    "normalized_id": "AVAX/USD",
+    "base": "AVAX",
+    "quote": "USD",
+    "display_name": "Avalanche / US Dollar",
+    "description": "Avalanche to US Dollar spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AVAX-USDT": {
+    "normalized_id": "AVAX/USD",
+    "base": "AVAX",
+    "quote": "USD",
+    "display_name": "Avalanche / US Dollar",
+    "description": "Avalanche to US Dollar spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AVT-USD": {
+    "normalized_id": "AVT/USD",
+    "base": "AVT",
+    "quote": "USD",
+    "display_name": "AVT / US Dollar",
+    "description": "AVT to US Dollar spot trading pair",
+    "tags": [
+      "avt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AXL-USD": {
+    "normalized_id": "AXL/USD",
+    "base": "AXL",
+    "quote": "USD",
+    "display_name": "AXL / US Dollar",
+    "description": "AXL to US Dollar spot trading pair",
+    "tags": [
+      "axl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AXS-BTC": {
+    "normalized_id": "AXS/BTC",
+    "base": "AXS",
+    "quote": "BTC",
+    "display_name": "Axie Infinity / Bitcoin",
+    "description": "Axie Infinity to Bitcoin spot trading pair",
+    "tags": [
+      "axs",
+      "axie infinity",
+      "gaming",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "AXS-EUR": {
+    "normalized_id": "AXS/EUR",
+    "base": "AXS",
+    "quote": "EUR",
+    "display_name": "Axie Infinity / Euro",
+    "description": "Axie Infinity to Euro spot trading pair",
+    "tags": [
+      "axs",
+      "axie infinity",
+      "gaming",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AXS-USD": {
+    "normalized_id": "AXS/USD",
+    "base": "AXS",
+    "quote": "USD",
+    "display_name": "Axie Infinity / US Dollar",
+    "description": "Axie Infinity to US Dollar spot trading pair",
+    "tags": [
+      "axs",
+      "axie infinity",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AXS-USDT": {
+    "normalized_id": "AXS/USD",
+    "base": "AXS",
+    "quote": "USD",
+    "display_name": "Axie Infinity / US Dollar",
+    "description": "Axie Infinity to US Dollar spot trading pair",
+    "tags": [
+      "axs",
+      "axie infinity",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "B3-USD": {
+    "normalized_id": "B3/USD",
+    "base": "B3",
+    "quote": "USD",
+    "display_name": "B3 / US Dollar",
+    "description": "B3 to US Dollar spot trading pair",
+    "tags": [
+      "b3",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BADGER-USD": {
+    "normalized_id": "BADGER/USD",
+    "base": "BADGER",
+    "quote": "USD",
+    "display_name": "BADGER / US Dollar",
+    "description": "BADGER to US Dollar spot trading pair",
+    "tags": [
+      "badger",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BAL-USD": {
+    "normalized_id": "BAL/USD",
+    "base": "BAL",
+    "quote": "USD",
+    "display_name": "BAL / US Dollar",
+    "description": "BAL to US Dollar spot trading pair",
+    "tags": [
+      "bal",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BAND-USD": {
+    "normalized_id": "BAND/USD",
+    "base": "BAND",
+    "quote": "USD",
+    "display_name": "BAND / US Dollar",
+    "description": "BAND to US Dollar spot trading pair",
+    "tags": [
+      "band",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BAT-BTC": {
+    "normalized_id": "BAT/BTC",
+    "base": "BAT",
+    "quote": "BTC",
+    "display_name": "Basic Attention Token / Bitcoin",
+    "description": "Basic Attention Token to Bitcoin spot trading pair",
+    "tags": [
+      "bat",
+      "basic attention token",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "BAT-ETH": {
+    "normalized_id": "BAT/ETH",
+    "base": "BAT",
+    "quote": "ETH",
+    "display_name": "Basic Attention Token / Ethereum",
+    "description": "Basic Attention Token to Ethereum spot trading pair",
+    "tags": [
+      "bat",
+      "basic attention token",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "BAT-EUR": {
+    "normalized_id": "BAT/EUR",
+    "base": "BAT",
+    "quote": "EUR",
+    "display_name": "Basic Attention Token / Euro",
+    "description": "Basic Attention Token to Euro spot trading pair",
+    "tags": [
+      "bat",
+      "basic attention token",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BAT-USD": {
+    "normalized_id": "BAT/USD",
+    "base": "BAT",
+    "quote": "USD",
+    "display_name": "Basic Attention Token / US Dollar",
+    "description": "Basic Attention Token to US Dollar spot trading pair",
+    "tags": [
+      "bat",
+      "basic attention token",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BCH-BTC": {
+    "normalized_id": "BCH/BTC",
+    "base": "BCH",
+    "quote": "BTC",
+    "display_name": "Bitcoin Cash / Bitcoin",
+    "description": "Bitcoin Cash to Bitcoin spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "BCH-EUR": {
+    "normalized_id": "BCH/EUR",
+    "base": "BCH",
+    "quote": "EUR",
+    "display_name": "Bitcoin Cash / Euro",
+    "description": "Bitcoin Cash to Euro spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BCH-GBP": {
+    "normalized_id": "BCH/GBP",
+    "base": "BCH",
+    "quote": "GBP",
+    "display_name": "Bitcoin Cash / British Pound",
+    "description": "Bitcoin Cash to British Pound spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "BCH-USD": {
+    "normalized_id": "BCH/USD",
+    "base": "BCH",
+    "quote": "USD",
+    "display_name": "Bitcoin Cash / US Dollar",
+    "description": "Bitcoin Cash to US Dollar spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BERA-USD": {
+    "normalized_id": "BERA/USD",
+    "base": "BERA",
+    "quote": "USD",
+    "display_name": "BERA / US Dollar",
+    "description": "BERA to US Dollar spot trading pair",
+    "tags": [
+      "bera",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BICO-USD": {
+    "normalized_id": "BICO/USD",
+    "base": "BICO",
+    "quote": "USD",
+    "display_name": "BICO / US Dollar",
+    "description": "BICO to US Dollar spot trading pair",
+    "tags": [
+      "bico",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BIGTIME-USD": {
+    "normalized_id": "BIGTIME/USD",
+    "base": "BIGTIME",
+    "quote": "USD",
+    "display_name": "BIGTIME / US Dollar",
+    "description": "BIGTIME to US Dollar spot trading pair",
+    "tags": [
+      "bigtime",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BIO-USD": {
+    "normalized_id": "BIO/USD",
+    "base": "BIO",
+    "quote": "USD",
+    "display_name": "BIO / US Dollar",
+    "description": "BIO to US Dollar spot trading pair",
+    "tags": [
+      "bio",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BLAST-USD": {
+    "normalized_id": "BLAST/USD",
+    "base": "BLAST",
+    "quote": "USD",
+    "display_name": "BLAST / US Dollar",
+    "description": "BLAST to US Dollar spot trading pair",
+    "tags": [
+      "blast",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BLUR-USD": {
+    "normalized_id": "BLUR/USD",
+    "base": "BLUR",
+    "quote": "USD",
+    "display_name": "BLUR / US Dollar",
+    "description": "BLUR to US Dollar spot trading pair",
+    "tags": [
+      "blur",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BLZ-USD": {
+    "normalized_id": "BLZ/USD",
+    "base": "BLZ",
+    "quote": "USD",
+    "display_name": "BLZ / US Dollar",
+    "description": "BLZ to US Dollar spot trading pair",
+    "tags": [
+      "blz",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNKR-USD": {
+    "normalized_id": "BNKR/USD",
+    "base": "BNKR",
+    "quote": "USD",
+    "display_name": "BNKR / US Dollar",
+    "description": "BNKR to US Dollar spot trading pair",
+    "tags": [
+      "bnkr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNT-USD": {
+    "normalized_id": "BNT/USD",
+    "base": "BNT",
+    "quote": "USD",
+    "display_name": "BNT / US Dollar",
+    "description": "BNT to US Dollar spot trading pair",
+    "tags": [
+      "bnt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BOBA-USD": {
+    "normalized_id": "BOBA/USD",
+    "base": "BOBA",
+    "quote": "USD",
+    "display_name": "BOBA / US Dollar",
+    "description": "BOBA to US Dollar spot trading pair",
+    "tags": [
+      "boba",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BONK-USD": {
+    "normalized_id": "BONK/USD",
+    "base": "BONK",
+    "quote": "USD",
+    "display_name": "Bonk / US Dollar",
+    "description": "Bonk to US Dollar spot trading pair",
+    "tags": [
+      "bonk",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BTC-EUR": {
+    "normalized_id": "BTC/EUR",
+    "base": "BTC",
+    "quote": "EUR",
+    "display_name": "Bitcoin / Euro",
+    "description": "Bitcoin to Euro spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BTC-GBP": {
+    "normalized_id": "BTC/GBP",
+    "base": "BTC",
+    "quote": "GBP",
+    "display_name": "Bitcoin / British Pound",
+    "description": "Bitcoin to British Pound spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "BTC-USD": {
+    "normalized_id": "BTC/USD",
+    "base": "BTC",
+    "quote": "USD",
+    "display_name": "Bitcoin / US Dollar",
+    "description": "Bitcoin to US Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BTC-USDT": {
+    "normalized_id": "BTC/USD",
+    "base": "BTC",
+    "quote": "USD",
+    "display_name": "Bitcoin / US Dollar",
+    "description": "Bitcoin to US Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BTRST-USD": {
+    "normalized_id": "BTRST/USD",
+    "base": "BTRST",
+    "quote": "USD",
+    "display_name": "BTRST / US Dollar",
+    "description": "BTRST to US Dollar spot trading pair",
+    "tags": [
+      "btrst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "C98-USD": {
+    "normalized_id": "C98/USD",
+    "base": "C98",
+    "quote": "USD",
+    "display_name": "C98 / US Dollar",
+    "description": "C98 to US Dollar spot trading pair",
+    "tags": [
+      "c98",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CAKE-USD": {
+    "normalized_id": "CAKE/USD",
+    "base": "CAKE",
+    "quote": "USD",
+    "display_name": "CAKE / US Dollar",
+    "description": "CAKE to US Dollar spot trading pair",
+    "tags": [
+      "cake",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CBETH-ETH": {
+    "normalized_id": "CBETH/ETH",
+    "base": "CBETH",
+    "quote": "ETH",
+    "display_name": "CBETH / Ethereum",
+    "description": "CBETH to Ethereum spot trading pair",
+    "tags": [
+      "cbeth",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "CBETH-USD": {
+    "normalized_id": "CBETH/USD",
+    "base": "CBETH",
+    "quote": "USD",
+    "display_name": "CBETH / US Dollar",
+    "description": "CBETH to US Dollar spot trading pair",
+    "tags": [
+      "cbeth",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CELR-USD": {
+    "normalized_id": "CELR/USD",
+    "base": "CELR",
+    "quote": "USD",
+    "display_name": "CELR / US Dollar",
+    "description": "CELR to US Dollar spot trading pair",
+    "tags": [
+      "celr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CGLD-EUR": {
+    "normalized_id": "CGLD/EUR",
+    "base": "CGLD",
+    "quote": "EUR",
+    "display_name": "CGLD / Euro",
+    "description": "CGLD to Euro spot trading pair",
+    "tags": [
+      "cgld",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CGLD-GBP": {
+    "normalized_id": "CGLD/GBP",
+    "base": "CGLD",
+    "quote": "GBP",
+    "display_name": "CGLD / British Pound",
+    "description": "CGLD to British Pound spot trading pair",
+    "tags": [
+      "cgld",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "CGLD-USD": {
+    "normalized_id": "CGLD/USD",
+    "base": "CGLD",
+    "quote": "USD",
+    "display_name": "CGLD / US Dollar",
+    "description": "CGLD to US Dollar spot trading pair",
+    "tags": [
+      "cgld",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CHZ-EUR": {
+    "normalized_id": "CHZ/EUR",
+    "base": "CHZ",
+    "quote": "EUR",
+    "display_name": "Chiliz / Euro",
+    "description": "Chiliz to Euro spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CHZ-GBP": {
+    "normalized_id": "CHZ/GBP",
+    "base": "CHZ",
+    "quote": "GBP",
+    "display_name": "Chiliz / British Pound",
+    "description": "Chiliz to British Pound spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "CHZ-USD": {
+    "normalized_id": "CHZ/USD",
+    "base": "CHZ",
+    "quote": "USD",
+    "display_name": "Chiliz / US Dollar",
+    "description": "Chiliz to US Dollar spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CHZ-USDT": {
+    "normalized_id": "CHZ/USD",
+    "base": "CHZ",
+    "quote": "USD",
+    "display_name": "Chiliz / US Dollar",
+    "description": "Chiliz to US Dollar spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CLANKER-USD": {
+    "normalized_id": "CLANKER/USD",
+    "base": "CLANKER",
+    "quote": "USD",
+    "display_name": "CLANKER / US Dollar",
+    "description": "CLANKER to US Dollar spot trading pair",
+    "tags": [
+      "clanker",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CLV-USD": {
+    "normalized_id": "CLV/USD",
+    "base": "CLV",
+    "quote": "USD",
+    "display_name": "CLV / US Dollar",
+    "description": "CLV to US Dollar spot trading pair",
+    "tags": [
+      "clv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COMP-BTC": {
+    "normalized_id": "COMP/BTC",
+    "base": "COMP",
+    "quote": "BTC",
+    "display_name": "Compound / Bitcoin",
+    "description": "Compound to Bitcoin spot trading pair",
+    "tags": [
+      "comp",
+      "compound",
+      "defi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "COMP-USD": {
+    "normalized_id": "COMP/USD",
+    "base": "COMP",
+    "quote": "USD",
+    "display_name": "Compound / US Dollar",
+    "description": "Compound to US Dollar spot trading pair",
+    "tags": [
+      "comp",
+      "compound",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COOKIE-USD": {
+    "normalized_id": "COOKIE/USD",
+    "base": "COOKIE",
+    "quote": "USD",
+    "display_name": "COOKIE / US Dollar",
+    "description": "COOKIE to US Dollar spot trading pair",
+    "tags": [
+      "cookie",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CORECHAIN-USD": {
+    "normalized_id": "CORECHAIN/USD",
+    "base": "CORECHAIN",
+    "quote": "USD",
+    "display_name": "CORECHAIN / US Dollar",
+    "description": "CORECHAIN to US Dollar spot trading pair",
+    "tags": [
+      "corechain",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COSMOSDYDX-USD": {
+    "normalized_id": "COSMOSDYDX/USD",
+    "base": "COSMOSDYDX",
+    "quote": "USD",
+    "display_name": "COSMOSDYDX / US Dollar",
+    "description": "COSMOSDYDX to US Dollar spot trading pair",
+    "tags": [
+      "cosmosdydx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COTI-USD": {
+    "normalized_id": "COTI/USD",
+    "base": "COTI",
+    "quote": "USD",
+    "display_name": "COTI / US Dollar",
+    "description": "COTI to US Dollar spot trading pair",
+    "tags": [
+      "coti",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COW-USD": {
+    "normalized_id": "COW/USD",
+    "base": "COW",
+    "quote": "USD",
+    "display_name": "COW / US Dollar",
+    "description": "COW to US Dollar spot trading pair",
+    "tags": [
+      "cow",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CRO-EUR": {
+    "normalized_id": "CRO/EUR",
+    "base": "CRO",
+    "quote": "EUR",
+    "display_name": "CRO / Euro",
+    "description": "CRO to Euro spot trading pair",
+    "tags": [
+      "cro",
+      "exchange",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CRO-USD": {
+    "normalized_id": "CRO/USD",
+    "base": "CRO",
+    "quote": "USD",
+    "display_name": "CRO / US Dollar",
+    "description": "CRO to US Dollar spot trading pair",
+    "tags": [
+      "cro",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CRO-USDT": {
+    "normalized_id": "CRO/USD",
+    "base": "CRO",
+    "quote": "USD",
+    "display_name": "CRO / US Dollar",
+    "description": "CRO to US Dollar spot trading pair",
+    "tags": [
+      "cro",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CRV-BTC": {
+    "normalized_id": "CRV/BTC",
+    "base": "CRV",
+    "quote": "BTC",
+    "display_name": "Curve / Bitcoin",
+    "description": "Curve to Bitcoin spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "CRV-EUR": {
+    "normalized_id": "CRV/EUR",
+    "base": "CRV",
+    "quote": "EUR",
+    "display_name": "Curve / Euro",
+    "description": "Curve to Euro spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CRV-GBP": {
+    "normalized_id": "CRV/GBP",
+    "base": "CRV",
+    "quote": "GBP",
+    "display_name": "Curve / British Pound",
+    "description": "Curve to British Pound spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "CRV-USD": {
+    "normalized_id": "CRV/USD",
+    "base": "CRV",
+    "quote": "USD",
+    "display_name": "Curve / US Dollar",
+    "description": "Curve to US Dollar spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CTSI-USD": {
+    "normalized_id": "CTSI/USD",
+    "base": "CTSI",
+    "quote": "USD",
+    "display_name": "CTSI / US Dollar",
+    "description": "CTSI to US Dollar spot trading pair",
+    "tags": [
+      "ctsi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CTX-USD": {
+    "normalized_id": "CTX/USD",
+    "base": "CTX",
+    "quote": "USD",
+    "display_name": "CTX / US Dollar",
+    "description": "CTX to US Dollar spot trading pair",
+    "tags": [
+      "ctx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CVC-USD": {
+    "normalized_id": "CVC/USD",
+    "base": "CVC",
+    "quote": "USD",
+    "display_name": "CVC / US Dollar",
+    "description": "CVC to US Dollar spot trading pair",
+    "tags": [
+      "cvc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CVX-USD": {
+    "normalized_id": "CVX/USD",
+    "base": "CVX",
+    "quote": "USD",
+    "display_name": "CVX / US Dollar",
+    "description": "CVX to US Dollar spot trading pair",
+    "tags": [
+      "cvx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DAI-USD": {
+    "normalized_id": "DAI/USD",
+    "base": "DAI",
+    "quote": "USD",
+    "display_name": "Dai / US Dollar",
+    "description": "Dai to US Dollar spot trading pair",
+    "tags": [
+      "dai",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DASH-BTC": {
+    "normalized_id": "DASH/BTC",
+    "base": "DASH",
+    "quote": "BTC",
+    "display_name": "DASH / Bitcoin",
+    "description": "DASH to Bitcoin spot trading pair",
+    "tags": [
+      "dash",
+      "privacy",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "DASH-USD": {
+    "normalized_id": "DASH/USD",
+    "base": "DASH",
+    "quote": "USD",
+    "display_name": "DASH / US Dollar",
+    "description": "DASH to US Dollar spot trading pair",
+    "tags": [
+      "dash",
+      "privacy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DEGEN-USD": {
+    "normalized_id": "DEGEN/USD",
+    "base": "DEGEN",
+    "quote": "USD",
+    "display_name": "DEGEN / US Dollar",
+    "description": "DEGEN to US Dollar spot trading pair",
+    "tags": [
+      "degen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DEXT-USD": {
+    "normalized_id": "DEXT/USD",
+    "base": "DEXT",
+    "quote": "USD",
+    "display_name": "DEXT / US Dollar",
+    "description": "DEXT to US Dollar spot trading pair",
+    "tags": [
+      "dext",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DIA-USD": {
+    "normalized_id": "DIA/USD",
+    "base": "DIA",
+    "quote": "USD",
+    "display_name": "DIA / US Dollar",
+    "description": "DIA to US Dollar spot trading pair",
+    "tags": [
+      "dia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DIMO-USD": {
+    "normalized_id": "DIMO/USD",
+    "base": "DIMO",
+    "quote": "USD",
+    "display_name": "DIMO / US Dollar",
+    "description": "DIMO to US Dollar spot trading pair",
+    "tags": [
+      "dimo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DNT-USD": {
+    "normalized_id": "DNT/USD",
+    "base": "DNT",
+    "quote": "USD",
+    "display_name": "DNT / US Dollar",
+    "description": "DNT to US Dollar spot trading pair",
+    "tags": [
+      "dnt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGE-BTC": {
+    "normalized_id": "DOGE/BTC",
+    "base": "DOGE",
+    "quote": "BTC",
+    "display_name": "Dogecoin / Bitcoin",
+    "description": "Dogecoin to Bitcoin spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "DOGE-EUR": {
+    "normalized_id": "DOGE/EUR",
+    "base": "DOGE",
+    "quote": "EUR",
+    "display_name": "Dogecoin / Euro",
+    "description": "Dogecoin to Euro spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DOGE-GBP": {
+    "normalized_id": "DOGE/GBP",
+    "base": "DOGE",
+    "quote": "GBP",
+    "display_name": "Dogecoin / British Pound",
+    "description": "Dogecoin to British Pound spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "DOGE-USD": {
+    "normalized_id": "DOGE/USD",
+    "base": "DOGE",
+    "quote": "USD",
+    "display_name": "Dogecoin / US Dollar",
+    "description": "Dogecoin to US Dollar spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGE-USDT": {
+    "normalized_id": "DOGE/USD",
+    "base": "DOGE",
+    "quote": "USD",
+    "display_name": "Dogecoin / US Dollar",
+    "description": "Dogecoin to US Dollar spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGINME-USD": {
+    "normalized_id": "DOGINME/USD",
+    "base": "DOGINME",
+    "quote": "USD",
+    "display_name": "DOGINME / US Dollar",
+    "description": "DOGINME to US Dollar spot trading pair",
+    "tags": [
+      "doginme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOT-BTC": {
+    "normalized_id": "DOT/BTC",
+    "base": "DOT",
+    "quote": "BTC",
+    "display_name": "Polkadot / Bitcoin",
+    "description": "Polkadot to Bitcoin spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "DOT-EUR": {
+    "normalized_id": "DOT/EUR",
+    "base": "DOT",
+    "quote": "EUR",
+    "display_name": "Polkadot / Euro",
+    "description": "Polkadot to Euro spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DOT-GBP": {
+    "normalized_id": "DOT/GBP",
+    "base": "DOT",
+    "quote": "GBP",
+    "display_name": "Polkadot / British Pound",
+    "description": "Polkadot to British Pound spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "DOT-USD": {
+    "normalized_id": "DOT/USD",
+    "base": "DOT",
+    "quote": "USD",
+    "display_name": "Polkadot / US Dollar",
+    "description": "Polkadot to US Dollar spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOT-USDT": {
+    "normalized_id": "DOT/USD",
+    "base": "DOT",
+    "quote": "USD",
+    "display_name": "Polkadot / US Dollar",
+    "description": "Polkadot to US Dollar spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DRIFT-USD": {
+    "normalized_id": "DRIFT/USD",
+    "base": "DRIFT",
+    "quote": "USD",
+    "display_name": "DRIFT / US Dollar",
+    "description": "DRIFT to US Dollar spot trading pair",
+    "tags": [
+      "drift",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EDGE-USD": {
+    "normalized_id": "EDGE/USD",
+    "base": "EDGE",
+    "quote": "USD",
+    "display_name": "EDGE / US Dollar",
+    "description": "EDGE to US Dollar spot trading pair",
+    "tags": [
+      "edge",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EGLD-USD": {
+    "normalized_id": "EGLD/USD",
+    "base": "EGLD",
+    "quote": "USD",
+    "display_name": "MultiversX / US Dollar",
+    "description": "MultiversX to US Dollar spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EIGEN-USD": {
+    "normalized_id": "EIGEN/USD",
+    "base": "EIGEN",
+    "quote": "USD",
+    "display_name": "EIGEN / US Dollar",
+    "description": "EIGEN to US Dollar spot trading pair",
+    "tags": [
+      "eigen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ELA-USD": {
+    "normalized_id": "ELA/USD",
+    "base": "ELA",
+    "quote": "USD",
+    "display_name": "ELA / US Dollar",
+    "description": "ELA to US Dollar spot trading pair",
+    "tags": [
+      "ela",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENA-USD": {
+    "normalized_id": "ENA/USD",
+    "base": "ENA",
+    "quote": "USD",
+    "display_name": "ENA / US Dollar",
+    "description": "ENA to US Dollar spot trading pair",
+    "tags": [
+      "ena",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENS-EUR": {
+    "normalized_id": "ENS/EUR",
+    "base": "ENS",
+    "quote": "EUR",
+    "display_name": "ENS / Euro",
+    "description": "ENS to Euro spot trading pair",
+    "tags": [
+      "ens",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ENS-USD": {
+    "normalized_id": "ENS/USD",
+    "base": "ENS",
+    "quote": "USD",
+    "display_name": "ENS / US Dollar",
+    "description": "ENS to US Dollar spot trading pair",
+    "tags": [
+      "ens",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENS-USDT": {
+    "normalized_id": "ENS/USD",
+    "base": "ENS",
+    "quote": "USD",
+    "display_name": "ENS / US Dollar",
+    "description": "ENS to US Dollar spot trading pair",
+    "tags": [
+      "ens",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EOS-BTC": {
+    "normalized_id": "EOS/BTC",
+    "base": "EOS",
+    "quote": "BTC",
+    "display_name": "EOS / Bitcoin",
+    "description": "EOS to Bitcoin spot trading pair",
+    "tags": [
+      "eos",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "EOS-EUR": {
+    "normalized_id": "EOS/EUR",
+    "base": "EOS",
+    "quote": "EUR",
+    "display_name": "EOS / Euro",
+    "description": "EOS to Euro spot trading pair",
+    "tags": [
+      "eos",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "EOS-USD": {
+    "normalized_id": "EOS/USD",
+    "base": "EOS",
+    "quote": "USD",
+    "display_name": "EOS / US Dollar",
+    "description": "EOS to US Dollar spot trading pair",
+    "tags": [
+      "eos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ERA-USD": {
+    "normalized_id": "ERA/USD",
+    "base": "ERA",
+    "quote": "USD",
+    "display_name": "ERA / US Dollar",
+    "description": "ERA to US Dollar spot trading pair",
+    "tags": [
+      "era",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ERN-USD": {
+    "normalized_id": "ERN/USD",
+    "base": "ERN",
+    "quote": "USD",
+    "display_name": "ERN / US Dollar",
+    "description": "ERN to US Dollar spot trading pair",
+    "tags": [
+      "ern",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETC-BTC": {
+    "normalized_id": "ETC/BTC",
+    "base": "ETC",
+    "quote": "BTC",
+    "display_name": "ETC / Bitcoin",
+    "description": "ETC to Bitcoin spot trading pair",
+    "tags": [
+      "etc",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ETC-EUR": {
+    "normalized_id": "ETC/EUR",
+    "base": "ETC",
+    "quote": "EUR",
+    "display_name": "ETC / Euro",
+    "description": "ETC to Euro spot trading pair",
+    "tags": [
+      "etc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ETC-GBP": {
+    "normalized_id": "ETC/GBP",
+    "base": "ETC",
+    "quote": "GBP",
+    "display_name": "ETC / British Pound",
+    "description": "ETC to British Pound spot trading pair",
+    "tags": [
+      "etc",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "ETC-USD": {
+    "normalized_id": "ETC/USD",
+    "base": "ETC",
+    "quote": "USD",
+    "display_name": "ETC / US Dollar",
+    "description": "ETC to US Dollar spot trading pair",
+    "tags": [
+      "etc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETH-BTC": {
+    "normalized_id": "ETH/BTC",
+    "base": "ETH",
+    "quote": "BTC",
+    "display_name": "Ethereum / Bitcoin",
+    "description": "Ethereum to Bitcoin spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ETH-DAI": {
+    "normalized_id": "ETH/DAI",
+    "base": "ETH",
+    "quote": "DAI",
+    "display_name": "Ethereum / Dai",
+    "description": "Ethereum to Dai spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "dai"
+    ],
+    "category": "crypto"
+  },
+  "ETH-EUR": {
+    "normalized_id": "ETH/EUR",
+    "base": "ETH",
+    "quote": "EUR",
+    "display_name": "Ethereum / Euro",
+    "description": "Ethereum to Euro spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ETH-GBP": {
+    "normalized_id": "ETH/GBP",
+    "base": "ETH",
+    "quote": "GBP",
+    "display_name": "Ethereum / British Pound",
+    "description": "Ethereum to British Pound spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "ETH-USD": {
+    "normalized_id": "ETH/USD",
+    "base": "ETH",
+    "quote": "USD",
+    "display_name": "Ethereum / US Dollar",
+    "description": "Ethereum to US Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETH-USDT": {
+    "normalized_id": "ETH/USD",
+    "base": "ETH",
+    "quote": "USD",
+    "display_name": "Ethereum / US Dollar",
+    "description": "Ethereum to US Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETHFI-USD": {
+    "normalized_id": "ETHFI/USD",
+    "base": "ETHFI",
+    "quote": "USD",
+    "display_name": "ETHFI / US Dollar",
+    "description": "ETHFI to US Dollar spot trading pair",
+    "tags": [
+      "ethfi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EUL-USD": {
+    "normalized_id": "EUL/USD",
+    "base": "EUL",
+    "quote": "USD",
+    "display_name": "EUL / US Dollar",
+    "description": "EUL to US Dollar spot trading pair",
+    "tags": [
+      "eul",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EURC-USDC": {
+    "normalized_id": "EURC/USD",
+    "base": "EURC",
+    "quote": "USD",
+    "display_name": "EURC / US Dollar",
+    "description": "EURC to US Dollar spot trading pair",
+    "tags": [
+      "eurc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FAI-USD": {
+    "normalized_id": "FAI/USD",
+    "base": "FAI",
+    "quote": "USD",
+    "display_name": "FAI / US Dollar",
+    "description": "FAI to US Dollar spot trading pair",
+    "tags": [
+      "fai",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FARM-USD": {
+    "normalized_id": "FARM/USD",
+    "base": "FARM",
+    "quote": "USD",
+    "display_name": "FARM / US Dollar",
+    "description": "FARM to US Dollar spot trading pair",
+    "tags": [
+      "farm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FARTCOIN-USD": {
+    "normalized_id": "FARTCOIN/USD",
+    "base": "FARTCOIN",
+    "quote": "USD",
+    "display_name": "FARTCOIN / US Dollar",
+    "description": "FARTCOIN to US Dollar spot trading pair",
+    "tags": [
+      "fartcoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FET-USD": {
+    "normalized_id": "FET/USD",
+    "base": "FET",
+    "quote": "USD",
+    "display_name": "FET / US Dollar",
+    "description": "FET to US Dollar spot trading pair",
+    "tags": [
+      "fet",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FET-USDT": {
+    "normalized_id": "FET/USD",
+    "base": "FET",
+    "quote": "USD",
+    "display_name": "FET / US Dollar",
+    "description": "FET to US Dollar spot trading pair",
+    "tags": [
+      "fet",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FIDA-USD": {
+    "normalized_id": "FIDA/USD",
+    "base": "FIDA",
+    "quote": "USD",
+    "display_name": "FIDA / US Dollar",
+    "description": "FIDA to US Dollar spot trading pair",
+    "tags": [
+      "fida",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FIL-BTC": {
+    "normalized_id": "FIL/BTC",
+    "base": "FIL",
+    "quote": "BTC",
+    "display_name": "Filecoin / Bitcoin",
+    "description": "Filecoin to Bitcoin spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "FIL-EUR": {
+    "normalized_id": "FIL/EUR",
+    "base": "FIL",
+    "quote": "EUR",
+    "display_name": "Filecoin / Euro",
+    "description": "Filecoin to Euro spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FIL-GBP": {
+    "normalized_id": "FIL/GBP",
+    "base": "FIL",
+    "quote": "GBP",
+    "display_name": "Filecoin / British Pound",
+    "description": "Filecoin to British Pound spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "FIL-USD": {
+    "normalized_id": "FIL/USD",
+    "base": "FIL",
+    "quote": "USD",
+    "display_name": "Filecoin / US Dollar",
+    "description": "Filecoin to US Dollar spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FIS-USD": {
+    "normalized_id": "FIS/USD",
+    "base": "FIS",
+    "quote": "USD",
+    "display_name": "FIS / US Dollar",
+    "description": "FIS to US Dollar spot trading pair",
+    "tags": [
+      "fis",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLOKI-USD": {
+    "normalized_id": "FLOKI/USD",
+    "base": "FLOKI",
+    "quote": "USD",
+    "display_name": "Floki / US Dollar",
+    "description": "Floki to US Dollar spot trading pair",
+    "tags": [
+      "floki",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLOW-USD": {
+    "normalized_id": "FLOW/USD",
+    "base": "FLOW",
+    "quote": "USD",
+    "display_name": "Flow / US Dollar",
+    "description": "Flow to US Dollar spot trading pair",
+    "tags": [
+      "flow",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLOW-USDT": {
+    "normalized_id": "FLOW/USD",
+    "base": "FLOW",
+    "quote": "USD",
+    "display_name": "Flow / US Dollar",
+    "description": "Flow to US Dollar spot trading pair",
+    "tags": [
+      "flow",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLR-USD": {
+    "normalized_id": "FLR/USD",
+    "base": "FLR",
+    "quote": "USD",
+    "display_name": "FLR / US Dollar",
+    "description": "FLR to US Dollar spot trading pair",
+    "tags": [
+      "flr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FORT-USD": {
+    "normalized_id": "FORT/USD",
+    "base": "FORT",
+    "quote": "USD",
+    "display_name": "FORT / US Dollar",
+    "description": "FORT to US Dollar spot trading pair",
+    "tags": [
+      "fort",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FORTH-USD": {
+    "normalized_id": "FORTH/USD",
+    "base": "FORTH",
+    "quote": "USD",
+    "display_name": "FORTH / US Dollar",
+    "description": "FORTH to US Dollar spot trading pair",
+    "tags": [
+      "forth",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FOX-USD": {
+    "normalized_id": "FOX/USD",
+    "base": "FOX",
+    "quote": "USD",
+    "display_name": "FOX / US Dollar",
+    "description": "FOX to US Dollar spot trading pair",
+    "tags": [
+      "fox",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "G-USD": {
+    "normalized_id": "G/USD",
+    "base": "G",
+    "quote": "USD",
+    "display_name": "G / US Dollar",
+    "description": "G to US Dollar spot trading pair",
+    "tags": [
+      "g",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GFI-USD": {
+    "normalized_id": "GFI/USD",
+    "base": "GFI",
+    "quote": "USD",
+    "display_name": "GFI / US Dollar",
+    "description": "GFI to US Dollar spot trading pair",
+    "tags": [
+      "gfi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GHST-USD": {
+    "normalized_id": "GHST/USD",
+    "base": "GHST",
+    "quote": "USD",
+    "display_name": "GHST / US Dollar",
+    "description": "GHST to US Dollar spot trading pair",
+    "tags": [
+      "ghst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GIGA-USD": {
+    "normalized_id": "GIGA/USD",
+    "base": "GIGA",
+    "quote": "USD",
+    "display_name": "GIGA / US Dollar",
+    "description": "GIGA to US Dollar spot trading pair",
+    "tags": [
+      "giga",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GLM-USD": {
+    "normalized_id": "GLM/USD",
+    "base": "GLM",
+    "quote": "USD",
+    "display_name": "GLM / US Dollar",
+    "description": "GLM to US Dollar spot trading pair",
+    "tags": [
+      "glm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GMT-USD": {
+    "normalized_id": "GMT/USD",
+    "base": "GMT",
+    "quote": "USD",
+    "display_name": "GMT / US Dollar",
+    "description": "GMT to US Dollar spot trading pair",
+    "tags": [
+      "gmt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GMT-USDT": {
+    "normalized_id": "GMT/USD",
+    "base": "GMT",
+    "quote": "USD",
+    "display_name": "GMT / US Dollar",
+    "description": "GMT to US Dollar spot trading pair",
+    "tags": [
+      "gmt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GNO-USD": {
+    "normalized_id": "GNO/USD",
+    "base": "GNO",
+    "quote": "USD",
+    "display_name": "GNO / US Dollar",
+    "description": "GNO to US Dollar spot trading pair",
+    "tags": [
+      "gno",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GODS-USD": {
+    "normalized_id": "GODS/USD",
+    "base": "GODS",
+    "quote": "USD",
+    "display_name": "GODS / US Dollar",
+    "description": "GODS to US Dollar spot trading pair",
+    "tags": [
+      "gods",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GRT-BTC": {
+    "normalized_id": "GRT/BTC",
+    "base": "GRT",
+    "quote": "BTC",
+    "display_name": "GRT / Bitcoin",
+    "description": "GRT to Bitcoin spot trading pair",
+    "tags": [
+      "grt",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "GRT-EUR": {
+    "normalized_id": "GRT/EUR",
+    "base": "GRT",
+    "quote": "EUR",
+    "display_name": "GRT / Euro",
+    "description": "GRT to Euro spot trading pair",
+    "tags": [
+      "grt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GRT-GBP": {
+    "normalized_id": "GRT/GBP",
+    "base": "GRT",
+    "quote": "GBP",
+    "display_name": "GRT / British Pound",
+    "description": "GRT to British Pound spot trading pair",
+    "tags": [
+      "grt",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "GRT-USD": {
+    "normalized_id": "GRT/USD",
+    "base": "GRT",
+    "quote": "USD",
+    "display_name": "GRT / US Dollar",
+    "description": "GRT to US Dollar spot trading pair",
+    "tags": [
+      "grt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GST-USD": {
+    "normalized_id": "GST/USD",
+    "base": "GST",
+    "quote": "USD",
+    "display_name": "GST / US Dollar",
+    "description": "GST to US Dollar spot trading pair",
+    "tags": [
+      "gst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GTC-USD": {
+    "normalized_id": "GTC/USD",
+    "base": "GTC",
+    "quote": "USD",
+    "display_name": "GTC / US Dollar",
+    "description": "GTC to US Dollar spot trading pair",
+    "tags": [
+      "gtc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HBAR-USD": {
+    "normalized_id": "HBAR/USD",
+    "base": "HBAR",
+    "quote": "USD",
+    "display_name": "Hedera / US Dollar",
+    "description": "Hedera to US Dollar spot trading pair",
+    "tags": [
+      "hbar",
+      "hedera",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HBAR-USDT": {
+    "normalized_id": "HBAR/USD",
+    "base": "HBAR",
+    "quote": "USD",
+    "display_name": "Hedera / US Dollar",
+    "description": "Hedera to US Dollar spot trading pair",
+    "tags": [
+      "hbar",
+      "hedera",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HFT-USD": {
+    "normalized_id": "HFT/USD",
+    "base": "HFT",
+    "quote": "USD",
+    "display_name": "HFT / US Dollar",
+    "description": "HFT to US Dollar spot trading pair",
+    "tags": [
+      "hft",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HIGH-USD": {
+    "normalized_id": "HIGH/USD",
+    "base": "HIGH",
+    "quote": "USD",
+    "display_name": "HIGH / US Dollar",
+    "description": "HIGH to US Dollar spot trading pair",
+    "tags": [
+      "high",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HNT-USD": {
+    "normalized_id": "HNT/USD",
+    "base": "HNT",
+    "quote": "USD",
+    "display_name": "HNT / US Dollar",
+    "description": "HNT to US Dollar spot trading pair",
+    "tags": [
+      "hnt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HOME-USD": {
+    "normalized_id": "HOME/USD",
+    "base": "HOME",
+    "quote": "USD",
+    "display_name": "HOME / US Dollar",
+    "description": "HOME to US Dollar spot trading pair",
+    "tags": [
+      "home",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HONEY-USD": {
+    "normalized_id": "HONEY/USD",
+    "base": "HONEY",
+    "quote": "USD",
+    "display_name": "HONEY / US Dollar",
+    "description": "HONEY to US Dollar spot trading pair",
+    "tags": [
+      "honey",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HOPR-USD": {
+    "normalized_id": "HOPR/USD",
+    "base": "HOPR",
+    "quote": "USD",
+    "display_name": "HOPR / US Dollar",
+    "description": "HOPR to US Dollar spot trading pair",
+    "tags": [
+      "hopr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICP-BTC": {
+    "normalized_id": "ICP/BTC",
+    "base": "ICP",
+    "quote": "BTC",
+    "display_name": "Internet Computer / Bitcoin",
+    "description": "Internet Computer to Bitcoin spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ICP-EUR": {
+    "normalized_id": "ICP/EUR",
+    "base": "ICP",
+    "quote": "EUR",
+    "display_name": "Internet Computer / Euro",
+    "description": "Internet Computer to Euro spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ICP-GBP": {
+    "normalized_id": "ICP/GBP",
+    "base": "ICP",
+    "quote": "GBP",
+    "display_name": "Internet Computer / British Pound",
+    "description": "Internet Computer to British Pound spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "ICP-USD": {
+    "normalized_id": "ICP/USD",
+    "base": "ICP",
+    "quote": "USD",
+    "display_name": "Internet Computer / US Dollar",
+    "description": "Internet Computer to US Dollar spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICP-USDT": {
+    "normalized_id": "ICP/USD",
+    "base": "ICP",
+    "quote": "USD",
+    "display_name": "Internet Computer / US Dollar",
+    "description": "Internet Computer to US Dollar spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IDEX-USD": {
+    "normalized_id": "IDEX/USD",
+    "base": "IDEX",
+    "quote": "USD",
+    "display_name": "IDEX / US Dollar",
+    "description": "IDEX to US Dollar spot trading pair",
+    "tags": [
+      "idex",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ILV-USD": {
+    "normalized_id": "ILV/USD",
+    "base": "ILV",
+    "quote": "USD",
+    "display_name": "ILV / US Dollar",
+    "description": "ILV to US Dollar spot trading pair",
+    "tags": [
+      "ilv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IMX-USD": {
+    "normalized_id": "IMX/USD",
+    "base": "IMX",
+    "quote": "USD",
+    "display_name": "IMX / US Dollar",
+    "description": "IMX to US Dollar spot trading pair",
+    "tags": [
+      "imx",
+      "layer2",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IMX-USDT": {
+    "normalized_id": "IMX/USD",
+    "base": "IMX",
+    "quote": "USD",
+    "display_name": "IMX / US Dollar",
+    "description": "IMX to US Dollar spot trading pair",
+    "tags": [
+      "imx",
+      "layer2",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "INDEX-USD": {
+    "normalized_id": "INDEX/USD",
+    "base": "INDEX",
+    "quote": "USD",
+    "display_name": "INDEX / US Dollar",
+    "description": "INDEX to US Dollar spot trading pair",
+    "tags": [
+      "index",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "INJ-USD": {
+    "normalized_id": "INJ/USD",
+    "base": "INJ",
+    "quote": "USD",
+    "display_name": "Injective / US Dollar",
+    "description": "Injective to US Dollar spot trading pair",
+    "tags": [
+      "inj",
+      "injective",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "INV-USD": {
+    "normalized_id": "INV/USD",
+    "base": "INV",
+    "quote": "USD",
+    "display_name": "INV / US Dollar",
+    "description": "INV to US Dollar spot trading pair",
+    "tags": [
+      "inv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IO-USD": {
+    "normalized_id": "IO/USD",
+    "base": "IO",
+    "quote": "USD",
+    "display_name": "IO / US Dollar",
+    "description": "IO to US Dollar spot trading pair",
+    "tags": [
+      "io",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IOTX-USD": {
+    "normalized_id": "IOTX/USD",
+    "base": "IOTX",
+    "quote": "USD",
+    "display_name": "IOTX / US Dollar",
+    "description": "IOTX to US Dollar spot trading pair",
+    "tags": [
+      "iotx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IP-USD": {
+    "normalized_id": "IP/USD",
+    "base": "IP",
+    "quote": "USD",
+    "display_name": "IP / US Dollar",
+    "description": "IP to US Dollar spot trading pair",
+    "tags": [
+      "ip",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JASMY-USD": {
+    "normalized_id": "JASMY/USD",
+    "base": "JASMY",
+    "quote": "USD",
+    "display_name": "JASMY / US Dollar",
+    "description": "JASMY to US Dollar spot trading pair",
+    "tags": [
+      "jasmy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JASMY-USDT": {
+    "normalized_id": "JASMY/USD",
+    "base": "JASMY",
+    "quote": "USD",
+    "display_name": "JASMY / US Dollar",
+    "description": "JASMY to US Dollar spot trading pair",
+    "tags": [
+      "jasmy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JITOSOL-USD": {
+    "normalized_id": "JITOSOL/USD",
+    "base": "JITOSOL",
+    "quote": "USD",
+    "display_name": "JITOSOL / US Dollar",
+    "description": "JITOSOL to US Dollar spot trading pair",
+    "tags": [
+      "jitosol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JTO-USD": {
+    "normalized_id": "JTO/USD",
+    "base": "JTO",
+    "quote": "USD",
+    "display_name": "JTO / US Dollar",
+    "description": "JTO to US Dollar spot trading pair",
+    "tags": [
+      "jto",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAITO-USD": {
+    "normalized_id": "KAITO/USD",
+    "base": "KAITO",
+    "quote": "USD",
+    "display_name": "KAITO / US Dollar",
+    "description": "KAITO to US Dollar spot trading pair",
+    "tags": [
+      "kaito",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KARRAT-USD": {
+    "normalized_id": "KARRAT/USD",
+    "base": "KARRAT",
+    "quote": "USD",
+    "display_name": "KARRAT / US Dollar",
+    "description": "KARRAT to US Dollar spot trading pair",
+    "tags": [
+      "karrat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAVA-USD": {
+    "normalized_id": "KAVA/USD",
+    "base": "KAVA",
+    "quote": "USD",
+    "display_name": "KAVA / US Dollar",
+    "description": "KAVA to US Dollar spot trading pair",
+    "tags": [
+      "kava",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KERNEL-USD": {
+    "normalized_id": "KERNEL/USD",
+    "base": "KERNEL",
+    "quote": "USD",
+    "display_name": "KERNEL / US Dollar",
+    "description": "KERNEL to US Dollar spot trading pair",
+    "tags": [
+      "kernel",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KEYCAT-USD": {
+    "normalized_id": "KEYCAT/USD",
+    "base": "KEYCAT",
+    "quote": "USD",
+    "display_name": "KEYCAT / US Dollar",
+    "description": "KEYCAT to US Dollar spot trading pair",
+    "tags": [
+      "keycat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KNC-USD": {
+    "normalized_id": "KNC/USD",
+    "base": "KNC",
+    "quote": "USD",
+    "display_name": "KNC / US Dollar",
+    "description": "KNC to US Dollar spot trading pair",
+    "tags": [
+      "knc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KRL-USD": {
+    "normalized_id": "KRL/USD",
+    "base": "KRL",
+    "quote": "USD",
+    "display_name": "KRL / US Dollar",
+    "description": "KRL to US Dollar spot trading pair",
+    "tags": [
+      "krl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KSM-USD": {
+    "normalized_id": "KSM/USD",
+    "base": "KSM",
+    "quote": "USD",
+    "display_name": "KSM / US Dollar",
+    "description": "KSM to US Dollar spot trading pair",
+    "tags": [
+      "ksm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "L3-USD": {
+    "normalized_id": "L3/USD",
+    "base": "L3",
+    "quote": "USD",
+    "display_name": "L3 / US Dollar",
+    "description": "L3 to US Dollar spot trading pair",
+    "tags": [
+      "l3",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LA-USD": {
+    "normalized_id": "LA/USD",
+    "base": "LA",
+    "quote": "USD",
+    "display_name": "LA / US Dollar",
+    "description": "LA to US Dollar spot trading pair",
+    "tags": [
+      "la",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LCX-USD": {
+    "normalized_id": "LCX/USD",
+    "base": "LCX",
+    "quote": "USD",
+    "display_name": "LCX / US Dollar",
+    "description": "LCX to US Dollar spot trading pair",
+    "tags": [
+      "lcx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LDO-USD": {
+    "normalized_id": "LDO/USD",
+    "base": "LDO",
+    "quote": "USD",
+    "display_name": "LDO / US Dollar",
+    "description": "LDO to US Dollar spot trading pair",
+    "tags": [
+      "ldo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LINK-BTC": {
+    "normalized_id": "LINK/BTC",
+    "base": "LINK",
+    "quote": "BTC",
+    "display_name": "Chainlink / Bitcoin",
+    "description": "Chainlink to Bitcoin spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "LINK-ETH": {
+    "normalized_id": "LINK/ETH",
+    "base": "LINK",
+    "quote": "ETH",
+    "display_name": "Chainlink / Ethereum",
+    "description": "Chainlink to Ethereum spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "LINK-EUR": {
+    "normalized_id": "LINK/EUR",
+    "base": "LINK",
+    "quote": "EUR",
+    "display_name": "Chainlink / Euro",
+    "description": "Chainlink to Euro spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LINK-GBP": {
+    "normalized_id": "LINK/GBP",
+    "base": "LINK",
+    "quote": "GBP",
+    "display_name": "Chainlink / British Pound",
+    "description": "Chainlink to British Pound spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "LINK-USD": {
+    "normalized_id": "LINK/USD",
+    "base": "LINK",
+    "quote": "USD",
+    "display_name": "Chainlink / US Dollar",
+    "description": "Chainlink to US Dollar spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LINK-USDT": {
+    "normalized_id": "LINK/USD",
+    "base": "LINK",
+    "quote": "USD",
+    "display_name": "Chainlink / US Dollar",
+    "description": "Chainlink to US Dollar spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LOKA-USD": {
+    "normalized_id": "LOKA/USD",
+    "base": "LOKA",
+    "quote": "USD",
+    "display_name": "LOKA / US Dollar",
+    "description": "LOKA to US Dollar spot trading pair",
+    "tags": [
+      "loka",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LPT-USD": {
+    "normalized_id": "LPT/USD",
+    "base": "LPT",
+    "quote": "USD",
+    "display_name": "LPT / US Dollar",
+    "description": "LPT to US Dollar spot trading pair",
+    "tags": [
+      "lpt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LQTY-USD": {
+    "normalized_id": "LQTY/USD",
+    "base": "LQTY",
+    "quote": "USD",
+    "display_name": "LQTY / US Dollar",
+    "description": "LQTY to US Dollar spot trading pair",
+    "tags": [
+      "lqty",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LRC-BTC": {
+    "normalized_id": "LRC/BTC",
+    "base": "LRC",
+    "quote": "BTC",
+    "display_name": "LRC / Bitcoin",
+    "description": "LRC to Bitcoin spot trading pair",
+    "tags": [
+      "lrc",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "LRC-USD": {
+    "normalized_id": "LRC/USD",
+    "base": "LRC",
+    "quote": "USD",
+    "display_name": "LRC / US Dollar",
+    "description": "LRC to US Dollar spot trading pair",
+    "tags": [
+      "lrc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LRC-USDT": {
+    "normalized_id": "LRC/USD",
+    "base": "LRC",
+    "quote": "USD",
+    "display_name": "LRC / US Dollar",
+    "description": "LRC to US Dollar spot trading pair",
+    "tags": [
+      "lrc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LRDS-USD": {
+    "normalized_id": "LRDS/USD",
+    "base": "LRDS",
+    "quote": "USD",
+    "display_name": "LRDS / US Dollar",
+    "description": "LRDS to US Dollar spot trading pair",
+    "tags": [
+      "lrds",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LSETH-ETH": {
+    "normalized_id": "LSETH/ETH",
+    "base": "LSETH",
+    "quote": "ETH",
+    "display_name": "LSETH / Ethereum",
+    "description": "LSETH to Ethereum spot trading pair",
+    "tags": [
+      "lseth",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "LSETH-USD": {
+    "normalized_id": "LSETH/USD",
+    "base": "LSETH",
+    "quote": "USD",
+    "display_name": "LSETH / US Dollar",
+    "description": "LSETH to US Dollar spot trading pair",
+    "tags": [
+      "lseth",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LTC-BTC": {
+    "normalized_id": "LTC/BTC",
+    "base": "LTC",
+    "quote": "BTC",
+    "display_name": "Litecoin / Bitcoin",
+    "description": "Litecoin to Bitcoin spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "LTC-EUR": {
+    "normalized_id": "LTC/EUR",
+    "base": "LTC",
+    "quote": "EUR",
+    "display_name": "Litecoin / Euro",
+    "description": "Litecoin to Euro spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LTC-GBP": {
+    "normalized_id": "LTC/GBP",
+    "base": "LTC",
+    "quote": "GBP",
+    "display_name": "Litecoin / British Pound",
+    "description": "Litecoin to British Pound spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "LTC-USD": {
+    "normalized_id": "LTC/USD",
+    "base": "LTC",
+    "quote": "USD",
+    "display_name": "Litecoin / US Dollar",
+    "description": "Litecoin to US Dollar spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MAGIC-USD": {
+    "normalized_id": "MAGIC/USD",
+    "base": "MAGIC",
+    "quote": "USD",
+    "display_name": "MAGIC / US Dollar",
+    "description": "MAGIC to US Dollar spot trading pair",
+    "tags": [
+      "magic",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MAMO-USD": {
+    "normalized_id": "MAMO/USD",
+    "base": "MAMO",
+    "quote": "USD",
+    "display_name": "MAMO / US Dollar",
+    "description": "MAMO to US Dollar spot trading pair",
+    "tags": [
+      "mamo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MANA-ETH": {
+    "normalized_id": "MANA/ETH",
+    "base": "MANA",
+    "quote": "ETH",
+    "display_name": "Decentraland / Ethereum",
+    "description": "Decentraland to Ethereum spot trading pair",
+    "tags": [
+      "mana",
+      "decentraland",
+      "gaming",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "MANA-EUR": {
+    "normalized_id": "MANA/EUR",
+    "base": "MANA",
+    "quote": "EUR",
+    "display_name": "Decentraland / Euro",
+    "description": "Decentraland to Euro spot trading pair",
+    "tags": [
+      "mana",
+      "decentraland",
+      "gaming",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MANA-USD": {
+    "normalized_id": "MANA/USD",
+    "base": "MANA",
+    "quote": "USD",
+    "display_name": "Decentraland / US Dollar",
+    "description": "Decentraland to US Dollar spot trading pair",
+    "tags": [
+      "mana",
+      "decentraland",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MANTLE-USD": {
+    "normalized_id": "MANTLE/USD",
+    "base": "MANTLE",
+    "quote": "USD",
+    "display_name": "MANTLE / US Dollar",
+    "description": "MANTLE to US Dollar spot trading pair",
+    "tags": [
+      "mantle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MASK-EUR": {
+    "normalized_id": "MASK/EUR",
+    "base": "MASK",
+    "quote": "EUR",
+    "display_name": "MASK / Euro",
+    "description": "MASK to Euro spot trading pair",
+    "tags": [
+      "mask",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MASK-GBP": {
+    "normalized_id": "MASK/GBP",
+    "base": "MASK",
+    "quote": "GBP",
+    "display_name": "MASK / British Pound",
+    "description": "MASK to British Pound spot trading pair",
+    "tags": [
+      "mask",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "MASK-USD": {
+    "normalized_id": "MASK/USD",
+    "base": "MASK",
+    "quote": "USD",
+    "display_name": "MASK / US Dollar",
+    "description": "MASK to US Dollar spot trading pair",
+    "tags": [
+      "mask",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MASK-USDT": {
+    "normalized_id": "MASK/USD",
+    "base": "MASK",
+    "quote": "USD",
+    "display_name": "MASK / US Dollar",
+    "description": "MASK to US Dollar spot trading pair",
+    "tags": [
+      "mask",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MATH-USD": {
+    "normalized_id": "MATH/USD",
+    "base": "MATH",
+    "quote": "USD",
+    "display_name": "MATH / US Dollar",
+    "description": "MATH to US Dollar spot trading pair",
+    "tags": [
+      "math",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MATIC-BTC": {
+    "normalized_id": "MATIC/BTC",
+    "base": "MATIC",
+    "quote": "BTC",
+    "display_name": "Polygon / Bitcoin",
+    "description": "Polygon to Bitcoin spot trading pair",
+    "tags": [
+      "matic",
+      "polygon",
+      "layer2",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "MATIC-EUR": {
+    "normalized_id": "MATIC/EUR",
+    "base": "MATIC",
+    "quote": "EUR",
+    "display_name": "Polygon / Euro",
+    "description": "Polygon to Euro spot trading pair",
+    "tags": [
+      "matic",
+      "polygon",
+      "layer2",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MATIC-GBP": {
+    "normalized_id": "MATIC/GBP",
+    "base": "MATIC",
+    "quote": "GBP",
+    "display_name": "Polygon / British Pound",
+    "description": "Polygon to British Pound spot trading pair",
+    "tags": [
+      "matic",
+      "polygon",
+      "layer2",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "MATIC-USD": {
+    "normalized_id": "MATIC/USD",
+    "base": "MATIC",
+    "quote": "USD",
+    "display_name": "Polygon / US Dollar",
+    "description": "Polygon to US Dollar spot trading pair",
+    "tags": [
+      "matic",
+      "polygon",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MATIC-USDT": {
+    "normalized_id": "MATIC/USD",
+    "base": "MATIC",
+    "quote": "USD",
+    "display_name": "Polygon / US Dollar",
+    "description": "Polygon to US Dollar spot trading pair",
+    "tags": [
+      "matic",
+      "polygon",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MDT-USD": {
+    "normalized_id": "MDT/USD",
+    "base": "MDT",
+    "quote": "USD",
+    "display_name": "MDT / US Dollar",
+    "description": "MDT to US Dollar spot trading pair",
+    "tags": [
+      "mdt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ME-USD": {
+    "normalized_id": "ME/USD",
+    "base": "ME",
+    "quote": "USD",
+    "display_name": "ME / US Dollar",
+    "description": "ME to US Dollar spot trading pair",
+    "tags": [
+      "me",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "METIS-USD": {
+    "normalized_id": "METIS/USD",
+    "base": "METIS",
+    "quote": "USD",
+    "display_name": "METIS / US Dollar",
+    "description": "METIS to US Dollar spot trading pair",
+    "tags": [
+      "metis",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MINA-EUR": {
+    "normalized_id": "MINA/EUR",
+    "base": "MINA",
+    "quote": "EUR",
+    "display_name": "MINA / Euro",
+    "description": "MINA to Euro spot trading pair",
+    "tags": [
+      "mina",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MINA-USD": {
+    "normalized_id": "MINA/USD",
+    "base": "MINA",
+    "quote": "USD",
+    "display_name": "MINA / US Dollar",
+    "description": "MINA to US Dollar spot trading pair",
+    "tags": [
+      "mina",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MINA-USDT": {
+    "normalized_id": "MINA/USD",
+    "base": "MINA",
+    "quote": "USD",
+    "display_name": "MINA / US Dollar",
+    "description": "MINA to US Dollar spot trading pair",
+    "tags": [
+      "mina",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MKR-BTC": {
+    "normalized_id": "MKR/BTC",
+    "base": "MKR",
+    "quote": "BTC",
+    "display_name": "Maker / Bitcoin",
+    "description": "Maker to Bitcoin spot trading pair",
+    "tags": [
+      "mkr",
+      "maker",
+      "defi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "MKR-USD": {
+    "normalized_id": "MKR/USD",
+    "base": "MKR",
+    "quote": "USD",
+    "display_name": "Maker / US Dollar",
+    "description": "Maker to US Dollar spot trading pair",
+    "tags": [
+      "mkr",
+      "maker",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MLN-USD": {
+    "normalized_id": "MLN/USD",
+    "base": "MLN",
+    "quote": "USD",
+    "display_name": "MLN / US Dollar",
+    "description": "MLN to US Dollar spot trading pair",
+    "tags": [
+      "mln",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MNDE-USD": {
+    "normalized_id": "MNDE/USD",
+    "base": "MNDE",
+    "quote": "USD",
+    "display_name": "MNDE / US Dollar",
+    "description": "MNDE to US Dollar spot trading pair",
+    "tags": [
+      "mnde",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOG-USD": {
+    "normalized_id": "MOG/USD",
+    "base": "MOG",
+    "quote": "USD",
+    "display_name": "MOG / US Dollar",
+    "description": "MOG to US Dollar spot trading pair",
+    "tags": [
+      "mog",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOODENG-USD": {
+    "normalized_id": "MOODENG/USD",
+    "base": "MOODENG",
+    "quote": "USD",
+    "display_name": "MOODENG / US Dollar",
+    "description": "MOODENG to US Dollar spot trading pair",
+    "tags": [
+      "moodeng",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MORPHO-USD": {
+    "normalized_id": "MORPHO/USD",
+    "base": "MORPHO",
+    "quote": "USD",
+    "display_name": "MORPHO / US Dollar",
+    "description": "MORPHO to US Dollar spot trading pair",
+    "tags": [
+      "morpho",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MPLX-USD": {
+    "normalized_id": "MPLX/USD",
+    "base": "MPLX",
+    "quote": "USD",
+    "display_name": "MPLX / US Dollar",
+    "description": "MPLX to US Dollar spot trading pair",
+    "tags": [
+      "mplx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MSOL-USD": {
+    "normalized_id": "MSOL/USD",
+    "base": "MSOL",
+    "quote": "USD",
+    "display_name": "MSOL / US Dollar",
+    "description": "MSOL to US Dollar spot trading pair",
+    "tags": [
+      "msol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MUSE-USD": {
+    "normalized_id": "MUSE/USD",
+    "base": "MUSE",
+    "quote": "USD",
+    "display_name": "MUSE / US Dollar",
+    "description": "MUSE to US Dollar spot trading pair",
+    "tags": [
+      "muse",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NCT-USD": {
+    "normalized_id": "NCT/USD",
+    "base": "NCT",
+    "quote": "USD",
+    "display_name": "NCT / US Dollar",
+    "description": "NCT to US Dollar spot trading pair",
+    "tags": [
+      "nct",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEAR-USD": {
+    "normalized_id": "NEAR/USD",
+    "base": "NEAR",
+    "quote": "USD",
+    "display_name": "NEAR Protocol / US Dollar",
+    "description": "NEAR Protocol to US Dollar spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEAR-USDT": {
+    "normalized_id": "NEAR/USD",
+    "base": "NEAR",
+    "quote": "USD",
+    "display_name": "NEAR Protocol / US Dollar",
+    "description": "NEAR Protocol to US Dollar spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEON-USD": {
+    "normalized_id": "NEON/USD",
+    "base": "NEON",
+    "quote": "USD",
+    "display_name": "NEON / US Dollar",
+    "description": "NEON to US Dollar spot trading pair",
+    "tags": [
+      "neon",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEWT-USD": {
+    "normalized_id": "NEWT/USD",
+    "base": "NEWT",
+    "quote": "USD",
+    "display_name": "NEWT / US Dollar",
+    "description": "NEWT to US Dollar spot trading pair",
+    "tags": [
+      "newt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NKN-USD": {
+    "normalized_id": "NKN/USD",
+    "base": "NKN",
+    "quote": "USD",
+    "display_name": "NKN / US Dollar",
+    "description": "NKN to US Dollar spot trading pair",
+    "tags": [
+      "nkn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NMR-USD": {
+    "normalized_id": "NMR/USD",
+    "base": "NMR",
+    "quote": "USD",
+    "display_name": "NMR / US Dollar",
+    "description": "NMR to US Dollar spot trading pair",
+    "tags": [
+      "nmr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OCEAN-USD": {
+    "normalized_id": "OCEAN/USD",
+    "base": "OCEAN",
+    "quote": "USD",
+    "display_name": "OCEAN / US Dollar",
+    "description": "OCEAN to US Dollar spot trading pair",
+    "tags": [
+      "ocean",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OGN-USD": {
+    "normalized_id": "OGN/USD",
+    "base": "OGN",
+    "quote": "USD",
+    "display_name": "OGN / US Dollar",
+    "description": "OGN to US Dollar spot trading pair",
+    "tags": [
+      "ogn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OMNI-USD": {
+    "normalized_id": "OMNI/USD",
+    "base": "OMNI",
+    "quote": "USD",
+    "display_name": "OMNI / US Dollar",
+    "description": "OMNI to US Dollar spot trading pair",
+    "tags": [
+      "omni",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ONDO-USD": {
+    "normalized_id": "ONDO/USD",
+    "base": "ONDO",
+    "quote": "USD",
+    "display_name": "ONDO / US Dollar",
+    "description": "ONDO to US Dollar spot trading pair",
+    "tags": [
+      "ondo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OP-USD": {
+    "normalized_id": "OP/USD",
+    "base": "OP",
+    "quote": "USD",
+    "display_name": "Optimism / US Dollar",
+    "description": "Optimism to US Dollar spot trading pair",
+    "tags": [
+      "op",
+      "optimism",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OP-USDT": {
+    "normalized_id": "OP/USD",
+    "base": "OP",
+    "quote": "USD",
+    "display_name": "Optimism / US Dollar",
+    "description": "Optimism to US Dollar spot trading pair",
+    "tags": [
+      "op",
+      "optimism",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ORCA-USD": {
+    "normalized_id": "ORCA/USD",
+    "base": "ORCA",
+    "quote": "USD",
+    "display_name": "ORCA / US Dollar",
+    "description": "ORCA to US Dollar spot trading pair",
+    "tags": [
+      "orca",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OSMO-USD": {
+    "normalized_id": "OSMO/USD",
+    "base": "OSMO",
+    "quote": "USD",
+    "display_name": "OSMO / US Dollar",
+    "description": "OSMO to US Dollar spot trading pair",
+    "tags": [
+      "osmo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OXT-USD": {
+    "normalized_id": "OXT/USD",
+    "base": "OXT",
+    "quote": "USD",
+    "display_name": "OXT / US Dollar",
+    "description": "OXT to US Dollar spot trading pair",
+    "tags": [
+      "oxt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PAX-USD": {
+    "normalized_id": "PAX/USD",
+    "base": "PAX",
+    "quote": "USD",
+    "display_name": "PAX / US Dollar",
+    "description": "PAX to US Dollar spot trading pair",
+    "tags": [
+      "pax",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PAXG-USD": {
+    "normalized_id": "PAXG/USD",
+    "base": "PAXG",
+    "quote": "USD",
+    "display_name": "PAXG / US Dollar",
+    "description": "PAXG to US Dollar spot trading pair",
+    "tags": [
+      "paxg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENDLE-USD": {
+    "normalized_id": "PENDLE/USD",
+    "base": "PENDLE",
+    "quote": "USD",
+    "display_name": "PENDLE / US Dollar",
+    "description": "PENDLE to US Dollar spot trading pair",
+    "tags": [
+      "pendle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENGU-USD": {
+    "normalized_id": "PENGU/USD",
+    "base": "PENGU",
+    "quote": "USD",
+    "display_name": "PENGU / US Dollar",
+    "description": "PENGU to US Dollar spot trading pair",
+    "tags": [
+      "pengu",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PEPE-USD": {
+    "normalized_id": "PEPE/USD",
+    "base": "PEPE",
+    "quote": "USD",
+    "display_name": "Pepe / US Dollar",
+    "description": "Pepe to US Dollar spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PERP-USD": {
+    "normalized_id": "PERP/USD",
+    "base": "PERP",
+    "quote": "USD",
+    "display_name": "PERP / US Dollar",
+    "description": "PERP to US Dollar spot trading pair",
+    "tags": [
+      "perp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PIRATE-USD": {
+    "normalized_id": "PIRATE/USD",
+    "base": "PIRATE",
+    "quote": "USD",
+    "display_name": "PIRATE / US Dollar",
+    "description": "PIRATE to US Dollar spot trading pair",
+    "tags": [
+      "pirate",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PLU-USD": {
+    "normalized_id": "PLU/USD",
+    "base": "PLU",
+    "quote": "USD",
+    "display_name": "PLU / US Dollar",
+    "description": "PLU to US Dollar spot trading pair",
+    "tags": [
+      "plu",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PNG-USD": {
+    "normalized_id": "PNG/USD",
+    "base": "PNG",
+    "quote": "USD",
+    "display_name": "PNG / US Dollar",
+    "description": "PNG to US Dollar spot trading pair",
+    "tags": [
+      "png",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PNUT-USD": {
+    "normalized_id": "PNUT/USD",
+    "base": "PNUT",
+    "quote": "USD",
+    "display_name": "PNUT / US Dollar",
+    "description": "PNUT to US Dollar spot trading pair",
+    "tags": [
+      "pnut",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POL-USD": {
+    "normalized_id": "POL/USD",
+    "base": "POL",
+    "quote": "USD",
+    "display_name": "POL / US Dollar",
+    "description": "POL to US Dollar spot trading pair",
+    "tags": [
+      "pol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POLS-USD": {
+    "normalized_id": "POLS/USD",
+    "base": "POLS",
+    "quote": "USD",
+    "display_name": "POLS / US Dollar",
+    "description": "POLS to US Dollar spot trading pair",
+    "tags": [
+      "pols",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POND-USD": {
+    "normalized_id": "POND/USD",
+    "base": "POND",
+    "quote": "USD",
+    "display_name": "POND / US Dollar",
+    "description": "POND to US Dollar spot trading pair",
+    "tags": [
+      "pond",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POPCAT-USD": {
+    "normalized_id": "POPCAT/USD",
+    "base": "POPCAT",
+    "quote": "USD",
+    "display_name": "POPCAT / US Dollar",
+    "description": "POPCAT to US Dollar spot trading pair",
+    "tags": [
+      "popcat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POWR-USD": {
+    "normalized_id": "POWR/USD",
+    "base": "POWR",
+    "quote": "USD",
+    "display_name": "POWR / US Dollar",
+    "description": "POWR to US Dollar spot trading pair",
+    "tags": [
+      "powr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PRCL-USD": {
+    "normalized_id": "PRCL/USD",
+    "base": "PRCL",
+    "quote": "USD",
+    "display_name": "PRCL / US Dollar",
+    "description": "PRCL to US Dollar spot trading pair",
+    "tags": [
+      "prcl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PRIME-USD": {
+    "normalized_id": "PRIME/USD",
+    "base": "PRIME",
+    "quote": "USD",
+    "display_name": "PRIME / US Dollar",
+    "description": "PRIME to US Dollar spot trading pair",
+    "tags": [
+      "prime",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PRO-USD": {
+    "normalized_id": "PRO/USD",
+    "base": "PRO",
+    "quote": "USD",
+    "display_name": "PRO / US Dollar",
+    "description": "PRO to US Dollar spot trading pair",
+    "tags": [
+      "pro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PROMPT-USD": {
+    "normalized_id": "PROMPT/USD",
+    "base": "PROMPT",
+    "quote": "USD",
+    "display_name": "PROMPT / US Dollar",
+    "description": "PROMPT to US Dollar spot trading pair",
+    "tags": [
+      "prompt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PROVE-USD": {
+    "normalized_id": "PROVE/USD",
+    "base": "PROVE",
+    "quote": "USD",
+    "display_name": "PROVE / US Dollar",
+    "description": "PROVE to US Dollar spot trading pair",
+    "tags": [
+      "prove",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PUMP-USD": {
+    "normalized_id": "PUMP/USD",
+    "base": "PUMP",
+    "quote": "USD",
+    "display_name": "PUMP / US Dollar",
+    "description": "PUMP to US Dollar spot trading pair",
+    "tags": [
+      "pump",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PUNDIX-USD": {
+    "normalized_id": "PUNDIX/USD",
+    "base": "PUNDIX",
+    "quote": "USD",
+    "display_name": "PUNDIX / US Dollar",
+    "description": "PUNDIX to US Dollar spot trading pair",
+    "tags": [
+      "pundix",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PYR-USD": {
+    "normalized_id": "PYR/USD",
+    "base": "PYR",
+    "quote": "USD",
+    "display_name": "PYR / US Dollar",
+    "description": "PYR to US Dollar spot trading pair",
+    "tags": [
+      "pyr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PYTH-USD": {
+    "normalized_id": "PYTH/USD",
+    "base": "PYTH",
+    "quote": "USD",
+    "display_name": "Pyth Network / US Dollar",
+    "description": "Pyth Network to US Dollar spot trading pair",
+    "tags": [
+      "pyth",
+      "pyth network",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "QI-USD": {
+    "normalized_id": "QI/USD",
+    "base": "QI",
+    "quote": "USD",
+    "display_name": "QI / US Dollar",
+    "description": "QI to US Dollar spot trading pair",
+    "tags": [
+      "qi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "QNT-USD": {
+    "normalized_id": "QNT/USD",
+    "base": "QNT",
+    "quote": "USD",
+    "display_name": "Quant / US Dollar",
+    "description": "Quant to US Dollar spot trading pair",
+    "tags": [
+      "qnt",
+      "quant",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "QNT-USDT": {
+    "normalized_id": "QNT/USD",
+    "base": "QNT",
+    "quote": "USD",
+    "display_name": "Quant / US Dollar",
+    "description": "Quant to US Dollar spot trading pair",
+    "tags": [
+      "qnt",
+      "quant",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RAD-USD": {
+    "normalized_id": "RAD/USD",
+    "base": "RAD",
+    "quote": "USD",
+    "display_name": "RAD / US Dollar",
+    "description": "RAD to US Dollar spot trading pair",
+    "tags": [
+      "rad",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RARE-USD": {
+    "normalized_id": "RARE/USD",
+    "base": "RARE",
+    "quote": "USD",
+    "display_name": "RARE / US Dollar",
+    "description": "RARE to US Dollar spot trading pair",
+    "tags": [
+      "rare",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RARI-USD": {
+    "normalized_id": "RARI/USD",
+    "base": "RARI",
+    "quote": "USD",
+    "display_name": "RARI / US Dollar",
+    "description": "RARI to US Dollar spot trading pair",
+    "tags": [
+      "rari",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RED-USD": {
+    "normalized_id": "RED/USD",
+    "base": "RED",
+    "quote": "USD",
+    "display_name": "RED / US Dollar",
+    "description": "RED to US Dollar spot trading pair",
+    "tags": [
+      "red",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RENDER-USD": {
+    "normalized_id": "RENDER/USD",
+    "base": "RENDER",
+    "quote": "USD",
+    "display_name": "RENDER / US Dollar",
+    "description": "RENDER to US Dollar spot trading pair",
+    "tags": [
+      "render",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "REQ-USD": {
+    "normalized_id": "REQ/USD",
+    "base": "REQ",
+    "quote": "USD",
+    "display_name": "REQ / US Dollar",
+    "description": "REQ to US Dollar spot trading pair",
+    "tags": [
+      "req",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "REZ-USD": {
+    "normalized_id": "REZ/USD",
+    "base": "REZ",
+    "quote": "USD",
+    "display_name": "REZ / US Dollar",
+    "description": "REZ to US Dollar spot trading pair",
+    "tags": [
+      "rez",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RLC-USD": {
+    "normalized_id": "RLC/USD",
+    "base": "RLC",
+    "quote": "USD",
+    "display_name": "RLC / US Dollar",
+    "description": "RLC to US Dollar spot trading pair",
+    "tags": [
+      "rlc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RONIN-USD": {
+    "normalized_id": "RONIN/USD",
+    "base": "RONIN",
+    "quote": "USD",
+    "display_name": "RONIN / US Dollar",
+    "description": "RONIN to US Dollar spot trading pair",
+    "tags": [
+      "ronin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ROSE-USD": {
+    "normalized_id": "ROSE/USD",
+    "base": "ROSE",
+    "quote": "USD",
+    "display_name": "ROSE / US Dollar",
+    "description": "ROSE to US Dollar spot trading pair",
+    "tags": [
+      "rose",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ROSE-USDT": {
+    "normalized_id": "ROSE/USD",
+    "base": "ROSE",
+    "quote": "USD",
+    "display_name": "ROSE / US Dollar",
+    "description": "ROSE to US Dollar spot trading pair",
+    "tags": [
+      "rose",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RPL-USD": {
+    "normalized_id": "RPL/USD",
+    "base": "RPL",
+    "quote": "USD",
+    "display_name": "RPL / US Dollar",
+    "description": "RPL to US Dollar spot trading pair",
+    "tags": [
+      "rpl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RSC-USD": {
+    "normalized_id": "RSC/USD",
+    "base": "RSC",
+    "quote": "USD",
+    "display_name": "RSC / US Dollar",
+    "description": "RSC to US Dollar spot trading pair",
+    "tags": [
+      "rsc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RSR-USD": {
+    "normalized_id": "RSR/USD",
+    "base": "RSR",
+    "quote": "USD",
+    "display_name": "RSR / US Dollar",
+    "description": "RSR to US Dollar spot trading pair",
+    "tags": [
+      "rsr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "S-USD": {
+    "normalized_id": "S/USD",
+    "base": "S",
+    "quote": "USD",
+    "display_name": "S / US Dollar",
+    "description": "S to US Dollar spot trading pair",
+    "tags": [
+      "s",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAFE-USD": {
+    "normalized_id": "SAFE/USD",
+    "base": "SAFE",
+    "quote": "USD",
+    "display_name": "SAFE / US Dollar",
+    "description": "SAFE to US Dollar spot trading pair",
+    "tags": [
+      "safe",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAND-USD": {
+    "normalized_id": "SAND/USD",
+    "base": "SAND",
+    "quote": "USD",
+    "display_name": "The Sandbox / US Dollar",
+    "description": "The Sandbox to US Dollar spot trading pair",
+    "tags": [
+      "sand",
+      "the sandbox",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAND-USDT": {
+    "normalized_id": "SAND/USD",
+    "base": "SAND",
+    "quote": "USD",
+    "display_name": "The Sandbox / US Dollar",
+    "description": "The Sandbox to US Dollar spot trading pair",
+    "tags": [
+      "sand",
+      "the sandbox",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SD-USD": {
+    "normalized_id": "SD/USD",
+    "base": "SD",
+    "quote": "USD",
+    "display_name": "SD / US Dollar",
+    "description": "SD to US Dollar spot trading pair",
+    "tags": [
+      "sd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SEAM-USD": {
+    "normalized_id": "SEAM/USD",
+    "base": "SEAM",
+    "quote": "USD",
+    "display_name": "SEAM / US Dollar",
+    "description": "SEAM to US Dollar spot trading pair",
+    "tags": [
+      "seam",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SEI-USD": {
+    "normalized_id": "SEI/USD",
+    "base": "SEI",
+    "quote": "USD",
+    "display_name": "Sei / US Dollar",
+    "description": "Sei to US Dollar spot trading pair",
+    "tags": [
+      "sei",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHDW-USD": {
+    "normalized_id": "SHDW/USD",
+    "base": "SHDW",
+    "quote": "USD",
+    "display_name": "SHDW / US Dollar",
+    "description": "SHDW to US Dollar spot trading pair",
+    "tags": [
+      "shdw",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHIB-EUR": {
+    "normalized_id": "SHIB/EUR",
+    "base": "SHIB",
+    "quote": "EUR",
+    "display_name": "Shiba Inu / Euro",
+    "description": "Shiba Inu to Euro spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SHIB-GBP": {
+    "normalized_id": "SHIB/GBP",
+    "base": "SHIB",
+    "quote": "GBP",
+    "display_name": "Shiba Inu / British Pound",
+    "description": "Shiba Inu to British Pound spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "SHIB-USD": {
+    "normalized_id": "SHIB/USD",
+    "base": "SHIB",
+    "quote": "USD",
+    "display_name": "Shiba Inu / US Dollar",
+    "description": "Shiba Inu to US Dollar spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHIB-USDT": {
+    "normalized_id": "SHIB/USD",
+    "base": "SHIB",
+    "quote": "USD",
+    "display_name": "Shiba Inu / US Dollar",
+    "description": "Shiba Inu to US Dollar spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHPING-USD": {
+    "normalized_id": "SHPING/USD",
+    "base": "SHPING",
+    "quote": "USD",
+    "display_name": "SHPING / US Dollar",
+    "description": "SHPING to US Dollar spot trading pair",
+    "tags": [
+      "shping",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SKL-USD": {
+    "normalized_id": "SKL/USD",
+    "base": "SKL",
+    "quote": "USD",
+    "display_name": "SKL / US Dollar",
+    "description": "SKL to US Dollar spot trading pair",
+    "tags": [
+      "skl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SKY-USD": {
+    "normalized_id": "SKY/USD",
+    "base": "SKY",
+    "quote": "USD",
+    "display_name": "SKY / US Dollar",
+    "description": "SKY to US Dollar spot trading pair",
+    "tags": [
+      "sky",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SNX-BTC": {
+    "normalized_id": "SNX/BTC",
+    "base": "SNX",
+    "quote": "BTC",
+    "display_name": "Synthetix / Bitcoin",
+    "description": "Synthetix to Bitcoin spot trading pair",
+    "tags": [
+      "snx",
+      "synthetix",
+      "defi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SNX-EUR": {
+    "normalized_id": "SNX/EUR",
+    "base": "SNX",
+    "quote": "EUR",
+    "display_name": "Synthetix / Euro",
+    "description": "Synthetix to Euro spot trading pair",
+    "tags": [
+      "snx",
+      "synthetix",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SNX-GBP": {
+    "normalized_id": "SNX/GBP",
+    "base": "SNX",
+    "quote": "GBP",
+    "display_name": "Synthetix / British Pound",
+    "description": "Synthetix to British Pound spot trading pair",
+    "tags": [
+      "snx",
+      "synthetix",
+      "defi",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "SNX-USD": {
+    "normalized_id": "SNX/USD",
+    "base": "SNX",
+    "quote": "USD",
+    "display_name": "Synthetix / US Dollar",
+    "description": "Synthetix to US Dollar spot trading pair",
+    "tags": [
+      "snx",
+      "synthetix",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOL-BTC": {
+    "normalized_id": "SOL/BTC",
+    "base": "SOL",
+    "quote": "BTC",
+    "display_name": "Solana / Bitcoin",
+    "description": "Solana to Bitcoin spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SOL-ETH": {
+    "normalized_id": "SOL/ETH",
+    "base": "SOL",
+    "quote": "ETH",
+    "display_name": "Solana / Ethereum",
+    "description": "Solana to Ethereum spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "SOL-EUR": {
+    "normalized_id": "SOL/EUR",
+    "base": "SOL",
+    "quote": "EUR",
+    "display_name": "Solana / Euro",
+    "description": "Solana to Euro spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SOL-GBP": {
+    "normalized_id": "SOL/GBP",
+    "base": "SOL",
+    "quote": "GBP",
+    "display_name": "Solana / British Pound",
+    "description": "Solana to British Pound spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "SOL-USD": {
+    "normalized_id": "SOL/USD",
+    "base": "SOL",
+    "quote": "USD",
+    "display_name": "Solana / US Dollar",
+    "description": "Solana to US Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOL-USDT": {
+    "normalized_id": "SOL/USD",
+    "base": "SOL",
+    "quote": "USD",
+    "display_name": "Solana / US Dollar",
+    "description": "Solana to US Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SPA-USD": {
+    "normalized_id": "SPA/USD",
+    "base": "SPA",
+    "quote": "USD",
+    "display_name": "SPA / US Dollar",
+    "description": "SPA to US Dollar spot trading pair",
+    "tags": [
+      "spa",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SPELL-USD": {
+    "normalized_id": "SPELL/USD",
+    "base": "SPELL",
+    "quote": "USD",
+    "display_name": "SPELL / US Dollar",
+    "description": "SPELL to US Dollar spot trading pair",
+    "tags": [
+      "spell",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SPK-USD": {
+    "normalized_id": "SPK/USD",
+    "base": "SPK",
+    "quote": "USD",
+    "display_name": "SPK / US Dollar",
+    "description": "SPK to US Dollar spot trading pair",
+    "tags": [
+      "spk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SQD-USD": {
+    "normalized_id": "SQD/USD",
+    "base": "SQD",
+    "quote": "USD",
+    "display_name": "SQD / US Dollar",
+    "description": "SQD to US Dollar spot trading pair",
+    "tags": [
+      "sqd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STG-USD": {
+    "normalized_id": "STG/USD",
+    "base": "STG",
+    "quote": "USD",
+    "display_name": "STG / US Dollar",
+    "description": "STG to US Dollar spot trading pair",
+    "tags": [
+      "stg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STORJ-USD": {
+    "normalized_id": "STORJ/USD",
+    "base": "STORJ",
+    "quote": "USD",
+    "display_name": "STORJ / US Dollar",
+    "description": "STORJ to US Dollar spot trading pair",
+    "tags": [
+      "storj",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STRK-USD": {
+    "normalized_id": "STRK/USD",
+    "base": "STRK",
+    "quote": "USD",
+    "display_name": "STRK / US Dollar",
+    "description": "STRK to US Dollar spot trading pair",
+    "tags": [
+      "strk",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STX-USD": {
+    "normalized_id": "STX/USD",
+    "base": "STX",
+    "quote": "USD",
+    "display_name": "STX / US Dollar",
+    "description": "STX to US Dollar spot trading pair",
+    "tags": [
+      "stx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STX-USDT": {
+    "normalized_id": "STX/USD",
+    "base": "STX",
+    "quote": "USD",
+    "display_name": "STX / US Dollar",
+    "description": "STX to US Dollar spot trading pair",
+    "tags": [
+      "stx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUI-USD": {
+    "normalized_id": "SUI/USD",
+    "base": "SUI",
+    "quote": "USD",
+    "display_name": "Sui / US Dollar",
+    "description": "Sui to US Dollar spot trading pair",
+    "tags": [
+      "sui",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUKU-USD": {
+    "normalized_id": "SUKU/USD",
+    "base": "SUKU",
+    "quote": "USD",
+    "display_name": "SUKU / US Dollar",
+    "description": "SUKU to US Dollar spot trading pair",
+    "tags": [
+      "suku",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUPER-USD": {
+    "normalized_id": "SUPER/USD",
+    "base": "SUPER",
+    "quote": "USD",
+    "display_name": "SUPER / US Dollar",
+    "description": "SUPER to US Dollar spot trading pair",
+    "tags": [
+      "super",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUSHI-USD": {
+    "normalized_id": "SUSHI/USD",
+    "base": "SUSHI",
+    "quote": "USD",
+    "display_name": "SUSHI / US Dollar",
+    "description": "SUSHI to US Dollar spot trading pair",
+    "tags": [
+      "sushi",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SWELL-USD": {
+    "normalized_id": "SWELL/USD",
+    "base": "SWELL",
+    "quote": "USD",
+    "display_name": "SWELL / US Dollar",
+    "description": "SWELL to US Dollar spot trading pair",
+    "tags": [
+      "swell",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SWFTC-USD": {
+    "normalized_id": "SWFTC/USD",
+    "base": "SWFTC",
+    "quote": "USD",
+    "display_name": "SWFTC / US Dollar",
+    "description": "SWFTC to US Dollar spot trading pair",
+    "tags": [
+      "swftc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SXT-USD": {
+    "normalized_id": "SXT/USD",
+    "base": "SXT",
+    "quote": "USD",
+    "display_name": "SXT / US Dollar",
+    "description": "SXT to US Dollar spot trading pair",
+    "tags": [
+      "sxt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SYRUP-USD": {
+    "normalized_id": "SYRUP/USD",
+    "base": "SYRUP",
+    "quote": "USD",
+    "display_name": "SYRUP / US Dollar",
+    "description": "SYRUP to US Dollar spot trading pair",
+    "tags": [
+      "syrup",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "T-USD": {
+    "normalized_id": "T/USD",
+    "base": "T",
+    "quote": "USD",
+    "display_name": "T / US Dollar",
+    "description": "T to US Dollar spot trading pair",
+    "tags": [
+      "t",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TAO-USD": {
+    "normalized_id": "TAO/USD",
+    "base": "TAO",
+    "quote": "USD",
+    "display_name": "TAO / US Dollar",
+    "description": "TAO to US Dollar spot trading pair",
+    "tags": [
+      "tao",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TIA-USD": {
+    "normalized_id": "TIA/USD",
+    "base": "TIA",
+    "quote": "USD",
+    "display_name": "Celestia / US Dollar",
+    "description": "Celestia to US Dollar spot trading pair",
+    "tags": [
+      "tia",
+      "celestia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TIME-USD": {
+    "normalized_id": "TIME/USD",
+    "base": "TIME",
+    "quote": "USD",
+    "display_name": "TIME / US Dollar",
+    "description": "TIME to US Dollar spot trading pair",
+    "tags": [
+      "time",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TNSR-USD": {
+    "normalized_id": "TNSR/USD",
+    "base": "TNSR",
+    "quote": "USD",
+    "display_name": "TNSR / US Dollar",
+    "description": "TNSR to US Dollar spot trading pair",
+    "tags": [
+      "tnsr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TOSHI-USD": {
+    "normalized_id": "TOSHI/USD",
+    "base": "TOSHI",
+    "quote": "USD",
+    "display_name": "TOSHI / US Dollar",
+    "description": "TOSHI to US Dollar spot trading pair",
+    "tags": [
+      "toshi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TOWNS-USD": {
+    "normalized_id": "TOWNS/USD",
+    "base": "TOWNS",
+    "quote": "USD",
+    "display_name": "TOWNS / US Dollar",
+    "description": "TOWNS to US Dollar spot trading pair",
+    "tags": [
+      "towns",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRAC-USD": {
+    "normalized_id": "TRAC/USD",
+    "base": "TRAC",
+    "quote": "USD",
+    "display_name": "TRAC / US Dollar",
+    "description": "TRAC to US Dollar spot trading pair",
+    "tags": [
+      "trac",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRB-USD": {
+    "normalized_id": "TRB/USD",
+    "base": "TRB",
+    "quote": "USD",
+    "display_name": "TRB / US Dollar",
+    "description": "TRB to US Dollar spot trading pair",
+    "tags": [
+      "trb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TREE-USD": {
+    "normalized_id": "TREE/USD",
+    "base": "TREE",
+    "quote": "USD",
+    "display_name": "TREE / US Dollar",
+    "description": "TREE to US Dollar spot trading pair",
+    "tags": [
+      "tree",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRU-USD": {
+    "normalized_id": "TRU/USD",
+    "base": "TRU",
+    "quote": "USD",
+    "display_name": "TRU / US Dollar",
+    "description": "TRU to US Dollar spot trading pair",
+    "tags": [
+      "tru",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRUMP-USD": {
+    "normalized_id": "TRUMP/USD",
+    "base": "TRUMP",
+    "quote": "USD",
+    "display_name": "TRUMP / US Dollar",
+    "description": "TRUMP to US Dollar spot trading pair",
+    "tags": [
+      "trump",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TURBO-USD": {
+    "normalized_id": "TURBO/USD",
+    "base": "TURBO",
+    "quote": "USD",
+    "display_name": "TURBO / US Dollar",
+    "description": "TURBO to US Dollar spot trading pair",
+    "tags": [
+      "turbo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UMA-USD": {
+    "normalized_id": "UMA/USD",
+    "base": "UMA",
+    "quote": "USD",
+    "display_name": "UMA / US Dollar",
+    "description": "UMA to US Dollar spot trading pair",
+    "tags": [
+      "uma",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UNI-BTC": {
+    "normalized_id": "UNI/BTC",
+    "base": "UNI",
+    "quote": "BTC",
+    "display_name": "Uniswap / Bitcoin",
+    "description": "Uniswap to Bitcoin spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "UNI-EUR": {
+    "normalized_id": "UNI/EUR",
+    "base": "UNI",
+    "quote": "EUR",
+    "display_name": "Uniswap / Euro",
+    "description": "Uniswap to Euro spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "UNI-GBP": {
+    "normalized_id": "UNI/GBP",
+    "base": "UNI",
+    "quote": "GBP",
+    "display_name": "Uniswap / British Pound",
+    "description": "Uniswap to British Pound spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "UNI-USD": {
+    "normalized_id": "UNI/USD",
+    "base": "UNI",
+    "quote": "USD",
+    "display_name": "Uniswap / US Dollar",
+    "description": "Uniswap to US Dollar spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDC-EUR": {
+    "normalized_id": "USDC/EUR",
+    "base": "USDC",
+    "quote": "EUR",
+    "display_name": "USD Coin / Euro",
+    "description": "USD Coin to Euro spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "USDC-GBP": {
+    "normalized_id": "USDC/GBP",
+    "base": "USDC",
+    "quote": "GBP",
+    "display_name": "USD Coin / British Pound",
+    "description": "USD Coin to British Pound spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "USDS-USD": {
+    "normalized_id": "USDS/USD",
+    "base": "USDS",
+    "quote": "USD",
+    "display_name": "USDS / US Dollar",
+    "description": "USDS to US Dollar spot trading pair",
+    "tags": [
+      "usds",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDT-EUR": {
+    "normalized_id": "USDT/EUR",
+    "base": "USDT",
+    "quote": "EUR",
+    "display_name": "Tether / Euro",
+    "description": "Tether to Euro spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "USDT-GBP": {
+    "normalized_id": "USDT/GBP",
+    "base": "USDT",
+    "quote": "GBP",
+    "display_name": "Tether / British Pound",
+    "description": "Tether to British Pound spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "USDT-USD": {
+    "normalized_id": "USDT/USD",
+    "base": "USDT",
+    "quote": "USD",
+    "display_name": "Tether / US Dollar",
+    "description": "Tether to US Dollar spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDT-USDC": {
+    "normalized_id": "USDT/USD",
+    "base": "USDT",
+    "quote": "USD",
+    "display_name": "Tether / US Dollar",
+    "description": "Tether to US Dollar spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VARA-USD": {
+    "normalized_id": "VARA/USD",
+    "base": "VARA",
+    "quote": "USD",
+    "display_name": "VARA / US Dollar",
+    "description": "VARA to US Dollar spot trading pair",
+    "tags": [
+      "vara",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VELO-USD": {
+    "normalized_id": "VELO/USD",
+    "base": "VELO",
+    "quote": "USD",
+    "display_name": "VELO / US Dollar",
+    "description": "VELO to US Dollar spot trading pair",
+    "tags": [
+      "velo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VET-USD": {
+    "normalized_id": "VET/USD",
+    "base": "VET",
+    "quote": "USD",
+    "display_name": "VeChain / US Dollar",
+    "description": "VeChain to US Dollar spot trading pair",
+    "tags": [
+      "vet",
+      "vechain",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VOXEL-USD": {
+    "normalized_id": "VOXEL/USD",
+    "base": "VOXEL",
+    "quote": "USD",
+    "display_name": "VOXEL / US Dollar",
+    "description": "VOXEL to US Dollar spot trading pair",
+    "tags": [
+      "voxel",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VTHO-USD": {
+    "normalized_id": "VTHO/USD",
+    "base": "VTHO",
+    "quote": "USD",
+    "display_name": "VTHO / US Dollar",
+    "description": "VTHO to US Dollar spot trading pair",
+    "tags": [
+      "vtho",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VVV-USD": {
+    "normalized_id": "VVV/USD",
+    "base": "VVV",
+    "quote": "USD",
+    "display_name": "VVV / US Dollar",
+    "description": "VVV to US Dollar spot trading pair",
+    "tags": [
+      "vvv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "W-USD": {
+    "normalized_id": "W/USD",
+    "base": "W",
+    "quote": "USD",
+    "display_name": "W / US Dollar",
+    "description": "W to US Dollar spot trading pair",
+    "tags": [
+      "w",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WAXL-USD": {
+    "normalized_id": "WAXL/USD",
+    "base": "WAXL",
+    "quote": "USD",
+    "display_name": "WAXL / US Dollar",
+    "description": "WAXL to US Dollar spot trading pair",
+    "tags": [
+      "waxl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WCFG-USD": {
+    "normalized_id": "WCFG/USD",
+    "base": "WCFG",
+    "quote": "USD",
+    "display_name": "WCFG / US Dollar",
+    "description": "WCFG to US Dollar spot trading pair",
+    "tags": [
+      "wcfg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WCT-USD": {
+    "normalized_id": "WCT/USD",
+    "base": "WCT",
+    "quote": "USD",
+    "display_name": "WCT / US Dollar",
+    "description": "WCT to US Dollar spot trading pair",
+    "tags": [
+      "wct",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WELL-USD": {
+    "normalized_id": "WELL/USD",
+    "base": "WELL",
+    "quote": "USD",
+    "display_name": "WELL / US Dollar",
+    "description": "WELL to US Dollar spot trading pair",
+    "tags": [
+      "well",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WIF-USD": {
+    "normalized_id": "WIF/USD",
+    "base": "WIF",
+    "quote": "USD",
+    "display_name": "dogwifhat / US Dollar",
+    "description": "dogwifhat to US Dollar spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WLD-USD": {
+    "normalized_id": "WLD/USD",
+    "base": "WLD",
+    "quote": "USD",
+    "display_name": "WLD / US Dollar",
+    "description": "WLD to US Dollar spot trading pair",
+    "tags": [
+      "wld",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XCN-USD": {
+    "normalized_id": "XCN/USD",
+    "base": "XCN",
+    "quote": "USD",
+    "display_name": "XCN / US Dollar",
+    "description": "XCN to US Dollar spot trading pair",
+    "tags": [
+      "xcn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XLM-BTC": {
+    "normalized_id": "XLM/BTC",
+    "base": "XLM",
+    "quote": "BTC",
+    "display_name": "Stellar / Bitcoin",
+    "description": "Stellar to Bitcoin spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "XLM-EUR": {
+    "normalized_id": "XLM/EUR",
+    "base": "XLM",
+    "quote": "EUR",
+    "display_name": "Stellar / Euro",
+    "description": "Stellar to Euro spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XLM-USD": {
+    "normalized_id": "XLM/USD",
+    "base": "XLM",
+    "quote": "USD",
+    "display_name": "Stellar / US Dollar",
+    "description": "Stellar to US Dollar spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XLM-USDT": {
+    "normalized_id": "XLM/USD",
+    "base": "XLM",
+    "quote": "USD",
+    "display_name": "Stellar / US Dollar",
+    "description": "Stellar to US Dollar spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XRP-EUR": {
+    "normalized_id": "XRP/EUR",
+    "base": "XRP",
+    "quote": "EUR",
+    "display_name": "Ripple / Euro",
+    "description": "Ripple to Euro spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XRP-USD": {
+    "normalized_id": "XRP/USD",
+    "base": "XRP",
+    "quote": "USD",
+    "display_name": "Ripple / US Dollar",
+    "description": "Ripple to US Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XRP-USDT": {
+    "normalized_id": "XRP/USD",
+    "base": "XRP",
+    "quote": "USD",
+    "display_name": "Ripple / US Dollar",
+    "description": "Ripple to US Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XTZ-BTC": {
+    "normalized_id": "XTZ/BTC",
+    "base": "XTZ",
+    "quote": "BTC",
+    "display_name": "Tezos / Bitcoin",
+    "description": "Tezos to Bitcoin spot trading pair",
+    "tags": [
+      "xtz",
+      "tezos",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "XTZ-EUR": {
+    "normalized_id": "XTZ/EUR",
+    "base": "XTZ",
+    "quote": "EUR",
+    "display_name": "Tezos / Euro",
+    "description": "Tezos to Euro spot trading pair",
+    "tags": [
+      "xtz",
+      "tezos",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XTZ-GBP": {
+    "normalized_id": "XTZ/GBP",
+    "base": "XTZ",
+    "quote": "GBP",
+    "display_name": "Tezos / British Pound",
+    "description": "Tezos to British Pound spot trading pair",
+    "tags": [
+      "xtz",
+      "tezos",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "XTZ-USD": {
+    "normalized_id": "XTZ/USD",
+    "base": "XTZ",
+    "quote": "USD",
+    "display_name": "Tezos / US Dollar",
+    "description": "Tezos to US Dollar spot trading pair",
+    "tags": [
+      "xtz",
+      "tezos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XYO-USD": {
+    "normalized_id": "XYO/USD",
+    "base": "XYO",
+    "quote": "USD",
+    "display_name": "XYO / US Dollar",
+    "description": "XYO to US Dollar spot trading pair",
+    "tags": [
+      "xyo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "YFI-BTC": {
+    "normalized_id": "YFI/BTC",
+    "base": "YFI",
+    "quote": "BTC",
+    "display_name": "YFI / Bitcoin",
+    "description": "YFI to Bitcoin spot trading pair",
+    "tags": [
+      "yfi",
+      "defi",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "YFI-USD": {
+    "normalized_id": "YFI/USD",
+    "base": "YFI",
+    "quote": "USD",
+    "display_name": "YFI / US Dollar",
+    "description": "YFI to US Dollar spot trading pair",
+    "tags": [
+      "yfi",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZEC-USD": {
+    "normalized_id": "ZEC/USD",
+    "base": "ZEC",
+    "quote": "USD",
+    "display_name": "ZEC / US Dollar",
+    "description": "ZEC to US Dollar spot trading pair",
+    "tags": [
+      "zec",
+      "privacy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZEN-USD": {
+    "normalized_id": "ZEN/USD",
+    "base": "ZEN",
+    "quote": "USD",
+    "display_name": "ZEN / US Dollar",
+    "description": "ZEN to US Dollar spot trading pair",
+    "tags": [
+      "zen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZETA-USD": {
+    "normalized_id": "ZETA/USD",
+    "base": "ZETA",
+    "quote": "USD",
+    "display_name": "ZETA / US Dollar",
+    "description": "ZETA to US Dollar spot trading pair",
+    "tags": [
+      "zeta",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZETACHAIN-USD": {
+    "normalized_id": "ZETACHAIN/USD",
+    "base": "ZETACHAIN",
+    "quote": "USD",
+    "display_name": "ZETACHAIN / US Dollar",
+    "description": "ZETACHAIN to US Dollar spot trading pair",
+    "tags": [
+      "zetachain",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZK-USD": {
+    "normalized_id": "ZK/USD",
+    "base": "ZK",
+    "quote": "USD",
+    "display_name": "ZK / US Dollar",
+    "description": "ZK to US Dollar spot trading pair",
+    "tags": [
+      "zk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZORA-USD": {
+    "normalized_id": "ZORA/USD",
+    "base": "ZORA",
+    "quote": "USD",
+    "display_name": "ZORA / US Dollar",
+    "description": "ZORA to US Dollar spot trading pair",
+    "tags": [
+      "zora",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZRO-USD": {
+    "normalized_id": "ZRO/USD",
+    "base": "ZRO",
+    "quote": "USD",
+    "display_name": "ZRO / US Dollar",
+    "description": "ZRO to US Dollar spot trading pair",
+    "tags": [
+      "zro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZRX-USD": {
+    "normalized_id": "ZRX/USD",
+    "base": "ZRX",
+    "quote": "USD",
+    "display_name": "0x / US Dollar",
+    "description": "0x to US Dollar spot trading pair",
+    "tags": [
+      "zrx",
+      "0x",
+      "usd"
+    ],
+    "category": "crypto"
+  }
+}

--- a/server/src/symbols/configs/kraken.json
+++ b/server/src/symbols/configs/kraken.json
@@ -1,0 +1,15103 @@
+{
+  "1INCH_EUR": {
+    "normalized_id": "1INCH/EUR",
+    "base": "1INCH",
+    "quote": "EUR",
+    "display_name": "1INCH / Euro",
+    "description": "1INCH to Euro spot trading pair",
+    "tags": [
+      "1inch",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "1INCH_USD": {
+    "normalized_id": "1INCH/USD",
+    "base": "1INCH",
+    "quote": "USD",
+    "display_name": "1INCH / US Dollar",
+    "description": "1INCH to US Dollar spot trading pair",
+    "tags": [
+      "1inch",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AAVE_ETH": {
+    "normalized_id": "AAVE/ETH",
+    "base": "AAVE",
+    "quote": "ETH",
+    "display_name": "Aave / Ethereum",
+    "description": "Aave to Ethereum spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "AAVE_EUR": {
+    "normalized_id": "AAVE/EUR",
+    "base": "AAVE",
+    "quote": "EUR",
+    "display_name": "Aave / Euro",
+    "description": "Aave to Euro spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AAVE_GBP": {
+    "normalized_id": "AAVE/GBP",
+    "base": "AAVE",
+    "quote": "GBP",
+    "display_name": "Aave / British Pound",
+    "description": "Aave to British Pound spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "AAVE_USD": {
+    "normalized_id": "AAVE/USD",
+    "base": "AAVE",
+    "quote": "USD",
+    "display_name": "Aave / US Dollar",
+    "description": "Aave to US Dollar spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AAVE_XBT": {
+    "normalized_id": "AAVE/XBT",
+    "base": "AAVE",
+    "quote": "XBT",
+    "display_name": "Aave / XBT",
+    "description": "Aave to XBT spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "AB_EUR": {
+    "normalized_id": "AB/EUR",
+    "base": "AB",
+    "quote": "EUR",
+    "display_name": "AB / Euro",
+    "description": "AB to Euro spot trading pair",
+    "tags": [
+      "ab",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AB_USD": {
+    "normalized_id": "AB/USD",
+    "base": "AB",
+    "quote": "USD",
+    "display_name": "AB / US Dollar",
+    "description": "AB to US Dollar spot trading pair",
+    "tags": [
+      "ab",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACA_EUR": {
+    "normalized_id": "ACA/EUR",
+    "base": "ACA",
+    "quote": "EUR",
+    "display_name": "ACA / Euro",
+    "description": "ACA to Euro spot trading pair",
+    "tags": [
+      "aca",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ACA_USD": {
+    "normalized_id": "ACA/USD",
+    "base": "ACA",
+    "quote": "USD",
+    "display_name": "ACA / US Dollar",
+    "description": "ACA to US Dollar spot trading pair",
+    "tags": [
+      "aca",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACH_EUR": {
+    "normalized_id": "ACH/EUR",
+    "base": "ACH",
+    "quote": "EUR",
+    "display_name": "ACH / Euro",
+    "description": "ACH to Euro spot trading pair",
+    "tags": [
+      "ach",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ACH_USD": {
+    "normalized_id": "ACH/USD",
+    "base": "ACH",
+    "quote": "USD",
+    "display_name": "ACH / US Dollar",
+    "description": "ACH to US Dollar spot trading pair",
+    "tags": [
+      "ach",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACT_EUR": {
+    "normalized_id": "ACT/EUR",
+    "base": "ACT",
+    "quote": "EUR",
+    "display_name": "ACT / Euro",
+    "description": "ACT to Euro spot trading pair",
+    "tags": [
+      "act",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ACT_USD": {
+    "normalized_id": "ACT/USD",
+    "base": "ACT",
+    "quote": "USD",
+    "display_name": "ACT / US Dollar",
+    "description": "ACT to US Dollar spot trading pair",
+    "tags": [
+      "act",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACX_EUR": {
+    "normalized_id": "ACX/EUR",
+    "base": "ACX",
+    "quote": "EUR",
+    "display_name": "ACX / Euro",
+    "description": "ACX to Euro spot trading pair",
+    "tags": [
+      "acx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ACX_USD": {
+    "normalized_id": "ACX/USD",
+    "base": "ACX",
+    "quote": "USD",
+    "display_name": "ACX / US Dollar",
+    "description": "ACX to US Dollar spot trading pair",
+    "tags": [
+      "acx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ADA_AUD": {
+    "normalized_id": "ADA/AUD",
+    "base": "ADA",
+    "quote": "AUD",
+    "display_name": "Cardano / Australian Dollar",
+    "description": "Cardano to Australian Dollar spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "ADA_ETH": {
+    "normalized_id": "ADA/ETH",
+    "base": "ADA",
+    "quote": "ETH",
+    "display_name": "Cardano / Ethereum",
+    "description": "Cardano to Ethereum spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "ADA_EUR": {
+    "normalized_id": "ADA/EUR",
+    "base": "ADA",
+    "quote": "EUR",
+    "display_name": "Cardano / Euro",
+    "description": "Cardano to Euro spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ADA_GBP": {
+    "normalized_id": "ADA/GBP",
+    "base": "ADA",
+    "quote": "GBP",
+    "display_name": "Cardano / British Pound",
+    "description": "Cardano to British Pound spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "ADA_USD": {
+    "normalized_id": "ADA/USD",
+    "base": "ADA",
+    "quote": "USD",
+    "display_name": "Cardano / US Dollar",
+    "description": "Cardano to US Dollar spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ADA_USDC": {
+    "normalized_id": "ADA/USD",
+    "base": "ADA",
+    "quote": "USD",
+    "display_name": "Cardano / US Dollar",
+    "description": "Cardano to US Dollar spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ADA_USDT": {
+    "normalized_id": "ADA/USD",
+    "base": "ADA",
+    "quote": "USD",
+    "display_name": "Cardano / US Dollar",
+    "description": "Cardano to US Dollar spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ADA_XBT": {
+    "normalized_id": "ADA/XBT",
+    "base": "ADA",
+    "quote": "XBT",
+    "display_name": "Cardano / XBT",
+    "description": "Cardano to XBT spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "ADX_EUR": {
+    "normalized_id": "ADX/EUR",
+    "base": "ADX",
+    "quote": "EUR",
+    "display_name": "ADX / Euro",
+    "description": "ADX to Euro spot trading pair",
+    "tags": [
+      "adx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ADX_USD": {
+    "normalized_id": "ADX/USD",
+    "base": "ADX",
+    "quote": "USD",
+    "display_name": "ADX / US Dollar",
+    "description": "ADX to US Dollar spot trading pair",
+    "tags": [
+      "adx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AERO_EUR": {
+    "normalized_id": "AERO/EUR",
+    "base": "AERO",
+    "quote": "EUR",
+    "display_name": "AERO / Euro",
+    "description": "AERO to Euro spot trading pair",
+    "tags": [
+      "aero",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AERO_USD": {
+    "normalized_id": "AERO/USD",
+    "base": "AERO",
+    "quote": "USD",
+    "display_name": "AERO / US Dollar",
+    "description": "AERO to US Dollar spot trading pair",
+    "tags": [
+      "aero",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AEVO_EUR": {
+    "normalized_id": "AEVO/EUR",
+    "base": "AEVO",
+    "quote": "EUR",
+    "display_name": "AEVO / Euro",
+    "description": "AEVO to Euro spot trading pair",
+    "tags": [
+      "aevo",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AEVO_USD": {
+    "normalized_id": "AEVO/USD",
+    "base": "AEVO",
+    "quote": "USD",
+    "display_name": "AEVO / US Dollar",
+    "description": "AEVO to US Dollar spot trading pair",
+    "tags": [
+      "aevo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AGLD_EUR": {
+    "normalized_id": "AGLD/EUR",
+    "base": "AGLD",
+    "quote": "EUR",
+    "display_name": "AGLD / Euro",
+    "description": "AGLD to Euro spot trading pair",
+    "tags": [
+      "agld",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AGLD_USD": {
+    "normalized_id": "AGLD/USD",
+    "base": "AGLD",
+    "quote": "USD",
+    "display_name": "AGLD / US Dollar",
+    "description": "AGLD to US Dollar spot trading pair",
+    "tags": [
+      "agld",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AI16Z_EUR": {
+    "normalized_id": "AI16Z/EUR",
+    "base": "AI16Z",
+    "quote": "EUR",
+    "display_name": "AI16Z / Euro",
+    "description": "AI16Z to Euro spot trading pair",
+    "tags": [
+      "ai16z",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AI16Z_USD": {
+    "normalized_id": "AI16Z/USD",
+    "base": "AI16Z",
+    "quote": "USD",
+    "display_name": "AI16Z / US Dollar",
+    "description": "AI16Z to US Dollar spot trading pair",
+    "tags": [
+      "ai16z",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AI16Z_USDC": {
+    "normalized_id": "AI16Z/USD",
+    "base": "AI16Z",
+    "quote": "USD",
+    "display_name": "AI16Z / US Dollar",
+    "description": "AI16Z to US Dollar spot trading pair",
+    "tags": [
+      "ai16z",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AI16Z_USDT": {
+    "normalized_id": "AI16Z/USD",
+    "base": "AI16Z",
+    "quote": "USD",
+    "display_name": "AI16Z / US Dollar",
+    "description": "AI16Z to US Dollar spot trading pair",
+    "tags": [
+      "ai16z",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AIOZ_EUR": {
+    "normalized_id": "AIOZ/EUR",
+    "base": "AIOZ",
+    "quote": "EUR",
+    "display_name": "AIOZ / Euro",
+    "description": "AIOZ to Euro spot trading pair",
+    "tags": [
+      "aioz",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AIOZ_USD": {
+    "normalized_id": "AIOZ/USD",
+    "base": "AIOZ",
+    "quote": "USD",
+    "display_name": "AIOZ / US Dollar",
+    "description": "AIOZ to US Dollar spot trading pair",
+    "tags": [
+      "aioz",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AIR_EUR": {
+    "normalized_id": "AIR/EUR",
+    "base": "AIR",
+    "quote": "EUR",
+    "display_name": "AIR / Euro",
+    "description": "AIR to Euro spot trading pair",
+    "tags": [
+      "air",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AIR_USD": {
+    "normalized_id": "AIR/USD",
+    "base": "AIR",
+    "quote": "USD",
+    "display_name": "AIR / US Dollar",
+    "description": "AIR to US Dollar spot trading pair",
+    "tags": [
+      "air",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AIXBT_EUR": {
+    "normalized_id": "AIXBT/EUR",
+    "base": "AIXBT",
+    "quote": "EUR",
+    "display_name": "AIXBT / Euro",
+    "description": "AIXBT to Euro spot trading pair",
+    "tags": [
+      "aixbt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AIXBT_USD": {
+    "normalized_id": "AIXBT/USD",
+    "base": "AIXBT",
+    "quote": "USD",
+    "display_name": "AIXBT / US Dollar",
+    "description": "AIXBT to US Dollar spot trading pair",
+    "tags": [
+      "aixbt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AKT_EUR": {
+    "normalized_id": "AKT/EUR",
+    "base": "AKT",
+    "quote": "EUR",
+    "display_name": "AKT / Euro",
+    "description": "AKT to Euro spot trading pair",
+    "tags": [
+      "akt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AKT_USD": {
+    "normalized_id": "AKT/USD",
+    "base": "AKT",
+    "quote": "USD",
+    "display_name": "AKT / US Dollar",
+    "description": "AKT to US Dollar spot trading pair",
+    "tags": [
+      "akt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALCH_EUR": {
+    "normalized_id": "ALCH/EUR",
+    "base": "ALCH",
+    "quote": "EUR",
+    "display_name": "ALCH / Euro",
+    "description": "ALCH to Euro spot trading pair",
+    "tags": [
+      "alch",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ALCH_USD": {
+    "normalized_id": "ALCH/USD",
+    "base": "ALCH",
+    "quote": "USD",
+    "display_name": "ALCH / US Dollar",
+    "description": "ALCH to US Dollar spot trading pair",
+    "tags": [
+      "alch",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALCX_EUR": {
+    "normalized_id": "ALCX/EUR",
+    "base": "ALCX",
+    "quote": "EUR",
+    "display_name": "ALCX / Euro",
+    "description": "ALCX to Euro spot trading pair",
+    "tags": [
+      "alcx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ALCX_USD": {
+    "normalized_id": "ALCX/USD",
+    "base": "ALCX",
+    "quote": "USD",
+    "display_name": "ALCX / US Dollar",
+    "description": "ALCX to US Dollar spot trading pair",
+    "tags": [
+      "alcx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALGO_ETH": {
+    "normalized_id": "ALGO/ETH",
+    "base": "ALGO",
+    "quote": "ETH",
+    "display_name": "Algorand / Ethereum",
+    "description": "Algorand to Ethereum spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "ALGO_EUR": {
+    "normalized_id": "ALGO/EUR",
+    "base": "ALGO",
+    "quote": "EUR",
+    "display_name": "Algorand / Euro",
+    "description": "Algorand to Euro spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ALGO_GBP": {
+    "normalized_id": "ALGO/GBP",
+    "base": "ALGO",
+    "quote": "GBP",
+    "display_name": "Algorand / British Pound",
+    "description": "Algorand to British Pound spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "ALGO_USD": {
+    "normalized_id": "ALGO/USD",
+    "base": "ALGO",
+    "quote": "USD",
+    "display_name": "Algorand / US Dollar",
+    "description": "Algorand to US Dollar spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALGO_USDC": {
+    "normalized_id": "ALGO/USD",
+    "base": "ALGO",
+    "quote": "USD",
+    "display_name": "Algorand / US Dollar",
+    "description": "Algorand to US Dollar spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALGO_USDT": {
+    "normalized_id": "ALGO/USD",
+    "base": "ALGO",
+    "quote": "USD",
+    "display_name": "Algorand / US Dollar",
+    "description": "Algorand to US Dollar spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALGO_XBT": {
+    "normalized_id": "ALGO/XBT",
+    "base": "ALGO",
+    "quote": "XBT",
+    "display_name": "Algorand / XBT",
+    "description": "Algorand to XBT spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "ALICE_EUR": {
+    "normalized_id": "ALICE/EUR",
+    "base": "ALICE",
+    "quote": "EUR",
+    "display_name": "ALICE / Euro",
+    "description": "ALICE to Euro spot trading pair",
+    "tags": [
+      "alice",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ALICE_USD": {
+    "normalized_id": "ALICE/USD",
+    "base": "ALICE",
+    "quote": "USD",
+    "display_name": "ALICE / US Dollar",
+    "description": "ALICE to US Dollar spot trading pair",
+    "tags": [
+      "alice",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALPHA_EUR": {
+    "normalized_id": "ALPHA/EUR",
+    "base": "ALPHA",
+    "quote": "EUR",
+    "display_name": "ALPHA / Euro",
+    "description": "ALPHA to Euro spot trading pair",
+    "tags": [
+      "alpha",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ALPHA_USD": {
+    "normalized_id": "ALPHA/USD",
+    "base": "ALPHA",
+    "quote": "USD",
+    "display_name": "ALPHA / US Dollar",
+    "description": "ALPHA to US Dollar spot trading pair",
+    "tags": [
+      "alpha",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALT_EUR": {
+    "normalized_id": "ALT/EUR",
+    "base": "ALT",
+    "quote": "EUR",
+    "display_name": "ALT / Euro",
+    "description": "ALT to Euro spot trading pair",
+    "tags": [
+      "alt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ALT_USD": {
+    "normalized_id": "ALT/USD",
+    "base": "ALT",
+    "quote": "USD",
+    "display_name": "ALT / US Dollar",
+    "description": "ALT to US Dollar spot trading pair",
+    "tags": [
+      "alt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ANKR_EUR": {
+    "normalized_id": "ANKR/EUR",
+    "base": "ANKR",
+    "quote": "EUR",
+    "display_name": "ANKR / Euro",
+    "description": "ANKR to Euro spot trading pair",
+    "tags": [
+      "ankr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ANKR_USD": {
+    "normalized_id": "ANKR/USD",
+    "base": "ANKR",
+    "quote": "USD",
+    "display_name": "ANKR / US Dollar",
+    "description": "ANKR to US Dollar spot trading pair",
+    "tags": [
+      "ankr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ANKR_XBT": {
+    "normalized_id": "ANKR/XBT",
+    "base": "ANKR",
+    "quote": "XBT",
+    "display_name": "ANKR / XBT",
+    "description": "ANKR to XBT spot trading pair",
+    "tags": [
+      "ankr",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "ANLOG_EUR": {
+    "normalized_id": "ANLOG/EUR",
+    "base": "ANLOG",
+    "quote": "EUR",
+    "display_name": "ANLOG / Euro",
+    "description": "ANLOG to Euro spot trading pair",
+    "tags": [
+      "anlog",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ANLOG_USD": {
+    "normalized_id": "ANLOG/USD",
+    "base": "ANLOG",
+    "quote": "USD",
+    "display_name": "ANLOG / US Dollar",
+    "description": "ANLOG to US Dollar spot trading pair",
+    "tags": [
+      "anlog",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ANON_EUR": {
+    "normalized_id": "ANON/EUR",
+    "base": "ANON",
+    "quote": "EUR",
+    "display_name": "ANON / Euro",
+    "description": "ANON to Euro spot trading pair",
+    "tags": [
+      "anon",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ANON_USD": {
+    "normalized_id": "ANON/USD",
+    "base": "ANON",
+    "quote": "USD",
+    "display_name": "ANON / US Dollar",
+    "description": "ANON to US Dollar spot trading pair",
+    "tags": [
+      "anon",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APENFT_EUR": {
+    "normalized_id": "APENFT/EUR",
+    "base": "APENFT",
+    "quote": "EUR",
+    "display_name": "APENFT / Euro",
+    "description": "APENFT to Euro spot trading pair",
+    "tags": [
+      "apenft",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "APENFT_USD": {
+    "normalized_id": "APENFT/USD",
+    "base": "APENFT",
+    "quote": "USD",
+    "display_name": "APENFT / US Dollar",
+    "description": "APENFT to US Dollar spot trading pair",
+    "tags": [
+      "apenft",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APE_EUR": {
+    "normalized_id": "APE/EUR",
+    "base": "APE",
+    "quote": "EUR",
+    "display_name": "APE / Euro",
+    "description": "APE to Euro spot trading pair",
+    "tags": [
+      "ape",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "APE_USD": {
+    "normalized_id": "APE/USD",
+    "base": "APE",
+    "quote": "USD",
+    "display_name": "APE / US Dollar",
+    "description": "APE to US Dollar spot trading pair",
+    "tags": [
+      "ape",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APE_USDC": {
+    "normalized_id": "APE/USD",
+    "base": "APE",
+    "quote": "USD",
+    "display_name": "APE / US Dollar",
+    "description": "APE to US Dollar spot trading pair",
+    "tags": [
+      "ape",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APE_USDT": {
+    "normalized_id": "APE/USD",
+    "base": "APE",
+    "quote": "USD",
+    "display_name": "APE / US Dollar",
+    "description": "APE to US Dollar spot trading pair",
+    "tags": [
+      "ape",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "API3_EUR": {
+    "normalized_id": "API3/EUR",
+    "base": "API3",
+    "quote": "EUR",
+    "display_name": "API3 / Euro",
+    "description": "API3 to Euro spot trading pair",
+    "tags": [
+      "api3",
+      "oracle",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "API3_USD": {
+    "normalized_id": "API3/USD",
+    "base": "API3",
+    "quote": "USD",
+    "display_name": "API3 / US Dollar",
+    "description": "API3 to US Dollar spot trading pair",
+    "tags": [
+      "api3",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APT_EUR": {
+    "normalized_id": "APT/EUR",
+    "base": "APT",
+    "quote": "EUR",
+    "display_name": "Aptos / Euro",
+    "description": "Aptos to Euro spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "APT_USD": {
+    "normalized_id": "APT/USD",
+    "base": "APT",
+    "quote": "USD",
+    "display_name": "Aptos / US Dollar",
+    "description": "Aptos to US Dollar spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APU_EUR": {
+    "normalized_id": "APU/EUR",
+    "base": "APU",
+    "quote": "EUR",
+    "display_name": "APU / Euro",
+    "description": "APU to Euro spot trading pair",
+    "tags": [
+      "apu",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "APU_USD": {
+    "normalized_id": "APU/USD",
+    "base": "APU",
+    "quote": "USD",
+    "display_name": "APU / US Dollar",
+    "description": "APU to US Dollar spot trading pair",
+    "tags": [
+      "apu",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARB_EUR": {
+    "normalized_id": "ARB/EUR",
+    "base": "ARB",
+    "quote": "EUR",
+    "display_name": "Arbitrum / Euro",
+    "description": "Arbitrum to Euro spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ARB_USD": {
+    "normalized_id": "ARB/USD",
+    "base": "ARB",
+    "quote": "USD",
+    "display_name": "Arbitrum / US Dollar",
+    "description": "Arbitrum to US Dollar spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARC_EUR": {
+    "normalized_id": "ARC/EUR",
+    "base": "ARC",
+    "quote": "EUR",
+    "display_name": "ARC / Euro",
+    "description": "ARC to Euro spot trading pair",
+    "tags": [
+      "arc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ARC_USD": {
+    "normalized_id": "ARC/USD",
+    "base": "ARC",
+    "quote": "USD",
+    "display_name": "ARC / US Dollar",
+    "description": "ARC to US Dollar spot trading pair",
+    "tags": [
+      "arc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARKM_EUR": {
+    "normalized_id": "ARKM/EUR",
+    "base": "ARKM",
+    "quote": "EUR",
+    "display_name": "ARKM / Euro",
+    "description": "ARKM to Euro spot trading pair",
+    "tags": [
+      "arkm",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ARKM_USD": {
+    "normalized_id": "ARKM/USD",
+    "base": "ARKM",
+    "quote": "USD",
+    "display_name": "ARKM / US Dollar",
+    "description": "ARKM to US Dollar spot trading pair",
+    "tags": [
+      "arkm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARPA_EUR": {
+    "normalized_id": "ARPA/EUR",
+    "base": "ARPA",
+    "quote": "EUR",
+    "display_name": "ARPA / Euro",
+    "description": "ARPA to Euro spot trading pair",
+    "tags": [
+      "arpa",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ARPA_USD": {
+    "normalized_id": "ARPA/USD",
+    "base": "ARPA",
+    "quote": "USD",
+    "display_name": "ARPA / US Dollar",
+    "description": "ARPA to US Dollar spot trading pair",
+    "tags": [
+      "arpa",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AR_EUR": {
+    "normalized_id": "AR/EUR",
+    "base": "AR",
+    "quote": "EUR",
+    "display_name": "AR / Euro",
+    "description": "AR to Euro spot trading pair",
+    "tags": [
+      "ar",
+      "storage",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AR_USD": {
+    "normalized_id": "AR/USD",
+    "base": "AR",
+    "quote": "USD",
+    "display_name": "AR / US Dollar",
+    "description": "AR to US Dollar spot trading pair",
+    "tags": [
+      "ar",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ASRR_EUR": {
+    "normalized_id": "ASRR/EUR",
+    "base": "ASRR",
+    "quote": "EUR",
+    "display_name": "ASRR / Euro",
+    "description": "ASRR to Euro spot trading pair",
+    "tags": [
+      "asrr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ASRR_USD": {
+    "normalized_id": "ASRR/USD",
+    "base": "ASRR",
+    "quote": "USD",
+    "display_name": "ASRR / US Dollar",
+    "description": "ASRR to US Dollar spot trading pair",
+    "tags": [
+      "asrr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ASTR_EUR": {
+    "normalized_id": "ASTR/EUR",
+    "base": "ASTR",
+    "quote": "EUR",
+    "display_name": "ASTR / Euro",
+    "description": "ASTR to Euro spot trading pair",
+    "tags": [
+      "astr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ASTR_USD": {
+    "normalized_id": "ASTR/USD",
+    "base": "ASTR",
+    "quote": "USD",
+    "display_name": "ASTR / US Dollar",
+    "description": "ASTR to US Dollar spot trading pair",
+    "tags": [
+      "astr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATH_EUR": {
+    "normalized_id": "ATH/EUR",
+    "base": "ATH",
+    "quote": "EUR",
+    "display_name": "ATH / Euro",
+    "description": "ATH to Euro spot trading pair",
+    "tags": [
+      "ath",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ATH_USD": {
+    "normalized_id": "ATH/USD",
+    "base": "ATH",
+    "quote": "USD",
+    "display_name": "ATH / US Dollar",
+    "description": "ATH to US Dollar spot trading pair",
+    "tags": [
+      "ath",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATLAS_EUR": {
+    "normalized_id": "ATLAS/EUR",
+    "base": "ATLAS",
+    "quote": "EUR",
+    "display_name": "ATLAS / Euro",
+    "description": "ATLAS to Euro spot trading pair",
+    "tags": [
+      "atlas",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ATLAS_USD": {
+    "normalized_id": "ATLAS/USD",
+    "base": "ATLAS",
+    "quote": "USD",
+    "display_name": "ATLAS / US Dollar",
+    "description": "ATLAS to US Dollar spot trading pair",
+    "tags": [
+      "atlas",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATOM_ETH": {
+    "normalized_id": "ATOM/ETH",
+    "base": "ATOM",
+    "quote": "ETH",
+    "display_name": "Cosmos / Ethereum",
+    "description": "Cosmos to Ethereum spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "ATOM_EUR": {
+    "normalized_id": "ATOM/EUR",
+    "base": "ATOM",
+    "quote": "EUR",
+    "display_name": "Cosmos / Euro",
+    "description": "Cosmos to Euro spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ATOM_GBP": {
+    "normalized_id": "ATOM/GBP",
+    "base": "ATOM",
+    "quote": "GBP",
+    "display_name": "Cosmos / British Pound",
+    "description": "Cosmos to British Pound spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "ATOM_USD": {
+    "normalized_id": "ATOM/USD",
+    "base": "ATOM",
+    "quote": "USD",
+    "display_name": "Cosmos / US Dollar",
+    "description": "Cosmos to US Dollar spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATOM_USDC": {
+    "normalized_id": "ATOM/USD",
+    "base": "ATOM",
+    "quote": "USD",
+    "display_name": "Cosmos / US Dollar",
+    "description": "Cosmos to US Dollar spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATOM_USDT": {
+    "normalized_id": "ATOM/USD",
+    "base": "ATOM",
+    "quote": "USD",
+    "display_name": "Cosmos / US Dollar",
+    "description": "Cosmos to US Dollar spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATOM_XBT": {
+    "normalized_id": "ATOM/XBT",
+    "base": "ATOM",
+    "quote": "XBT",
+    "display_name": "Cosmos / XBT",
+    "description": "Cosmos to XBT spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "AUCTION_EUR": {
+    "normalized_id": "AUCTION/EUR",
+    "base": "AUCTION",
+    "quote": "EUR",
+    "display_name": "AUCTION / Euro",
+    "description": "AUCTION to Euro spot trading pair",
+    "tags": [
+      "auction",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AUCTION_USD": {
+    "normalized_id": "AUCTION/USD",
+    "base": "AUCTION",
+    "quote": "USD",
+    "display_name": "AUCTION / US Dollar",
+    "description": "AUCTION to US Dollar spot trading pair",
+    "tags": [
+      "auction",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AUDIO_EUR": {
+    "normalized_id": "AUDIO/EUR",
+    "base": "AUDIO",
+    "quote": "EUR",
+    "display_name": "AUDIO / Euro",
+    "description": "AUDIO to Euro spot trading pair",
+    "tags": [
+      "audio",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AUDIO_USD": {
+    "normalized_id": "AUDIO/USD",
+    "base": "AUDIO",
+    "quote": "USD",
+    "display_name": "AUDIO / US Dollar",
+    "description": "AUDIO to US Dollar spot trading pair",
+    "tags": [
+      "audio",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AUD_JPY": {
+    "normalized_id": "AUD/JPY",
+    "base": "AUD",
+    "quote": "JPY",
+    "display_name": "Australian Dollar / Japanese Yen",
+    "description": "Australian Dollar to Japanese Yen  trading pair",
+    "tags": [
+      "aud",
+      "australian dollar",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "forex"
+  },
+  "AUD_USD": {
+    "normalized_id": "AUD/USD",
+    "base": "AUD",
+    "quote": "USD",
+    "display_name": "Australian Dollar / US Dollar",
+    "description": "Australian Dollar to US Dollar  trading pair",
+    "tags": [
+      "aud",
+      "australian dollar",
+      "usd"
+    ],
+    "category": "forex"
+  },
+  "AVAAI_EUR": {
+    "normalized_id": "AVAAI/EUR",
+    "base": "AVAAI",
+    "quote": "EUR",
+    "display_name": "AVAAI / Euro",
+    "description": "AVAAI to Euro spot trading pair",
+    "tags": [
+      "avaai",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AVAAI_USD": {
+    "normalized_id": "AVAAI/USD",
+    "base": "AVAAI",
+    "quote": "USD",
+    "display_name": "AVAAI / US Dollar",
+    "description": "AVAAI to US Dollar spot trading pair",
+    "tags": [
+      "avaai",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AVAX_EUR": {
+    "normalized_id": "AVAX/EUR",
+    "base": "AVAX",
+    "quote": "EUR",
+    "display_name": "Avalanche / Euro",
+    "description": "Avalanche to Euro spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AVAX_USD": {
+    "normalized_id": "AVAX/USD",
+    "base": "AVAX",
+    "quote": "USD",
+    "display_name": "Avalanche / US Dollar",
+    "description": "Avalanche to US Dollar spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AVAX_USDC": {
+    "normalized_id": "AVAX/USD",
+    "base": "AVAX",
+    "quote": "USD",
+    "display_name": "Avalanche / US Dollar",
+    "description": "Avalanche to US Dollar spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AVAX_USDT": {
+    "normalized_id": "AVAX/USD",
+    "base": "AVAX",
+    "quote": "USD",
+    "display_name": "Avalanche / US Dollar",
+    "description": "Avalanche to US Dollar spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AXS_EUR": {
+    "normalized_id": "AXS/EUR",
+    "base": "AXS",
+    "quote": "EUR",
+    "display_name": "Axie Infinity / Euro",
+    "description": "Axie Infinity to Euro spot trading pair",
+    "tags": [
+      "axs",
+      "axie infinity",
+      "gaming",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AXS_USD": {
+    "normalized_id": "AXS/USD",
+    "base": "AXS",
+    "quote": "USD",
+    "display_name": "Axie Infinity / US Dollar",
+    "description": "Axie Infinity to US Dollar spot trading pair",
+    "tags": [
+      "axs",
+      "axie infinity",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "A_EUR": {
+    "normalized_id": "A/EUR",
+    "base": "A",
+    "quote": "EUR",
+    "display_name": "A / Euro",
+    "description": "A to Euro spot trading pair",
+    "tags": [
+      "a",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "A_USD": {
+    "normalized_id": "A/USD",
+    "base": "A",
+    "quote": "USD",
+    "display_name": "A / US Dollar",
+    "description": "A to US Dollar spot trading pair",
+    "tags": [
+      "a",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "B3_EUR": {
+    "normalized_id": "B3/EUR",
+    "base": "B3",
+    "quote": "EUR",
+    "display_name": "B3 / Euro",
+    "description": "B3 to Euro spot trading pair",
+    "tags": [
+      "b3",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "B3_USD": {
+    "normalized_id": "B3/USD",
+    "base": "B3",
+    "quote": "USD",
+    "display_name": "B3 / US Dollar",
+    "description": "B3 to US Dollar spot trading pair",
+    "tags": [
+      "b3",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BABY_EUR": {
+    "normalized_id": "BABY/EUR",
+    "base": "BABY",
+    "quote": "EUR",
+    "display_name": "BABY / Euro",
+    "description": "BABY to Euro spot trading pair",
+    "tags": [
+      "baby",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BABY_USD": {
+    "normalized_id": "BABY/USD",
+    "base": "BABY",
+    "quote": "USD",
+    "display_name": "BABY / US Dollar",
+    "description": "BABY to US Dollar spot trading pair",
+    "tags": [
+      "baby",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BADGER_EUR": {
+    "normalized_id": "BADGER/EUR",
+    "base": "BADGER",
+    "quote": "EUR",
+    "display_name": "BADGER / Euro",
+    "description": "BADGER to Euro spot trading pair",
+    "tags": [
+      "badger",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BADGER_USD": {
+    "normalized_id": "BADGER/USD",
+    "base": "BADGER",
+    "quote": "USD",
+    "display_name": "BADGER / US Dollar",
+    "description": "BADGER to US Dollar spot trading pair",
+    "tags": [
+      "badger",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BAL_EUR": {
+    "normalized_id": "BAL/EUR",
+    "base": "BAL",
+    "quote": "EUR",
+    "display_name": "BAL / Euro",
+    "description": "BAL to Euro spot trading pair",
+    "tags": [
+      "bal",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BAL_USD": {
+    "normalized_id": "BAL/USD",
+    "base": "BAL",
+    "quote": "USD",
+    "display_name": "BAL / US Dollar",
+    "description": "BAL to US Dollar spot trading pair",
+    "tags": [
+      "bal",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BANANAS31_EUR": {
+    "normalized_id": "BANANAS31/EUR",
+    "base": "BANANAS31",
+    "quote": "EUR",
+    "display_name": "BANANAS31 / Euro",
+    "description": "BANANAS31 to Euro spot trading pair",
+    "tags": [
+      "bananas31",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BANANAS31_USD": {
+    "normalized_id": "BANANAS31/USD",
+    "base": "BANANAS31",
+    "quote": "USD",
+    "display_name": "BANANAS31 / US Dollar",
+    "description": "BANANAS31 to US Dollar spot trading pair",
+    "tags": [
+      "bananas31",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BAND_EUR": {
+    "normalized_id": "BAND/EUR",
+    "base": "BAND",
+    "quote": "EUR",
+    "display_name": "BAND / Euro",
+    "description": "BAND to Euro spot trading pair",
+    "tags": [
+      "band",
+      "oracle",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BAND_USD": {
+    "normalized_id": "BAND/USD",
+    "base": "BAND",
+    "quote": "USD",
+    "display_name": "BAND / US Dollar",
+    "description": "BAND to US Dollar spot trading pair",
+    "tags": [
+      "band",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BAT_EUR": {
+    "normalized_id": "BAT/EUR",
+    "base": "BAT",
+    "quote": "EUR",
+    "display_name": "Basic Attention Token / Euro",
+    "description": "Basic Attention Token to Euro spot trading pair",
+    "tags": [
+      "bat",
+      "basic attention token",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BAT_USD": {
+    "normalized_id": "BAT/USD",
+    "base": "BAT",
+    "quote": "USD",
+    "display_name": "Basic Attention Token / US Dollar",
+    "description": "Basic Attention Token to US Dollar spot trading pair",
+    "tags": [
+      "bat",
+      "basic attention token",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BCH_AUD": {
+    "normalized_id": "BCH/AUD",
+    "base": "BCH",
+    "quote": "AUD",
+    "display_name": "Bitcoin Cash / Australian Dollar",
+    "description": "Bitcoin Cash to Australian Dollar spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "BCH_ETH": {
+    "normalized_id": "BCH/ETH",
+    "base": "BCH",
+    "quote": "ETH",
+    "display_name": "Bitcoin Cash / Ethereum",
+    "description": "Bitcoin Cash to Ethereum spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "BCH_EUR": {
+    "normalized_id": "BCH/EUR",
+    "base": "BCH",
+    "quote": "EUR",
+    "display_name": "Bitcoin Cash / Euro",
+    "description": "Bitcoin Cash to Euro spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BCH_GBP": {
+    "normalized_id": "BCH/GBP",
+    "base": "BCH",
+    "quote": "GBP",
+    "display_name": "Bitcoin Cash / British Pound",
+    "description": "Bitcoin Cash to British Pound spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "BCH_JPY": {
+    "normalized_id": "BCH/JPY",
+    "base": "BCH",
+    "quote": "JPY",
+    "display_name": "Bitcoin Cash / Japanese Yen",
+    "description": "Bitcoin Cash to Japanese Yen spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "BCH_USD": {
+    "normalized_id": "BCH/USD",
+    "base": "BCH",
+    "quote": "USD",
+    "display_name": "Bitcoin Cash / US Dollar",
+    "description": "Bitcoin Cash to US Dollar spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BCH_USDC": {
+    "normalized_id": "BCH/USD",
+    "base": "BCH",
+    "quote": "USD",
+    "display_name": "Bitcoin Cash / US Dollar",
+    "description": "Bitcoin Cash to US Dollar spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BCH_USDT": {
+    "normalized_id": "BCH/USD",
+    "base": "BCH",
+    "quote": "USD",
+    "display_name": "Bitcoin Cash / US Dollar",
+    "description": "Bitcoin Cash to US Dollar spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BCH_XBT": {
+    "normalized_id": "BCH/XBT",
+    "base": "BCH",
+    "quote": "XBT",
+    "display_name": "Bitcoin Cash / XBT",
+    "description": "Bitcoin Cash to XBT spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "BDXN_EUR": {
+    "normalized_id": "BDXN/EUR",
+    "base": "BDXN",
+    "quote": "EUR",
+    "display_name": "BDXN / Euro",
+    "description": "BDXN to Euro spot trading pair",
+    "tags": [
+      "bdxn",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BDXN_USD": {
+    "normalized_id": "BDXN/USD",
+    "base": "BDXN",
+    "quote": "USD",
+    "display_name": "BDXN / US Dollar",
+    "description": "BDXN to US Dollar spot trading pair",
+    "tags": [
+      "bdxn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BEAM_EUR": {
+    "normalized_id": "BEAM/EUR",
+    "base": "BEAM",
+    "quote": "EUR",
+    "display_name": "BEAM / Euro",
+    "description": "BEAM to Euro spot trading pair",
+    "tags": [
+      "beam",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BEAM_USD": {
+    "normalized_id": "BEAM/USD",
+    "base": "BEAM",
+    "quote": "USD",
+    "display_name": "BEAM / US Dollar",
+    "description": "BEAM to US Dollar spot trading pair",
+    "tags": [
+      "beam",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BERA_EUR": {
+    "normalized_id": "BERA/EUR",
+    "base": "BERA",
+    "quote": "EUR",
+    "display_name": "BERA / Euro",
+    "description": "BERA to Euro spot trading pair",
+    "tags": [
+      "bera",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BERA_USD": {
+    "normalized_id": "BERA/USD",
+    "base": "BERA",
+    "quote": "USD",
+    "display_name": "BERA / US Dollar",
+    "description": "BERA to US Dollar spot trading pair",
+    "tags": [
+      "bera",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BERA_USDC": {
+    "normalized_id": "BERA/USD",
+    "base": "BERA",
+    "quote": "USD",
+    "display_name": "BERA / US Dollar",
+    "description": "BERA to US Dollar spot trading pair",
+    "tags": [
+      "bera",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BERA_USDT": {
+    "normalized_id": "BERA/USD",
+    "base": "BERA",
+    "quote": "USD",
+    "display_name": "BERA / US Dollar",
+    "description": "BERA to US Dollar spot trading pair",
+    "tags": [
+      "bera",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BICO_EUR": {
+    "normalized_id": "BICO/EUR",
+    "base": "BICO",
+    "quote": "EUR",
+    "display_name": "BICO / Euro",
+    "description": "BICO to Euro spot trading pair",
+    "tags": [
+      "bico",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BICO_USD": {
+    "normalized_id": "BICO/USD",
+    "base": "BICO",
+    "quote": "USD",
+    "display_name": "BICO / US Dollar",
+    "description": "BICO to US Dollar spot trading pair",
+    "tags": [
+      "bico",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BIGTIME_EUR": {
+    "normalized_id": "BIGTIME/EUR",
+    "base": "BIGTIME",
+    "quote": "EUR",
+    "display_name": "BIGTIME / Euro",
+    "description": "BIGTIME to Euro spot trading pair",
+    "tags": [
+      "bigtime",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BIGTIME_USD": {
+    "normalized_id": "BIGTIME/USD",
+    "base": "BIGTIME",
+    "quote": "USD",
+    "display_name": "BIGTIME / US Dollar",
+    "description": "BIGTIME to US Dollar spot trading pair",
+    "tags": [
+      "bigtime",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BIO_EUR": {
+    "normalized_id": "BIO/EUR",
+    "base": "BIO",
+    "quote": "EUR",
+    "display_name": "BIO / Euro",
+    "description": "BIO to Euro spot trading pair",
+    "tags": [
+      "bio",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BIO_USD": {
+    "normalized_id": "BIO/USD",
+    "base": "BIO",
+    "quote": "USD",
+    "display_name": "BIO / US Dollar",
+    "description": "BIO to US Dollar spot trading pair",
+    "tags": [
+      "bio",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BIT_EUR": {
+    "normalized_id": "BIT/EUR",
+    "base": "BIT",
+    "quote": "EUR",
+    "display_name": "BIT / Euro",
+    "description": "BIT to Euro spot trading pair",
+    "tags": [
+      "bit",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BIT_USD": {
+    "normalized_id": "BIT/USD",
+    "base": "BIT",
+    "quote": "USD",
+    "display_name": "BIT / US Dollar",
+    "description": "BIT to US Dollar spot trading pair",
+    "tags": [
+      "bit",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BLUR_EUR": {
+    "normalized_id": "BLUR/EUR",
+    "base": "BLUR",
+    "quote": "EUR",
+    "display_name": "BLUR / Euro",
+    "description": "BLUR to Euro spot trading pair",
+    "tags": [
+      "blur",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BLUR_USD": {
+    "normalized_id": "BLUR/USD",
+    "base": "BLUR",
+    "quote": "USD",
+    "display_name": "BLUR / US Dollar",
+    "description": "BLUR to US Dollar spot trading pair",
+    "tags": [
+      "blur",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BLZ_EUR": {
+    "normalized_id": "BLZ/EUR",
+    "base": "BLZ",
+    "quote": "EUR",
+    "display_name": "BLZ / Euro",
+    "description": "BLZ to Euro spot trading pair",
+    "tags": [
+      "blz",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BLZ_USD": {
+    "normalized_id": "BLZ/USD",
+    "base": "BLZ",
+    "quote": "USD",
+    "display_name": "BLZ / US Dollar",
+    "description": "BLZ to US Dollar spot trading pair",
+    "tags": [
+      "blz",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BMT_EUR": {
+    "normalized_id": "BMT/EUR",
+    "base": "BMT",
+    "quote": "EUR",
+    "display_name": "BMT / Euro",
+    "description": "BMT to Euro spot trading pair",
+    "tags": [
+      "bmt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BMT_USD": {
+    "normalized_id": "BMT/USD",
+    "base": "BMT",
+    "quote": "USD",
+    "display_name": "BMT / US Dollar",
+    "description": "BMT to US Dollar spot trading pair",
+    "tags": [
+      "bmt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNB_EUR": {
+    "normalized_id": "BNB/EUR",
+    "base": "BNB",
+    "quote": "EUR",
+    "display_name": "Binance Coin / Euro",
+    "description": "Binance Coin to Euro spot trading pair",
+    "tags": [
+      "bnb",
+      "binance coin",
+      "major",
+      "exchange",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BNB_USD": {
+    "normalized_id": "BNB/USD",
+    "base": "BNB",
+    "quote": "USD",
+    "display_name": "Binance Coin / US Dollar",
+    "description": "Binance Coin to US Dollar spot trading pair",
+    "tags": [
+      "bnb",
+      "binance coin",
+      "major",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNB_USDC": {
+    "normalized_id": "BNB/USD",
+    "base": "BNB",
+    "quote": "USD",
+    "display_name": "Binance Coin / US Dollar",
+    "description": "Binance Coin to US Dollar spot trading pair",
+    "tags": [
+      "bnb",
+      "binance coin",
+      "major",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNB_USDT": {
+    "normalized_id": "BNB/USD",
+    "base": "BNB",
+    "quote": "USD",
+    "display_name": "Binance Coin / US Dollar",
+    "description": "Binance Coin to US Dollar spot trading pair",
+    "tags": [
+      "bnb",
+      "binance coin",
+      "major",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNC_EUR": {
+    "normalized_id": "BNC/EUR",
+    "base": "BNC",
+    "quote": "EUR",
+    "display_name": "BNC / Euro",
+    "description": "BNC to Euro spot trading pair",
+    "tags": [
+      "bnc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BNC_USD": {
+    "normalized_id": "BNC/USD",
+    "base": "BNC",
+    "quote": "USD",
+    "display_name": "BNC / US Dollar",
+    "description": "BNC to US Dollar spot trading pair",
+    "tags": [
+      "bnc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNT_EUR": {
+    "normalized_id": "BNT/EUR",
+    "base": "BNT",
+    "quote": "EUR",
+    "display_name": "BNT / Euro",
+    "description": "BNT to Euro spot trading pair",
+    "tags": [
+      "bnt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BNT_USD": {
+    "normalized_id": "BNT/USD",
+    "base": "BNT",
+    "quote": "USD",
+    "display_name": "BNT / US Dollar",
+    "description": "BNT to US Dollar spot trading pair",
+    "tags": [
+      "bnt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BOBA_EUR": {
+    "normalized_id": "BOBA/EUR",
+    "base": "BOBA",
+    "quote": "EUR",
+    "display_name": "BOBA / Euro",
+    "description": "BOBA to Euro spot trading pair",
+    "tags": [
+      "boba",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BOBA_USD": {
+    "normalized_id": "BOBA/USD",
+    "base": "BOBA",
+    "quote": "USD",
+    "display_name": "BOBA / US Dollar",
+    "description": "BOBA to US Dollar spot trading pair",
+    "tags": [
+      "boba",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BODEN_EUR": {
+    "normalized_id": "BODEN/EUR",
+    "base": "BODEN",
+    "quote": "EUR",
+    "display_name": "BODEN / Euro",
+    "description": "BODEN to Euro spot trading pair",
+    "tags": [
+      "boden",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BODEN_USD": {
+    "normalized_id": "BODEN/USD",
+    "base": "BODEN",
+    "quote": "USD",
+    "display_name": "BODEN / US Dollar",
+    "description": "BODEN to US Dollar spot trading pair",
+    "tags": [
+      "boden",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BOND_EUR": {
+    "normalized_id": "BOND/EUR",
+    "base": "BOND",
+    "quote": "EUR",
+    "display_name": "BOND / Euro",
+    "description": "BOND to Euro spot trading pair",
+    "tags": [
+      "bond",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BOND_USD": {
+    "normalized_id": "BOND/USD",
+    "base": "BOND",
+    "quote": "USD",
+    "display_name": "BOND / US Dollar",
+    "description": "BOND to US Dollar spot trading pair",
+    "tags": [
+      "bond",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BONK_EUR": {
+    "normalized_id": "BONK/EUR",
+    "base": "BONK",
+    "quote": "EUR",
+    "display_name": "Bonk / Euro",
+    "description": "Bonk to Euro spot trading pair",
+    "tags": [
+      "bonk",
+      "meme",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BONK_USD": {
+    "normalized_id": "BONK/USD",
+    "base": "BONK",
+    "quote": "USD",
+    "display_name": "Bonk / US Dollar",
+    "description": "Bonk to US Dollar spot trading pair",
+    "tags": [
+      "bonk",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BRICK_EUR": {
+    "normalized_id": "BRICK/EUR",
+    "base": "BRICK",
+    "quote": "EUR",
+    "display_name": "BRICK / Euro",
+    "description": "BRICK to Euro spot trading pair",
+    "tags": [
+      "brick",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BRICK_USD": {
+    "normalized_id": "BRICK/USD",
+    "base": "BRICK",
+    "quote": "USD",
+    "display_name": "BRICK / US Dollar",
+    "description": "BRICK to US Dollar spot trading pair",
+    "tags": [
+      "brick",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BSX_EUR": {
+    "normalized_id": "BSX/EUR",
+    "base": "BSX",
+    "quote": "EUR",
+    "display_name": "BSX / Euro",
+    "description": "BSX to Euro spot trading pair",
+    "tags": [
+      "bsx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BSX_USD": {
+    "normalized_id": "BSX/USD",
+    "base": "BSX",
+    "quote": "USD",
+    "display_name": "BSX / US Dollar",
+    "description": "BSX to US Dollar spot trading pair",
+    "tags": [
+      "bsx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BTC_USD": {
+    "normalized_id": "BTC/USD",
+    "base": "BTC",
+    "quote": "USD",
+    "display_name": "Bitcoin / US Dollar",
+    "description": "Bitcoin to US Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BTT_EUR": {
+    "normalized_id": "BTT/EUR",
+    "base": "BTT",
+    "quote": "EUR",
+    "display_name": "BTT / Euro",
+    "description": "BTT to Euro spot trading pair",
+    "tags": [
+      "btt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BTT_USD": {
+    "normalized_id": "BTT/USD",
+    "base": "BTT",
+    "quote": "USD",
+    "display_name": "BTT / US Dollar",
+    "description": "BTT to US Dollar spot trading pair",
+    "tags": [
+      "btt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "C98_EUR": {
+    "normalized_id": "C98/EUR",
+    "base": "C98",
+    "quote": "EUR",
+    "display_name": "C98 / Euro",
+    "description": "C98 to Euro spot trading pair",
+    "tags": [
+      "c98",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "C98_USD": {
+    "normalized_id": "C98/USD",
+    "base": "C98",
+    "quote": "USD",
+    "display_name": "C98 / US Dollar",
+    "description": "C98 to US Dollar spot trading pair",
+    "tags": [
+      "c98",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CAKE_EUR": {
+    "normalized_id": "CAKE/EUR",
+    "base": "CAKE",
+    "quote": "EUR",
+    "display_name": "CAKE / Euro",
+    "description": "CAKE to Euro spot trading pair",
+    "tags": [
+      "cake",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CAKE_USD": {
+    "normalized_id": "CAKE/USD",
+    "base": "CAKE",
+    "quote": "USD",
+    "display_name": "CAKE / US Dollar",
+    "description": "CAKE to US Dollar spot trading pair",
+    "tags": [
+      "cake",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CARV_EUR": {
+    "normalized_id": "CARV/EUR",
+    "base": "CARV",
+    "quote": "EUR",
+    "display_name": "CARV / Euro",
+    "description": "CARV to Euro spot trading pair",
+    "tags": [
+      "carv",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CARV_USD": {
+    "normalized_id": "CARV/USD",
+    "base": "CARV",
+    "quote": "USD",
+    "display_name": "CARV / US Dollar",
+    "description": "CARV to US Dollar spot trading pair",
+    "tags": [
+      "carv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CAT_EUR": {
+    "normalized_id": "CAT/EUR",
+    "base": "CAT",
+    "quote": "EUR",
+    "display_name": "CAT / Euro",
+    "description": "CAT to Euro spot trading pair",
+    "tags": [
+      "cat",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CAT_USD": {
+    "normalized_id": "CAT/USD",
+    "base": "CAT",
+    "quote": "USD",
+    "display_name": "CAT / US Dollar",
+    "description": "CAT to US Dollar spot trading pair",
+    "tags": [
+      "cat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CCD_EUR": {
+    "normalized_id": "CCD/EUR",
+    "base": "CCD",
+    "quote": "EUR",
+    "display_name": "CCD / Euro",
+    "description": "CCD to Euro spot trading pair",
+    "tags": [
+      "ccd",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CCD_USD": {
+    "normalized_id": "CCD/USD",
+    "base": "CCD",
+    "quote": "USD",
+    "display_name": "CCD / US Dollar",
+    "description": "CCD to US Dollar spot trading pair",
+    "tags": [
+      "ccd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CELO_EUR": {
+    "normalized_id": "CELO/EUR",
+    "base": "CELO",
+    "quote": "EUR",
+    "display_name": "CELO / Euro",
+    "description": "CELO to Euro spot trading pair",
+    "tags": [
+      "celo",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CELO_USD": {
+    "normalized_id": "CELO/USD",
+    "base": "CELO",
+    "quote": "USD",
+    "display_name": "CELO / US Dollar",
+    "description": "CELO to US Dollar spot trading pair",
+    "tags": [
+      "celo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CELR_EUR": {
+    "normalized_id": "CELR/EUR",
+    "base": "CELR",
+    "quote": "EUR",
+    "display_name": "CELR / Euro",
+    "description": "CELR to Euro spot trading pair",
+    "tags": [
+      "celr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CELR_USD": {
+    "normalized_id": "CELR/USD",
+    "base": "CELR",
+    "quote": "USD",
+    "display_name": "CELR / US Dollar",
+    "description": "CELR to US Dollar spot trading pair",
+    "tags": [
+      "celr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CFG_EUR": {
+    "normalized_id": "CFG/EUR",
+    "base": "CFG",
+    "quote": "EUR",
+    "display_name": "CFG / Euro",
+    "description": "CFG to Euro spot trading pair",
+    "tags": [
+      "cfg",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CFG_USD": {
+    "normalized_id": "CFG/USD",
+    "base": "CFG",
+    "quote": "USD",
+    "display_name": "CFG / US Dollar",
+    "description": "CFG to US Dollar spot trading pair",
+    "tags": [
+      "cfg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CHEEMS_EUR": {
+    "normalized_id": "CHEEMS/EUR",
+    "base": "CHEEMS",
+    "quote": "EUR",
+    "display_name": "CHEEMS / Euro",
+    "description": "CHEEMS to Euro spot trading pair",
+    "tags": [
+      "cheems",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CHEEMS_USD": {
+    "normalized_id": "CHEEMS/USD",
+    "base": "CHEEMS",
+    "quote": "USD",
+    "display_name": "CHEEMS / US Dollar",
+    "description": "CHEEMS to US Dollar spot trading pair",
+    "tags": [
+      "cheems",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CHEX_EUR": {
+    "normalized_id": "CHEX/EUR",
+    "base": "CHEX",
+    "quote": "EUR",
+    "display_name": "CHEX / Euro",
+    "description": "CHEX to Euro spot trading pair",
+    "tags": [
+      "chex",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CHEX_USD": {
+    "normalized_id": "CHEX/USD",
+    "base": "CHEX",
+    "quote": "USD",
+    "display_name": "CHEX / US Dollar",
+    "description": "CHEX to US Dollar spot trading pair",
+    "tags": [
+      "chex",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CHILLHOUSE_EUR": {
+    "normalized_id": "CHILLHOUSE/EUR",
+    "base": "CHILLHOUSE",
+    "quote": "EUR",
+    "display_name": "CHILLHOUSE / Euro",
+    "description": "CHILLHOUSE to Euro spot trading pair",
+    "tags": [
+      "chillhouse",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CHILLHOUSE_USD": {
+    "normalized_id": "CHILLHOUSE/USD",
+    "base": "CHILLHOUSE",
+    "quote": "USD",
+    "display_name": "CHILLHOUSE / US Dollar",
+    "description": "CHILLHOUSE to US Dollar spot trading pair",
+    "tags": [
+      "chillhouse",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CHR_EUR": {
+    "normalized_id": "CHR/EUR",
+    "base": "CHR",
+    "quote": "EUR",
+    "display_name": "CHR / Euro",
+    "description": "CHR to Euro spot trading pair",
+    "tags": [
+      "chr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CHR_USD": {
+    "normalized_id": "CHR/USD",
+    "base": "CHR",
+    "quote": "USD",
+    "display_name": "CHR / US Dollar",
+    "description": "CHR to US Dollar spot trading pair",
+    "tags": [
+      "chr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CHZ_EUR": {
+    "normalized_id": "CHZ/EUR",
+    "base": "CHZ",
+    "quote": "EUR",
+    "display_name": "Chiliz / Euro",
+    "description": "Chiliz to Euro spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CHZ_USD": {
+    "normalized_id": "CHZ/USD",
+    "base": "CHZ",
+    "quote": "USD",
+    "display_name": "Chiliz / US Dollar",
+    "description": "Chiliz to US Dollar spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CLANKER_EUR": {
+    "normalized_id": "CLANKER/EUR",
+    "base": "CLANKER",
+    "quote": "EUR",
+    "display_name": "CLANKER / Euro",
+    "description": "CLANKER to Euro spot trading pair",
+    "tags": [
+      "clanker",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CLANKER_USD": {
+    "normalized_id": "CLANKER/USD",
+    "base": "CLANKER",
+    "quote": "USD",
+    "display_name": "CLANKER / US Dollar",
+    "description": "CLANKER to US Dollar spot trading pair",
+    "tags": [
+      "clanker",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CLOUD_EUR": {
+    "normalized_id": "CLOUD/EUR",
+    "base": "CLOUD",
+    "quote": "EUR",
+    "display_name": "CLOUD / Euro",
+    "description": "CLOUD to Euro spot trading pair",
+    "tags": [
+      "cloud",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CLOUD_USD": {
+    "normalized_id": "CLOUD/USD",
+    "base": "CLOUD",
+    "quote": "USD",
+    "display_name": "CLOUD / US Dollar",
+    "description": "CLOUD to US Dollar spot trading pair",
+    "tags": [
+      "cloud",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CLV_EUR": {
+    "normalized_id": "CLV/EUR",
+    "base": "CLV",
+    "quote": "EUR",
+    "display_name": "CLV / Euro",
+    "description": "CLV to Euro spot trading pair",
+    "tags": [
+      "clv",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CLV_USD": {
+    "normalized_id": "CLV/USD",
+    "base": "CLV",
+    "quote": "USD",
+    "display_name": "CLV / US Dollar",
+    "description": "CLV to US Dollar spot trading pair",
+    "tags": [
+      "clv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CMETH_ETH": {
+    "normalized_id": "CMETH/ETH",
+    "base": "CMETH",
+    "quote": "ETH",
+    "display_name": "CMETH / Ethereum",
+    "description": "CMETH to Ethereum spot trading pair",
+    "tags": [
+      "cmeth",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "CMETH_USD": {
+    "normalized_id": "CMETH/USD",
+    "base": "CMETH",
+    "quote": "USD",
+    "display_name": "CMETH / US Dollar",
+    "description": "CMETH to US Dollar spot trading pair",
+    "tags": [
+      "cmeth",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COMP_EUR": {
+    "normalized_id": "COMP/EUR",
+    "base": "COMP",
+    "quote": "EUR",
+    "display_name": "Compound / Euro",
+    "description": "Compound to Euro spot trading pair",
+    "tags": [
+      "comp",
+      "compound",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "COMP_USD": {
+    "normalized_id": "COMP/USD",
+    "base": "COMP",
+    "quote": "USD",
+    "display_name": "Compound / US Dollar",
+    "description": "Compound to US Dollar spot trading pair",
+    "tags": [
+      "comp",
+      "compound",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COMP_XBT": {
+    "normalized_id": "COMP/XBT",
+    "base": "COMP",
+    "quote": "XBT",
+    "display_name": "Compound / XBT",
+    "description": "Compound to XBT spot trading pair",
+    "tags": [
+      "comp",
+      "compound",
+      "defi",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "COOKIE_EUR": {
+    "normalized_id": "COOKIE/EUR",
+    "base": "COOKIE",
+    "quote": "EUR",
+    "display_name": "COOKIE / Euro",
+    "description": "COOKIE to Euro spot trading pair",
+    "tags": [
+      "cookie",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "COOKIE_USD": {
+    "normalized_id": "COOKIE/USD",
+    "base": "COOKIE",
+    "quote": "USD",
+    "display_name": "COOKIE / US Dollar",
+    "description": "COOKIE to US Dollar spot trading pair",
+    "tags": [
+      "cookie",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COQ_EUR": {
+    "normalized_id": "COQ/EUR",
+    "base": "COQ",
+    "quote": "EUR",
+    "display_name": "COQ / Euro",
+    "description": "COQ to Euro spot trading pair",
+    "tags": [
+      "coq",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "COQ_USD": {
+    "normalized_id": "COQ/USD",
+    "base": "COQ",
+    "quote": "USD",
+    "display_name": "COQ / US Dollar",
+    "description": "COQ to US Dollar spot trading pair",
+    "tags": [
+      "coq",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CORN_EUR": {
+    "normalized_id": "CORN/EUR",
+    "base": "CORN",
+    "quote": "EUR",
+    "display_name": "CORN / Euro",
+    "description": "CORN to Euro spot trading pair",
+    "tags": [
+      "corn",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CORN_USD": {
+    "normalized_id": "CORN/USD",
+    "base": "CORN",
+    "quote": "USD",
+    "display_name": "CORN / US Dollar",
+    "description": "CORN to US Dollar spot trading pair",
+    "tags": [
+      "corn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COTI_EUR": {
+    "normalized_id": "COTI/EUR",
+    "base": "COTI",
+    "quote": "EUR",
+    "display_name": "COTI / Euro",
+    "description": "COTI to Euro spot trading pair",
+    "tags": [
+      "coti",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "COTI_USD": {
+    "normalized_id": "COTI/USD",
+    "base": "COTI",
+    "quote": "USD",
+    "display_name": "COTI / US Dollar",
+    "description": "COTI to US Dollar spot trading pair",
+    "tags": [
+      "coti",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COW_EUR": {
+    "normalized_id": "COW/EUR",
+    "base": "COW",
+    "quote": "EUR",
+    "display_name": "COW / Euro",
+    "description": "COW to Euro spot trading pair",
+    "tags": [
+      "cow",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "COW_USD": {
+    "normalized_id": "COW/USD",
+    "base": "COW",
+    "quote": "USD",
+    "display_name": "COW / US Dollar",
+    "description": "COW to US Dollar spot trading pair",
+    "tags": [
+      "cow",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CPOOL_EUR": {
+    "normalized_id": "CPOOL/EUR",
+    "base": "CPOOL",
+    "quote": "EUR",
+    "display_name": "CPOOL / Euro",
+    "description": "CPOOL to Euro spot trading pair",
+    "tags": [
+      "cpool",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CPOOL_USD": {
+    "normalized_id": "CPOOL/USD",
+    "base": "CPOOL",
+    "quote": "USD",
+    "display_name": "CPOOL / US Dollar",
+    "description": "CPOOL to US Dollar spot trading pair",
+    "tags": [
+      "cpool",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CQT_EUR": {
+    "normalized_id": "CQT/EUR",
+    "base": "CQT",
+    "quote": "EUR",
+    "display_name": "CQT / Euro",
+    "description": "CQT to Euro spot trading pair",
+    "tags": [
+      "cqt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CQT_USD": {
+    "normalized_id": "CQT/USD",
+    "base": "CQT",
+    "quote": "USD",
+    "display_name": "CQT / US Dollar",
+    "description": "CQT to US Dollar spot trading pair",
+    "tags": [
+      "cqt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CRO_EUR": {
+    "normalized_id": "CRO/EUR",
+    "base": "CRO",
+    "quote": "EUR",
+    "display_name": "CRO / Euro",
+    "description": "CRO to Euro spot trading pair",
+    "tags": [
+      "cro",
+      "exchange",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CRO_USD": {
+    "normalized_id": "CRO/USD",
+    "base": "CRO",
+    "quote": "USD",
+    "display_name": "CRO / US Dollar",
+    "description": "CRO to US Dollar spot trading pair",
+    "tags": [
+      "cro",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CRO_USDC": {
+    "normalized_id": "CRO/USD",
+    "base": "CRO",
+    "quote": "USD",
+    "display_name": "CRO / US Dollar",
+    "description": "CRO to US Dollar spot trading pair",
+    "tags": [
+      "cro",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CRO_USDT": {
+    "normalized_id": "CRO/USD",
+    "base": "CRO",
+    "quote": "USD",
+    "display_name": "CRO / US Dollar",
+    "description": "CRO to US Dollar spot trading pair",
+    "tags": [
+      "cro",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CRV_EUR": {
+    "normalized_id": "CRV/EUR",
+    "base": "CRV",
+    "quote": "EUR",
+    "display_name": "Curve / Euro",
+    "description": "Curve to Euro spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CRV_USD": {
+    "normalized_id": "CRV/USD",
+    "base": "CRV",
+    "quote": "USD",
+    "display_name": "Curve / US Dollar",
+    "description": "Curve to US Dollar spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CSM_EUR": {
+    "normalized_id": "CSM/EUR",
+    "base": "CSM",
+    "quote": "EUR",
+    "display_name": "CSM / Euro",
+    "description": "CSM to Euro spot trading pair",
+    "tags": [
+      "csm",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CSM_USD": {
+    "normalized_id": "CSM/USD",
+    "base": "CSM",
+    "quote": "USD",
+    "display_name": "CSM / US Dollar",
+    "description": "CSM to US Dollar spot trading pair",
+    "tags": [
+      "csm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CTSI_EUR": {
+    "normalized_id": "CTSI/EUR",
+    "base": "CTSI",
+    "quote": "EUR",
+    "display_name": "CTSI / Euro",
+    "description": "CTSI to Euro spot trading pair",
+    "tags": [
+      "ctsi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CTSI_USD": {
+    "normalized_id": "CTSI/USD",
+    "base": "CTSI",
+    "quote": "USD",
+    "display_name": "CTSI / US Dollar",
+    "description": "CTSI to US Dollar spot trading pair",
+    "tags": [
+      "ctsi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CVC_EUR": {
+    "normalized_id": "CVC/EUR",
+    "base": "CVC",
+    "quote": "EUR",
+    "display_name": "CVC / Euro",
+    "description": "CVC to Euro spot trading pair",
+    "tags": [
+      "cvc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CVC_USD": {
+    "normalized_id": "CVC/USD",
+    "base": "CVC",
+    "quote": "USD",
+    "display_name": "CVC / US Dollar",
+    "description": "CVC to US Dollar spot trading pair",
+    "tags": [
+      "cvc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CVX_EUR": {
+    "normalized_id": "CVX/EUR",
+    "base": "CVX",
+    "quote": "EUR",
+    "display_name": "CVX / Euro",
+    "description": "CVX to Euro spot trading pair",
+    "tags": [
+      "cvx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CVX_USD": {
+    "normalized_id": "CVX/USD",
+    "base": "CVX",
+    "quote": "USD",
+    "display_name": "CVX / US Dollar",
+    "description": "CVX to US Dollar spot trading pair",
+    "tags": [
+      "cvx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CXT_EUR": {
+    "normalized_id": "CXT/EUR",
+    "base": "CXT",
+    "quote": "EUR",
+    "display_name": "CXT / Euro",
+    "description": "CXT to Euro spot trading pair",
+    "tags": [
+      "cxt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CXT_USD": {
+    "normalized_id": "CXT/USD",
+    "base": "CXT",
+    "quote": "USD",
+    "display_name": "CXT / US Dollar",
+    "description": "CXT to US Dollar spot trading pair",
+    "tags": [
+      "cxt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CYBER_EUR": {
+    "normalized_id": "CYBER/EUR",
+    "base": "CYBER",
+    "quote": "EUR",
+    "display_name": "CYBER / Euro",
+    "description": "CYBER to Euro spot trading pair",
+    "tags": [
+      "cyber",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CYBER_USD": {
+    "normalized_id": "CYBER/USD",
+    "base": "CYBER",
+    "quote": "USD",
+    "display_name": "CYBER / US Dollar",
+    "description": "CYBER to US Dollar spot trading pair",
+    "tags": [
+      "cyber",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DAI_EUR": {
+    "normalized_id": "DAI/EUR",
+    "base": "DAI",
+    "quote": "EUR",
+    "display_name": "Dai / Euro",
+    "description": "Dai to Euro spot trading pair",
+    "tags": [
+      "dai",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DAI_USD": {
+    "normalized_id": "DAI/USD",
+    "base": "DAI",
+    "quote": "USD",
+    "display_name": "Dai / US Dollar",
+    "description": "Dai to US Dollar spot trading pair",
+    "tags": [
+      "dai",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DAI_USDT": {
+    "normalized_id": "DAI/USD",
+    "base": "DAI",
+    "quote": "USD",
+    "display_name": "Dai / US Dollar",
+    "description": "Dai to US Dollar spot trading pair",
+    "tags": [
+      "dai",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DASH_EUR": {
+    "normalized_id": "DASH/EUR",
+    "base": "DASH",
+    "quote": "EUR",
+    "display_name": "DASH / Euro",
+    "description": "DASH to Euro spot trading pair",
+    "tags": [
+      "dash",
+      "privacy",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DASH_USD": {
+    "normalized_id": "DASH/USD",
+    "base": "DASH",
+    "quote": "USD",
+    "display_name": "DASH / US Dollar",
+    "description": "DASH to US Dollar spot trading pair",
+    "tags": [
+      "dash",
+      "privacy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DBR_EUR": {
+    "normalized_id": "DBR/EUR",
+    "base": "DBR",
+    "quote": "EUR",
+    "display_name": "DBR / Euro",
+    "description": "DBR to Euro spot trading pair",
+    "tags": [
+      "dbr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DBR_USD": {
+    "normalized_id": "DBR/USD",
+    "base": "DBR",
+    "quote": "USD",
+    "display_name": "DBR / US Dollar",
+    "description": "DBR to US Dollar spot trading pair",
+    "tags": [
+      "dbr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DEEP_EUR": {
+    "normalized_id": "DEEP/EUR",
+    "base": "DEEP",
+    "quote": "EUR",
+    "display_name": "DEEP / Euro",
+    "description": "DEEP to Euro spot trading pair",
+    "tags": [
+      "deep",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DEEP_USD": {
+    "normalized_id": "DEEP/USD",
+    "base": "DEEP",
+    "quote": "USD",
+    "display_name": "DEEP / US Dollar",
+    "description": "DEEP to US Dollar spot trading pair",
+    "tags": [
+      "deep",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DEGEN_EUR": {
+    "normalized_id": "DEGEN/EUR",
+    "base": "DEGEN",
+    "quote": "EUR",
+    "display_name": "DEGEN / Euro",
+    "description": "DEGEN to Euro spot trading pair",
+    "tags": [
+      "degen",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DEGEN_USD": {
+    "normalized_id": "DEGEN/USD",
+    "base": "DEGEN",
+    "quote": "USD",
+    "display_name": "DEGEN / US Dollar",
+    "description": "DEGEN to US Dollar spot trading pair",
+    "tags": [
+      "degen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DENT_EUR": {
+    "normalized_id": "DENT/EUR",
+    "base": "DENT",
+    "quote": "EUR",
+    "display_name": "DENT / Euro",
+    "description": "DENT to Euro spot trading pair",
+    "tags": [
+      "dent",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DENT_USD": {
+    "normalized_id": "DENT/USD",
+    "base": "DENT",
+    "quote": "USD",
+    "display_name": "DENT / US Dollar",
+    "description": "DENT to US Dollar spot trading pair",
+    "tags": [
+      "dent",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DMC_EUR": {
+    "normalized_id": "DMC/EUR",
+    "base": "DMC",
+    "quote": "EUR",
+    "display_name": "DMC / Euro",
+    "description": "DMC to Euro spot trading pair",
+    "tags": [
+      "dmc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DMC_USD": {
+    "normalized_id": "DMC/USD",
+    "base": "DMC",
+    "quote": "USD",
+    "display_name": "DMC / US Dollar",
+    "description": "DMC to US Dollar spot trading pair",
+    "tags": [
+      "dmc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGS_EUR": {
+    "normalized_id": "DOGS/EUR",
+    "base": "DOGS",
+    "quote": "EUR",
+    "display_name": "DOGS / Euro",
+    "description": "DOGS to Euro spot trading pair",
+    "tags": [
+      "dogs",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DOGS_USD": {
+    "normalized_id": "DOGS/USD",
+    "base": "DOGS",
+    "quote": "USD",
+    "display_name": "DOGS / US Dollar",
+    "description": "DOGS to US Dollar spot trading pair",
+    "tags": [
+      "dogs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOG_EUR": {
+    "normalized_id": "DOG/EUR",
+    "base": "DOG",
+    "quote": "EUR",
+    "display_name": "DOG / Euro",
+    "description": "DOG to Euro spot trading pair",
+    "tags": [
+      "dog",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DOG_USD": {
+    "normalized_id": "DOG/USD",
+    "base": "DOG",
+    "quote": "USD",
+    "display_name": "DOG / US Dollar",
+    "description": "DOG to US Dollar spot trading pair",
+    "tags": [
+      "dog",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOLO_EUR": {
+    "normalized_id": "DOLO/EUR",
+    "base": "DOLO",
+    "quote": "EUR",
+    "display_name": "DOLO / Euro",
+    "description": "DOLO to Euro spot trading pair",
+    "tags": [
+      "dolo",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DOLO_USD": {
+    "normalized_id": "DOLO/USD",
+    "base": "DOLO",
+    "quote": "USD",
+    "display_name": "DOLO / US Dollar",
+    "description": "DOLO to US Dollar spot trading pair",
+    "tags": [
+      "dolo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOT_ETH": {
+    "normalized_id": "DOT/ETH",
+    "base": "DOT",
+    "quote": "ETH",
+    "display_name": "Polkadot / Ethereum",
+    "description": "Polkadot to Ethereum spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "DOT_EUR": {
+    "normalized_id": "DOT/EUR",
+    "base": "DOT",
+    "quote": "EUR",
+    "display_name": "Polkadot / Euro",
+    "description": "Polkadot to Euro spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DOT_GBP": {
+    "normalized_id": "DOT/GBP",
+    "base": "DOT",
+    "quote": "GBP",
+    "display_name": "Polkadot / British Pound",
+    "description": "Polkadot to British Pound spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "DOT_JPY": {
+    "normalized_id": "DOT/JPY",
+    "base": "DOT",
+    "quote": "JPY",
+    "display_name": "Polkadot / Japanese Yen",
+    "description": "Polkadot to Japanese Yen spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "DOT_USD": {
+    "normalized_id": "DOT/USD",
+    "base": "DOT",
+    "quote": "USD",
+    "display_name": "Polkadot / US Dollar",
+    "description": "Polkadot to US Dollar spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOT_USDC": {
+    "normalized_id": "DOT/USD",
+    "base": "DOT",
+    "quote": "USD",
+    "display_name": "Polkadot / US Dollar",
+    "description": "Polkadot to US Dollar spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOT_USDT": {
+    "normalized_id": "DOT/USD",
+    "base": "DOT",
+    "quote": "USD",
+    "display_name": "Polkadot / US Dollar",
+    "description": "Polkadot to US Dollar spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOT_XBT": {
+    "normalized_id": "DOT/XBT",
+    "base": "DOT",
+    "quote": "XBT",
+    "display_name": "Polkadot / XBT",
+    "description": "Polkadot to XBT spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "DRIFT_EUR": {
+    "normalized_id": "DRIFT/EUR",
+    "base": "DRIFT",
+    "quote": "EUR",
+    "display_name": "DRIFT / Euro",
+    "description": "DRIFT to Euro spot trading pair",
+    "tags": [
+      "drift",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DRIFT_USD": {
+    "normalized_id": "DRIFT/USD",
+    "base": "DRIFT",
+    "quote": "USD",
+    "display_name": "DRIFT / US Dollar",
+    "description": "DRIFT to US Dollar spot trading pair",
+    "tags": [
+      "drift",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DRV_EUR": {
+    "normalized_id": "DRV/EUR",
+    "base": "DRV",
+    "quote": "EUR",
+    "display_name": "DRV / Euro",
+    "description": "DRV to Euro spot trading pair",
+    "tags": [
+      "drv",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DRV_USD": {
+    "normalized_id": "DRV/USD",
+    "base": "DRV",
+    "quote": "USD",
+    "display_name": "DRV / US Dollar",
+    "description": "DRV to US Dollar spot trading pair",
+    "tags": [
+      "drv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DUCK_EUR": {
+    "normalized_id": "DUCK/EUR",
+    "base": "DUCK",
+    "quote": "EUR",
+    "display_name": "DUCK / Euro",
+    "description": "DUCK to Euro spot trading pair",
+    "tags": [
+      "duck",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DUCK_USD": {
+    "normalized_id": "DUCK/USD",
+    "base": "DUCK",
+    "quote": "USD",
+    "display_name": "DUCK / US Dollar",
+    "description": "DUCK to US Dollar spot trading pair",
+    "tags": [
+      "duck",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DYDX_EUR": {
+    "normalized_id": "DYDX/EUR",
+    "base": "DYDX",
+    "quote": "EUR",
+    "display_name": "DYDX / Euro",
+    "description": "DYDX to Euro spot trading pair",
+    "tags": [
+      "dydx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DYDX_USD": {
+    "normalized_id": "DYDX/USD",
+    "base": "DYDX",
+    "quote": "USD",
+    "display_name": "DYDX / US Dollar",
+    "description": "DYDX to US Dollar spot trading pair",
+    "tags": [
+      "dydx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DYM_EUR": {
+    "normalized_id": "DYM/EUR",
+    "base": "DYM",
+    "quote": "EUR",
+    "display_name": "DYM / Euro",
+    "description": "DYM to Euro spot trading pair",
+    "tags": [
+      "dym",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DYM_USD": {
+    "normalized_id": "DYM/USD",
+    "base": "DYM",
+    "quote": "USD",
+    "display_name": "DYM / US Dollar",
+    "description": "DYM to US Dollar spot trading pair",
+    "tags": [
+      "dym",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EDGE_EUR": {
+    "normalized_id": "EDGE/EUR",
+    "base": "EDGE",
+    "quote": "EUR",
+    "display_name": "EDGE / Euro",
+    "description": "EDGE to Euro spot trading pair",
+    "tags": [
+      "edge",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "EDGE_USD": {
+    "normalized_id": "EDGE/USD",
+    "base": "EDGE",
+    "quote": "USD",
+    "display_name": "EDGE / US Dollar",
+    "description": "EDGE to US Dollar spot trading pair",
+    "tags": [
+      "edge",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EGLD_EUR": {
+    "normalized_id": "EGLD/EUR",
+    "base": "EGLD",
+    "quote": "EUR",
+    "display_name": "MultiversX / Euro",
+    "description": "MultiversX to Euro spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "EGLD_USD": {
+    "normalized_id": "EGLD/USD",
+    "base": "EGLD",
+    "quote": "USD",
+    "display_name": "MultiversX / US Dollar",
+    "description": "MultiversX to US Dollar spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EIGEN_EUR": {
+    "normalized_id": "EIGEN/EUR",
+    "base": "EIGEN",
+    "quote": "EUR",
+    "display_name": "EIGEN / Euro",
+    "description": "EIGEN to Euro spot trading pair",
+    "tags": [
+      "eigen",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "EIGEN_USD": {
+    "normalized_id": "EIGEN/USD",
+    "base": "EIGEN",
+    "quote": "USD",
+    "display_name": "EIGEN / US Dollar",
+    "description": "EIGEN to US Dollar spot trading pair",
+    "tags": [
+      "eigen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ELX_EUR": {
+    "normalized_id": "ELX/EUR",
+    "base": "ELX",
+    "quote": "EUR",
+    "display_name": "ELX / Euro",
+    "description": "ELX to Euro spot trading pair",
+    "tags": [
+      "elx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ELX_USD": {
+    "normalized_id": "ELX/USD",
+    "base": "ELX",
+    "quote": "USD",
+    "display_name": "ELX / US Dollar",
+    "description": "ELX to US Dollar spot trading pair",
+    "tags": [
+      "elx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENA_EUR": {
+    "normalized_id": "ENA/EUR",
+    "base": "ENA",
+    "quote": "EUR",
+    "display_name": "ENA / Euro",
+    "description": "ENA to Euro spot trading pair",
+    "tags": [
+      "ena",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ENA_USD": {
+    "normalized_id": "ENA/USD",
+    "base": "ENA",
+    "quote": "USD",
+    "display_name": "ENA / US Dollar",
+    "description": "ENA to US Dollar spot trading pair",
+    "tags": [
+      "ena",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENJ_EUR": {
+    "normalized_id": "ENJ/EUR",
+    "base": "ENJ",
+    "quote": "EUR",
+    "display_name": "Enjin / Euro",
+    "description": "Enjin to Euro spot trading pair",
+    "tags": [
+      "enj",
+      "enjin",
+      "gaming",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ENJ_USD": {
+    "normalized_id": "ENJ/USD",
+    "base": "ENJ",
+    "quote": "USD",
+    "display_name": "Enjin / US Dollar",
+    "description": "Enjin to US Dollar spot trading pair",
+    "tags": [
+      "enj",
+      "enjin",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENS_EUR": {
+    "normalized_id": "ENS/EUR",
+    "base": "ENS",
+    "quote": "EUR",
+    "display_name": "ENS / Euro",
+    "description": "ENS to Euro spot trading pair",
+    "tags": [
+      "ens",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ENS_USD": {
+    "normalized_id": "ENS/USD",
+    "base": "ENS",
+    "quote": "USD",
+    "display_name": "ENS / US Dollar",
+    "description": "ENS to US Dollar spot trading pair",
+    "tags": [
+      "ens",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EPT_EUR": {
+    "normalized_id": "EPT/EUR",
+    "base": "EPT",
+    "quote": "EUR",
+    "display_name": "EPT / Euro",
+    "description": "EPT to Euro spot trading pair",
+    "tags": [
+      "ept",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "EPT_USD": {
+    "normalized_id": "EPT/USD",
+    "base": "EPT",
+    "quote": "USD",
+    "display_name": "EPT / US Dollar",
+    "description": "EPT to US Dollar spot trading pair",
+    "tags": [
+      "ept",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ESX_EUR": {
+    "normalized_id": "ESX/EUR",
+    "base": "ESX",
+    "quote": "EUR",
+    "display_name": "ESX / Euro",
+    "description": "ESX to Euro spot trading pair",
+    "tags": [
+      "esx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ESX_USD": {
+    "normalized_id": "ESX/USD",
+    "base": "ESX",
+    "quote": "USD",
+    "display_name": "ESX / US Dollar",
+    "description": "ESX to US Dollar spot trading pair",
+    "tags": [
+      "esx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ES_EUR": {
+    "normalized_id": "ES/EUR",
+    "base": "ES",
+    "quote": "EUR",
+    "display_name": "ES / Euro",
+    "description": "ES to Euro spot trading pair",
+    "tags": [
+      "es",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ES_USD": {
+    "normalized_id": "ES/USD",
+    "base": "ES",
+    "quote": "USD",
+    "display_name": "ES / US Dollar",
+    "description": "ES to US Dollar spot trading pair",
+    "tags": [
+      "es",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETC_ETH": {
+    "normalized_id": "ETC/ETH",
+    "base": "ETC",
+    "quote": "ETH",
+    "display_name": "ETC / Ethereum",
+    "description": "ETC to Ethereum spot trading pair",
+    "tags": [
+      "etc",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "ETC_EUR": {
+    "normalized_id": "ETC/EUR",
+    "base": "ETC",
+    "quote": "EUR",
+    "display_name": "ETC / Euro",
+    "description": "ETC to Euro spot trading pair",
+    "tags": [
+      "etc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ETC_USD": {
+    "normalized_id": "ETC/USD",
+    "base": "ETC",
+    "quote": "USD",
+    "display_name": "ETC / US Dollar",
+    "description": "ETC to US Dollar spot trading pair",
+    "tags": [
+      "etc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETC_XBT": {
+    "normalized_id": "ETC/XBT",
+    "base": "ETC",
+    "quote": "XBT",
+    "display_name": "ETC / XBT",
+    "description": "ETC to XBT spot trading pair",
+    "tags": [
+      "etc",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "ETHFI_EUR": {
+    "normalized_id": "ETHFI/EUR",
+    "base": "ETHFI",
+    "quote": "EUR",
+    "display_name": "ETHFI / Euro",
+    "description": "ETHFI to Euro spot trading pair",
+    "tags": [
+      "ethfi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ETHFI_USD": {
+    "normalized_id": "ETHFI/USD",
+    "base": "ETHFI",
+    "quote": "USD",
+    "display_name": "ETHFI / US Dollar",
+    "description": "ETHFI to US Dollar spot trading pair",
+    "tags": [
+      "ethfi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETHW_ETH": {
+    "normalized_id": "ETHW/ETH",
+    "base": "ETHW",
+    "quote": "ETH",
+    "display_name": "ETHW / Ethereum",
+    "description": "ETHW to Ethereum spot trading pair",
+    "tags": [
+      "ethw",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "ETHW_EUR": {
+    "normalized_id": "ETHW/EUR",
+    "base": "ETHW",
+    "quote": "EUR",
+    "display_name": "ETHW / Euro",
+    "description": "ETHW to Euro spot trading pair",
+    "tags": [
+      "ethw",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ETHW_USD": {
+    "normalized_id": "ETHW/USD",
+    "base": "ETHW",
+    "quote": "USD",
+    "display_name": "ETHW / US Dollar",
+    "description": "ETHW to US Dollar spot trading pair",
+    "tags": [
+      "ethw",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETH_AUD": {
+    "normalized_id": "ETH/AUD",
+    "base": "ETH",
+    "quote": "AUD",
+    "display_name": "Ethereum / Australian Dollar",
+    "description": "Ethereum to Australian Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "ETH_CAD": {
+    "normalized_id": "ETH/CAD",
+    "base": "ETH",
+    "quote": "CAD",
+    "display_name": "Ethereum / Canadian Dollar",
+    "description": "Ethereum to Canadian Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "cad",
+      "fiat",
+      "canadian dollar"
+    ],
+    "category": "crypto"
+  },
+  "ETH_CHF": {
+    "normalized_id": "ETH/CHF",
+    "base": "ETH",
+    "quote": "CHF",
+    "display_name": "Ethereum / Swiss Franc",
+    "description": "Ethereum to Swiss Franc spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "chf"
+    ],
+    "category": "crypto"
+  },
+  "ETH_DAI": {
+    "normalized_id": "ETH/DAI",
+    "base": "ETH",
+    "quote": "DAI",
+    "display_name": "Ethereum / Dai",
+    "description": "Ethereum to Dai spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "dai"
+    ],
+    "category": "crypto"
+  },
+  "ETH_EUR": {
+    "normalized_id": "ETH/EUR",
+    "base": "ETH",
+    "quote": "EUR",
+    "display_name": "Ethereum / Euro",
+    "description": "Ethereum to Euro spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ETH_GBP": {
+    "normalized_id": "ETH/GBP",
+    "base": "ETH",
+    "quote": "GBP",
+    "display_name": "Ethereum / British Pound",
+    "description": "Ethereum to British Pound spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "ETH_JPY": {
+    "normalized_id": "ETH/JPY",
+    "base": "ETH",
+    "quote": "JPY",
+    "display_name": "Ethereum / Japanese Yen",
+    "description": "Ethereum to Japanese Yen spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "ETH_PYUSD": {
+    "normalized_id": "ETH/PYUSD",
+    "base": "ETH",
+    "quote": "PYUSD",
+    "display_name": "Ethereum / PYUSD",
+    "description": "Ethereum to PYUSD spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "pyusd"
+    ],
+    "category": "crypto"
+  },
+  "ETH_USD": {
+    "normalized_id": "ETH/USD",
+    "base": "ETH",
+    "quote": "USD",
+    "display_name": "Ethereum / US Dollar",
+    "description": "Ethereum to US Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETH_USDC": {
+    "normalized_id": "ETH/USD",
+    "base": "ETH",
+    "quote": "USD",
+    "display_name": "Ethereum / US Dollar",
+    "description": "Ethereum to US Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETH_USDT": {
+    "normalized_id": "ETH/USD",
+    "base": "ETH",
+    "quote": "USD",
+    "display_name": "Ethereum / US Dollar",
+    "description": "Ethereum to US Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETH_XBT": {
+    "normalized_id": "ETH/XBT",
+    "base": "ETH",
+    "quote": "XBT",
+    "display_name": "Ethereum / XBT",
+    "description": "Ethereum to XBT spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "EUL_EUR": {
+    "normalized_id": "EUL/EUR",
+    "base": "EUL",
+    "quote": "EUR",
+    "display_name": "EUL / Euro",
+    "description": "EUL to Euro spot trading pair",
+    "tags": [
+      "eul",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "EUL_USD": {
+    "normalized_id": "EUL/USD",
+    "base": "EUL",
+    "quote": "USD",
+    "display_name": "EUL / US Dollar",
+    "description": "EUL to US Dollar spot trading pair",
+    "tags": [
+      "eul",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EUROP_EUR": {
+    "normalized_id": "EUROP/EUR",
+    "base": "EUROP",
+    "quote": "EUR",
+    "display_name": "EUROP / Euro",
+    "description": "EUROP to Euro spot trading pair",
+    "tags": [
+      "europ",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "EUROP_USD": {
+    "normalized_id": "EUROP/USD",
+    "base": "EUROP",
+    "quote": "USD",
+    "display_name": "EUROP / US Dollar",
+    "description": "EUROP to US Dollar spot trading pair",
+    "tags": [
+      "europ",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EUROP_USDC": {
+    "normalized_id": "EUROP/USD",
+    "base": "EUROP",
+    "quote": "USD",
+    "display_name": "EUROP / US Dollar",
+    "description": "EUROP to US Dollar spot trading pair",
+    "tags": [
+      "europ",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EURQ_EUR": {
+    "normalized_id": "EURQ/EUR",
+    "base": "EURQ",
+    "quote": "EUR",
+    "display_name": "EURQ / Euro",
+    "description": "EURQ to Euro spot trading pair",
+    "tags": [
+      "eurq",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "EURQ_USD": {
+    "normalized_id": "EURQ/USD",
+    "base": "EURQ",
+    "quote": "USD",
+    "display_name": "EURQ / US Dollar",
+    "description": "EURQ to US Dollar spot trading pair",
+    "tags": [
+      "eurq",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EURR_EUR": {
+    "normalized_id": "EURR/EUR",
+    "base": "EURR",
+    "quote": "EUR",
+    "display_name": "EURR / Euro",
+    "description": "EURR to Euro spot trading pair",
+    "tags": [
+      "eurr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "EURR_USD": {
+    "normalized_id": "EURR/USD",
+    "base": "EURR",
+    "quote": "USD",
+    "display_name": "EURR / US Dollar",
+    "description": "EURR to US Dollar spot trading pair",
+    "tags": [
+      "eurr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EURR_USDC": {
+    "normalized_id": "EURR/USD",
+    "base": "EURR",
+    "quote": "USD",
+    "display_name": "EURR / US Dollar",
+    "description": "EURR to US Dollar spot trading pair",
+    "tags": [
+      "eurr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EURR_USDT": {
+    "normalized_id": "EURR/USD",
+    "base": "EURR",
+    "quote": "USD",
+    "display_name": "EURR / US Dollar",
+    "description": "EURR to US Dollar spot trading pair",
+    "tags": [
+      "eurr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EUR_AUD": {
+    "normalized_id": "EUR/AUD",
+    "base": "EUR",
+    "quote": "AUD",
+    "display_name": "Euro / Australian Dollar",
+    "description": "Euro to Australian Dollar  trading pair",
+    "tags": [
+      "eur",
+      "euro",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "forex"
+  },
+  "EUR_CAD": {
+    "normalized_id": "EUR/CAD",
+    "base": "EUR",
+    "quote": "CAD",
+    "display_name": "Euro / Canadian Dollar",
+    "description": "Euro to Canadian Dollar  trading pair",
+    "tags": [
+      "eur",
+      "euro",
+      "cad",
+      "fiat",
+      "canadian dollar"
+    ],
+    "category": "forex"
+  },
+  "EUR_CHF": {
+    "normalized_id": "EUR/CHF",
+    "base": "EUR",
+    "quote": "CHF",
+    "display_name": "Euro / Swiss Franc",
+    "description": "Euro to Swiss Franc  trading pair",
+    "tags": [
+      "eur",
+      "euro",
+      "chf"
+    ],
+    "category": "forex"
+  },
+  "EUR_GBP": {
+    "normalized_id": "EUR/GBP",
+    "base": "EUR",
+    "quote": "GBP",
+    "display_name": "Euro / British Pound",
+    "description": "Euro to British Pound  trading pair",
+    "tags": [
+      "eur",
+      "euro",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "forex"
+  },
+  "EUR_JPY": {
+    "normalized_id": "EUR/JPY",
+    "base": "EUR",
+    "quote": "JPY",
+    "display_name": "Euro / Japanese Yen",
+    "description": "Euro to Japanese Yen  trading pair",
+    "tags": [
+      "eur",
+      "euro",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "forex"
+  },
+  "EUR_USD": {
+    "normalized_id": "EUR/USD",
+    "base": "EUR",
+    "quote": "USD",
+    "display_name": "Euro / US Dollar",
+    "description": "Euro to US Dollar  trading pair",
+    "tags": [
+      "eur",
+      "euro",
+      "usd"
+    ],
+    "category": "forex"
+  },
+  "EWT_EUR": {
+    "normalized_id": "EWT/EUR",
+    "base": "EWT",
+    "quote": "EUR",
+    "display_name": "EWT / Euro",
+    "description": "EWT to Euro spot trading pair",
+    "tags": [
+      "ewt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "EWT_USD": {
+    "normalized_id": "EWT/USD",
+    "base": "EWT",
+    "quote": "USD",
+    "display_name": "EWT / US Dollar",
+    "description": "EWT to US Dollar spot trading pair",
+    "tags": [
+      "ewt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FARM_EUR": {
+    "normalized_id": "FARM/EUR",
+    "base": "FARM",
+    "quote": "EUR",
+    "display_name": "FARM / Euro",
+    "description": "FARM to Euro spot trading pair",
+    "tags": [
+      "farm",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FARM_USD": {
+    "normalized_id": "FARM/USD",
+    "base": "FARM",
+    "quote": "USD",
+    "display_name": "FARM / US Dollar",
+    "description": "FARM to US Dollar spot trading pair",
+    "tags": [
+      "farm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FARTCOIN_EUR": {
+    "normalized_id": "FARTCOIN/EUR",
+    "base": "FARTCOIN",
+    "quote": "EUR",
+    "display_name": "FARTCOIN / Euro",
+    "description": "FARTCOIN to Euro spot trading pair",
+    "tags": [
+      "fartcoin",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FARTCOIN_USD": {
+    "normalized_id": "FARTCOIN/USD",
+    "base": "FARTCOIN",
+    "quote": "USD",
+    "display_name": "FARTCOIN / US Dollar",
+    "description": "FARTCOIN to US Dollar spot trading pair",
+    "tags": [
+      "fartcoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FARTCOIN_USDC": {
+    "normalized_id": "FARTCOIN/USD",
+    "base": "FARTCOIN",
+    "quote": "USD",
+    "display_name": "FARTCOIN / US Dollar",
+    "description": "FARTCOIN to US Dollar spot trading pair",
+    "tags": [
+      "fartcoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FARTCOIN_USDT": {
+    "normalized_id": "FARTCOIN/USD",
+    "base": "FARTCOIN",
+    "quote": "USD",
+    "display_name": "FARTCOIN / US Dollar",
+    "description": "FARTCOIN to US Dollar spot trading pair",
+    "tags": [
+      "fartcoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FET_EUR": {
+    "normalized_id": "FET/EUR",
+    "base": "FET",
+    "quote": "EUR",
+    "display_name": "FET / Euro",
+    "description": "FET to Euro spot trading pair",
+    "tags": [
+      "fet",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FET_USD": {
+    "normalized_id": "FET/USD",
+    "base": "FET",
+    "quote": "USD",
+    "display_name": "FET / US Dollar",
+    "description": "FET to US Dollar spot trading pair",
+    "tags": [
+      "fet",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FHE_EUR": {
+    "normalized_id": "FHE/EUR",
+    "base": "FHE",
+    "quote": "EUR",
+    "display_name": "FHE / Euro",
+    "description": "FHE to Euro spot trading pair",
+    "tags": [
+      "fhe",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FHE_USD": {
+    "normalized_id": "FHE/USD",
+    "base": "FHE",
+    "quote": "USD",
+    "display_name": "FHE / US Dollar",
+    "description": "FHE to US Dollar spot trading pair",
+    "tags": [
+      "fhe",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FIDA_EUR": {
+    "normalized_id": "FIDA/EUR",
+    "base": "FIDA",
+    "quote": "EUR",
+    "display_name": "FIDA / Euro",
+    "description": "FIDA to Euro spot trading pair",
+    "tags": [
+      "fida",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FIDA_USD": {
+    "normalized_id": "FIDA/USD",
+    "base": "FIDA",
+    "quote": "USD",
+    "display_name": "FIDA / US Dollar",
+    "description": "FIDA to US Dollar spot trading pair",
+    "tags": [
+      "fida",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FIL_ETH": {
+    "normalized_id": "FIL/ETH",
+    "base": "FIL",
+    "quote": "ETH",
+    "display_name": "Filecoin / Ethereum",
+    "description": "Filecoin to Ethereum spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "FIL_EUR": {
+    "normalized_id": "FIL/EUR",
+    "base": "FIL",
+    "quote": "EUR",
+    "display_name": "Filecoin / Euro",
+    "description": "Filecoin to Euro spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FIL_GBP": {
+    "normalized_id": "FIL/GBP",
+    "base": "FIL",
+    "quote": "GBP",
+    "display_name": "Filecoin / British Pound",
+    "description": "Filecoin to British Pound spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "FIL_USD": {
+    "normalized_id": "FIL/USD",
+    "base": "FIL",
+    "quote": "USD",
+    "display_name": "Filecoin / US Dollar",
+    "description": "Filecoin to US Dollar spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FIL_XBT": {
+    "normalized_id": "FIL/XBT",
+    "base": "FIL",
+    "quote": "XBT",
+    "display_name": "Filecoin / XBT",
+    "description": "Filecoin to XBT spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "FIS_EUR": {
+    "normalized_id": "FIS/EUR",
+    "base": "FIS",
+    "quote": "EUR",
+    "display_name": "FIS / Euro",
+    "description": "FIS to Euro spot trading pair",
+    "tags": [
+      "fis",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FIS_USD": {
+    "normalized_id": "FIS/USD",
+    "base": "FIS",
+    "quote": "USD",
+    "display_name": "FIS / US Dollar",
+    "description": "FIS to US Dollar spot trading pair",
+    "tags": [
+      "fis",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLOKI_EUR": {
+    "normalized_id": "FLOKI/EUR",
+    "base": "FLOKI",
+    "quote": "EUR",
+    "display_name": "Floki / Euro",
+    "description": "Floki to Euro spot trading pair",
+    "tags": [
+      "floki",
+      "meme",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FLOKI_USD": {
+    "normalized_id": "FLOKI/USD",
+    "base": "FLOKI",
+    "quote": "USD",
+    "display_name": "Floki / US Dollar",
+    "description": "Floki to US Dollar spot trading pair",
+    "tags": [
+      "floki",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLOW_EUR": {
+    "normalized_id": "FLOW/EUR",
+    "base": "FLOW",
+    "quote": "EUR",
+    "display_name": "Flow / Euro",
+    "description": "Flow to Euro spot trading pair",
+    "tags": [
+      "flow",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FLOW_USD": {
+    "normalized_id": "FLOW/USD",
+    "base": "FLOW",
+    "quote": "USD",
+    "display_name": "Flow / US Dollar",
+    "description": "Flow to US Dollar spot trading pair",
+    "tags": [
+      "flow",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLR_EUR": {
+    "normalized_id": "FLR/EUR",
+    "base": "FLR",
+    "quote": "EUR",
+    "display_name": "FLR / Euro",
+    "description": "FLR to Euro spot trading pair",
+    "tags": [
+      "flr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FLR_USD": {
+    "normalized_id": "FLR/USD",
+    "base": "FLR",
+    "quote": "USD",
+    "display_name": "FLR / US Dollar",
+    "description": "FLR to US Dollar spot trading pair",
+    "tags": [
+      "flr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLUX_EUR": {
+    "normalized_id": "FLUX/EUR",
+    "base": "FLUX",
+    "quote": "EUR",
+    "display_name": "FLUX / Euro",
+    "description": "FLUX to Euro spot trading pair",
+    "tags": [
+      "flux",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FLUX_USD": {
+    "normalized_id": "FLUX/USD",
+    "base": "FLUX",
+    "quote": "USD",
+    "display_name": "FLUX / US Dollar",
+    "description": "FLUX to US Dollar spot trading pair",
+    "tags": [
+      "flux",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLY_EUR": {
+    "normalized_id": "FLY/EUR",
+    "base": "FLY",
+    "quote": "EUR",
+    "display_name": "FLY / Euro",
+    "description": "FLY to Euro spot trading pair",
+    "tags": [
+      "fly",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FLY_USD": {
+    "normalized_id": "FLY/USD",
+    "base": "FLY",
+    "quote": "USD",
+    "display_name": "FLY / US Dollar",
+    "description": "FLY to US Dollar spot trading pair",
+    "tags": [
+      "fly",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FORTH_EUR": {
+    "normalized_id": "FORTH/EUR",
+    "base": "FORTH",
+    "quote": "EUR",
+    "display_name": "FORTH / Euro",
+    "description": "FORTH to Euro spot trading pair",
+    "tags": [
+      "forth",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FORTH_USD": {
+    "normalized_id": "FORTH/USD",
+    "base": "FORTH",
+    "quote": "USD",
+    "display_name": "FORTH / US Dollar",
+    "description": "FORTH to US Dollar spot trading pair",
+    "tags": [
+      "forth",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FWOG_EUR": {
+    "normalized_id": "FWOG/EUR",
+    "base": "FWOG",
+    "quote": "EUR",
+    "display_name": "FWOG / Euro",
+    "description": "FWOG to Euro spot trading pair",
+    "tags": [
+      "fwog",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FWOG_USD": {
+    "normalized_id": "FWOG/USD",
+    "base": "FWOG",
+    "quote": "USD",
+    "display_name": "FWOG / US Dollar",
+    "description": "FWOG to US Dollar spot trading pair",
+    "tags": [
+      "fwog",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FXS_EUR": {
+    "normalized_id": "FXS/EUR",
+    "base": "FXS",
+    "quote": "EUR",
+    "display_name": "FXS / Euro",
+    "description": "FXS to Euro spot trading pair",
+    "tags": [
+      "fxs",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FXS_USD": {
+    "normalized_id": "FXS/USD",
+    "base": "FXS",
+    "quote": "USD",
+    "display_name": "FXS / US Dollar",
+    "description": "FXS to US Dollar spot trading pair",
+    "tags": [
+      "fxs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GAIA_EUR": {
+    "normalized_id": "GAIA/EUR",
+    "base": "GAIA",
+    "quote": "EUR",
+    "display_name": "GAIA / Euro",
+    "description": "GAIA to Euro spot trading pair",
+    "tags": [
+      "gaia",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GAIA_USD": {
+    "normalized_id": "GAIA/USD",
+    "base": "GAIA",
+    "quote": "USD",
+    "display_name": "GAIA / US Dollar",
+    "description": "GAIA to US Dollar spot trading pair",
+    "tags": [
+      "gaia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GALA_EUR": {
+    "normalized_id": "GALA/EUR",
+    "base": "GALA",
+    "quote": "EUR",
+    "display_name": "Gala / Euro",
+    "description": "Gala to Euro spot trading pair",
+    "tags": [
+      "gala",
+      "gaming",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GALA_USD": {
+    "normalized_id": "GALA/USD",
+    "base": "GALA",
+    "quote": "USD",
+    "display_name": "Gala / US Dollar",
+    "description": "Gala to US Dollar spot trading pair",
+    "tags": [
+      "gala",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GAL_EUR": {
+    "normalized_id": "GAL/EUR",
+    "base": "GAL",
+    "quote": "EUR",
+    "display_name": "GAL / Euro",
+    "description": "GAL to Euro spot trading pair",
+    "tags": [
+      "gal",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GAL_USD": {
+    "normalized_id": "GAL/USD",
+    "base": "GAL",
+    "quote": "USD",
+    "display_name": "GAL / US Dollar",
+    "description": "GAL to US Dollar spot trading pair",
+    "tags": [
+      "gal",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GARI_EUR": {
+    "normalized_id": "GARI/EUR",
+    "base": "GARI",
+    "quote": "EUR",
+    "display_name": "GARI / Euro",
+    "description": "GARI to Euro spot trading pair",
+    "tags": [
+      "gari",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GARI_USD": {
+    "normalized_id": "GARI/USD",
+    "base": "GARI",
+    "quote": "USD",
+    "display_name": "GARI / US Dollar",
+    "description": "GARI to US Dollar spot trading pair",
+    "tags": [
+      "gari",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GBP_USD": {
+    "normalized_id": "GBP/USD",
+    "base": "GBP",
+    "quote": "USD",
+    "display_name": "British Pound / US Dollar",
+    "description": "British Pound to US Dollar  trading pair",
+    "tags": [
+      "gbp",
+      "british pound",
+      "usd"
+    ],
+    "category": "forex"
+  },
+  "GFI_EUR": {
+    "normalized_id": "GFI/EUR",
+    "base": "GFI",
+    "quote": "EUR",
+    "display_name": "GFI / Euro",
+    "description": "GFI to Euro spot trading pair",
+    "tags": [
+      "gfi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GFI_USD": {
+    "normalized_id": "GFI/USD",
+    "base": "GFI",
+    "quote": "USD",
+    "display_name": "GFI / US Dollar",
+    "description": "GFI to US Dollar spot trading pair",
+    "tags": [
+      "gfi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GHIBLI_EUR": {
+    "normalized_id": "GHIBLI/EUR",
+    "base": "GHIBLI",
+    "quote": "EUR",
+    "display_name": "GHIBLI / Euro",
+    "description": "GHIBLI to Euro spot trading pair",
+    "tags": [
+      "ghibli",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GHIBLI_USD": {
+    "normalized_id": "GHIBLI/USD",
+    "base": "GHIBLI",
+    "quote": "USD",
+    "display_name": "GHIBLI / US Dollar",
+    "description": "GHIBLI to US Dollar spot trading pair",
+    "tags": [
+      "ghibli",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GHST_EUR": {
+    "normalized_id": "GHST/EUR",
+    "base": "GHST",
+    "quote": "EUR",
+    "display_name": "GHST / Euro",
+    "description": "GHST to Euro spot trading pair",
+    "tags": [
+      "ghst",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GHST_USD": {
+    "normalized_id": "GHST/USD",
+    "base": "GHST",
+    "quote": "USD",
+    "display_name": "GHST / US Dollar",
+    "description": "GHST to US Dollar spot trading pair",
+    "tags": [
+      "ghst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GIGA_EUR": {
+    "normalized_id": "GIGA/EUR",
+    "base": "GIGA",
+    "quote": "EUR",
+    "display_name": "GIGA / Euro",
+    "description": "GIGA to Euro spot trading pair",
+    "tags": [
+      "giga",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GIGA_USD": {
+    "normalized_id": "GIGA/USD",
+    "base": "GIGA",
+    "quote": "USD",
+    "display_name": "GIGA / US Dollar",
+    "description": "GIGA to US Dollar spot trading pair",
+    "tags": [
+      "giga",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GLMR_EUR": {
+    "normalized_id": "GLMR/EUR",
+    "base": "GLMR",
+    "quote": "EUR",
+    "display_name": "GLMR / Euro",
+    "description": "GLMR to Euro spot trading pair",
+    "tags": [
+      "glmr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GLMR_USD": {
+    "normalized_id": "GLMR/USD",
+    "base": "GLMR",
+    "quote": "USD",
+    "display_name": "GLMR / US Dollar",
+    "description": "GLMR to US Dollar spot trading pair",
+    "tags": [
+      "glmr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GMT_EUR": {
+    "normalized_id": "GMT/EUR",
+    "base": "GMT",
+    "quote": "EUR",
+    "display_name": "GMT / Euro",
+    "description": "GMT to Euro spot trading pair",
+    "tags": [
+      "gmt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GMT_USD": {
+    "normalized_id": "GMT/USD",
+    "base": "GMT",
+    "quote": "USD",
+    "display_name": "GMT / US Dollar",
+    "description": "GMT to US Dollar spot trading pair",
+    "tags": [
+      "gmt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GMX_EUR": {
+    "normalized_id": "GMX/EUR",
+    "base": "GMX",
+    "quote": "EUR",
+    "display_name": "GMX / Euro",
+    "description": "GMX to Euro spot trading pair",
+    "tags": [
+      "gmx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GMX_USD": {
+    "normalized_id": "GMX/USD",
+    "base": "GMX",
+    "quote": "USD",
+    "display_name": "GMX / US Dollar",
+    "description": "GMX to US Dollar spot trading pair",
+    "tags": [
+      "gmx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GNO_EUR": {
+    "normalized_id": "GNO/EUR",
+    "base": "GNO",
+    "quote": "EUR",
+    "display_name": "GNO / Euro",
+    "description": "GNO to Euro spot trading pair",
+    "tags": [
+      "gno",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GNO_USD": {
+    "normalized_id": "GNO/USD",
+    "base": "GNO",
+    "quote": "USD",
+    "display_name": "GNO / US Dollar",
+    "description": "GNO to US Dollar spot trading pair",
+    "tags": [
+      "gno",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GOAT_EUR": {
+    "normalized_id": "GOAT/EUR",
+    "base": "GOAT",
+    "quote": "EUR",
+    "display_name": "GOAT / Euro",
+    "description": "GOAT to Euro spot trading pair",
+    "tags": [
+      "goat",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GOAT_USD": {
+    "normalized_id": "GOAT/USD",
+    "base": "GOAT",
+    "quote": "USD",
+    "display_name": "GOAT / US Dollar",
+    "description": "GOAT to US Dollar spot trading pair",
+    "tags": [
+      "goat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GOMINING_EUR": {
+    "normalized_id": "GOMINING/EUR",
+    "base": "GOMINING",
+    "quote": "EUR",
+    "display_name": "GOMINING / Euro",
+    "description": "GOMINING to Euro spot trading pair",
+    "tags": [
+      "gomining",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GOMINING_USD": {
+    "normalized_id": "GOMINING/USD",
+    "base": "GOMINING",
+    "quote": "USD",
+    "display_name": "GOMINING / US Dollar",
+    "description": "GOMINING to US Dollar spot trading pair",
+    "tags": [
+      "gomining",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GRASS_EUR": {
+    "normalized_id": "GRASS/EUR",
+    "base": "GRASS",
+    "quote": "EUR",
+    "display_name": "GRASS / Euro",
+    "description": "GRASS to Euro spot trading pair",
+    "tags": [
+      "grass",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GRASS_USD": {
+    "normalized_id": "GRASS/USD",
+    "base": "GRASS",
+    "quote": "USD",
+    "display_name": "GRASS / US Dollar",
+    "description": "GRASS to US Dollar spot trading pair",
+    "tags": [
+      "grass",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GRIFFAIN_EUR": {
+    "normalized_id": "GRIFFAIN/EUR",
+    "base": "GRIFFAIN",
+    "quote": "EUR",
+    "display_name": "GRIFFAIN / Euro",
+    "description": "GRIFFAIN to Euro spot trading pair",
+    "tags": [
+      "griffain",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GRIFFAIN_USD": {
+    "normalized_id": "GRIFFAIN/USD",
+    "base": "GRIFFAIN",
+    "quote": "USD",
+    "display_name": "GRIFFAIN / US Dollar",
+    "description": "GRIFFAIN to US Dollar spot trading pair",
+    "tags": [
+      "griffain",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GRT_EUR": {
+    "normalized_id": "GRT/EUR",
+    "base": "GRT",
+    "quote": "EUR",
+    "display_name": "GRT / Euro",
+    "description": "GRT to Euro spot trading pair",
+    "tags": [
+      "grt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GRT_GBP": {
+    "normalized_id": "GRT/GBP",
+    "base": "GRT",
+    "quote": "GBP",
+    "display_name": "GRT / British Pound",
+    "description": "GRT to British Pound spot trading pair",
+    "tags": [
+      "grt",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "GRT_USD": {
+    "normalized_id": "GRT/USD",
+    "base": "GRT",
+    "quote": "USD",
+    "display_name": "GRT / US Dollar",
+    "description": "GRT to US Dollar spot trading pair",
+    "tags": [
+      "grt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GRT_XBT": {
+    "normalized_id": "GRT/XBT",
+    "base": "GRT",
+    "quote": "XBT",
+    "display_name": "GRT / XBT",
+    "description": "GRT to XBT spot trading pair",
+    "tags": [
+      "grt",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "GST_EUR": {
+    "normalized_id": "GST/EUR",
+    "base": "GST",
+    "quote": "EUR",
+    "display_name": "GST / Euro",
+    "description": "GST to Euro spot trading pair",
+    "tags": [
+      "gst",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GST_USD": {
+    "normalized_id": "GST/USD",
+    "base": "GST",
+    "quote": "USD",
+    "display_name": "GST / US Dollar",
+    "description": "GST to US Dollar spot trading pair",
+    "tags": [
+      "gst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GTC_EUR": {
+    "normalized_id": "GTC/EUR",
+    "base": "GTC",
+    "quote": "EUR",
+    "display_name": "GTC / Euro",
+    "description": "GTC to Euro spot trading pair",
+    "tags": [
+      "gtc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GTC_USD": {
+    "normalized_id": "GTC/USD",
+    "base": "GTC",
+    "quote": "USD",
+    "display_name": "GTC / US Dollar",
+    "description": "GTC to US Dollar spot trading pair",
+    "tags": [
+      "gtc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GUN_EUR": {
+    "normalized_id": "GUN/EUR",
+    "base": "GUN",
+    "quote": "EUR",
+    "display_name": "GUN / Euro",
+    "description": "GUN to Euro spot trading pair",
+    "tags": [
+      "gun",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GUN_USD": {
+    "normalized_id": "GUN/USD",
+    "base": "GUN",
+    "quote": "USD",
+    "display_name": "GUN / US Dollar",
+    "description": "GUN to US Dollar spot trading pair",
+    "tags": [
+      "gun",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "G_EUR": {
+    "normalized_id": "G/EUR",
+    "base": "G",
+    "quote": "EUR",
+    "display_name": "G / Euro",
+    "description": "G to Euro spot trading pair",
+    "tags": [
+      "g",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "G_USD": {
+    "normalized_id": "G/USD",
+    "base": "G",
+    "quote": "USD",
+    "display_name": "G / US Dollar",
+    "description": "G to US Dollar spot trading pair",
+    "tags": [
+      "g",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HBAR_EUR": {
+    "normalized_id": "HBAR/EUR",
+    "base": "HBAR",
+    "quote": "EUR",
+    "display_name": "Hedera / Euro",
+    "description": "Hedera to Euro spot trading pair",
+    "tags": [
+      "hbar",
+      "hedera",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "HBAR_USD": {
+    "normalized_id": "HBAR/USD",
+    "base": "HBAR",
+    "quote": "USD",
+    "display_name": "Hedera / US Dollar",
+    "description": "Hedera to US Dollar spot trading pair",
+    "tags": [
+      "hbar",
+      "hedera",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HDX_EUR": {
+    "normalized_id": "HDX/EUR",
+    "base": "HDX",
+    "quote": "EUR",
+    "display_name": "HDX / Euro",
+    "description": "HDX to Euro spot trading pair",
+    "tags": [
+      "hdx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "HDX_USD": {
+    "normalized_id": "HDX/USD",
+    "base": "HDX",
+    "quote": "USD",
+    "display_name": "HDX / US Dollar",
+    "description": "HDX to US Dollar spot trading pair",
+    "tags": [
+      "hdx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HFT_EUR": {
+    "normalized_id": "HFT/EUR",
+    "base": "HFT",
+    "quote": "EUR",
+    "display_name": "HFT / Euro",
+    "description": "HFT to Euro spot trading pair",
+    "tags": [
+      "hft",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "HFT_USD": {
+    "normalized_id": "HFT/USD",
+    "base": "HFT",
+    "quote": "USD",
+    "display_name": "HFT / US Dollar",
+    "description": "HFT to US Dollar spot trading pair",
+    "tags": [
+      "hft",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HIPPO_EUR": {
+    "normalized_id": "HIPPO/EUR",
+    "base": "HIPPO",
+    "quote": "EUR",
+    "display_name": "HIPPO / Euro",
+    "description": "HIPPO to Euro spot trading pair",
+    "tags": [
+      "hippo",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "HIPPO_USD": {
+    "normalized_id": "HIPPO/USD",
+    "base": "HIPPO",
+    "quote": "USD",
+    "display_name": "HIPPO / US Dollar",
+    "description": "HIPPO to US Dollar spot trading pair",
+    "tags": [
+      "hippo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HMSTR_EUR": {
+    "normalized_id": "HMSTR/EUR",
+    "base": "HMSTR",
+    "quote": "EUR",
+    "display_name": "HMSTR / Euro",
+    "description": "HMSTR to Euro spot trading pair",
+    "tags": [
+      "hmstr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "HMSTR_USD": {
+    "normalized_id": "HMSTR/USD",
+    "base": "HMSTR",
+    "quote": "USD",
+    "display_name": "HMSTR / US Dollar",
+    "description": "HMSTR to US Dollar spot trading pair",
+    "tags": [
+      "hmstr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HNT_EUR": {
+    "normalized_id": "HNT/EUR",
+    "base": "HNT",
+    "quote": "EUR",
+    "display_name": "HNT / Euro",
+    "description": "HNT to Euro spot trading pair",
+    "tags": [
+      "hnt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "HNT_USD": {
+    "normalized_id": "HNT/USD",
+    "base": "HNT",
+    "quote": "USD",
+    "display_name": "HNT / US Dollar",
+    "description": "HNT to US Dollar spot trading pair",
+    "tags": [
+      "hnt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HONEY_EUR": {
+    "normalized_id": "HONEY/EUR",
+    "base": "HONEY",
+    "quote": "EUR",
+    "display_name": "HONEY / Euro",
+    "description": "HONEY to Euro spot trading pair",
+    "tags": [
+      "honey",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "HONEY_USD": {
+    "normalized_id": "HONEY/USD",
+    "base": "HONEY",
+    "quote": "USD",
+    "display_name": "HONEY / US Dollar",
+    "description": "HONEY to US Dollar spot trading pair",
+    "tags": [
+      "honey",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HOUSE_EUR": {
+    "normalized_id": "HOUSE/EUR",
+    "base": "HOUSE",
+    "quote": "EUR",
+    "display_name": "HOUSE / Euro",
+    "description": "HOUSE to Euro spot trading pair",
+    "tags": [
+      "house",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "HOUSE_USD": {
+    "normalized_id": "HOUSE/USD",
+    "base": "HOUSE",
+    "quote": "USD",
+    "display_name": "HOUSE / US Dollar",
+    "description": "HOUSE to US Dollar spot trading pair",
+    "tags": [
+      "house",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HPOS10I_EUR": {
+    "normalized_id": "HPOS10I/EUR",
+    "base": "HPOS10I",
+    "quote": "EUR",
+    "display_name": "HPOS10I / Euro",
+    "description": "HPOS10I to Euro spot trading pair",
+    "tags": [
+      "hpos10i",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "HPOS10I_USD": {
+    "normalized_id": "HPOS10I/USD",
+    "base": "HPOS10I",
+    "quote": "USD",
+    "display_name": "HPOS10I / US Dollar",
+    "description": "HPOS10I to US Dollar spot trading pair",
+    "tags": [
+      "hpos10i",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICNT_EUR": {
+    "normalized_id": "ICNT/EUR",
+    "base": "ICNT",
+    "quote": "EUR",
+    "display_name": "ICNT / Euro",
+    "description": "ICNT to Euro spot trading pair",
+    "tags": [
+      "icnt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ICNT_USD": {
+    "normalized_id": "ICNT/USD",
+    "base": "ICNT",
+    "quote": "USD",
+    "display_name": "ICNT / US Dollar",
+    "description": "ICNT to US Dollar spot trading pair",
+    "tags": [
+      "icnt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICP_EUR": {
+    "normalized_id": "ICP/EUR",
+    "base": "ICP",
+    "quote": "EUR",
+    "display_name": "Internet Computer / Euro",
+    "description": "Internet Computer to Euro spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ICP_USD": {
+    "normalized_id": "ICP/USD",
+    "base": "ICP",
+    "quote": "USD",
+    "display_name": "Internet Computer / US Dollar",
+    "description": "Internet Computer to US Dollar spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICX_EUR": {
+    "normalized_id": "ICX/EUR",
+    "base": "ICX",
+    "quote": "EUR",
+    "display_name": "ICX / Euro",
+    "description": "ICX to Euro spot trading pair",
+    "tags": [
+      "icx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ICX_USD": {
+    "normalized_id": "ICX/USD",
+    "base": "ICX",
+    "quote": "USD",
+    "display_name": "ICX / US Dollar",
+    "description": "ICX to US Dollar spot trading pair",
+    "tags": [
+      "icx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IDEX_EUR": {
+    "normalized_id": "IDEX/EUR",
+    "base": "IDEX",
+    "quote": "EUR",
+    "display_name": "IDEX / Euro",
+    "description": "IDEX to Euro spot trading pair",
+    "tags": [
+      "idex",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "IDEX_USD": {
+    "normalized_id": "IDEX/USD",
+    "base": "IDEX",
+    "quote": "USD",
+    "display_name": "IDEX / US Dollar",
+    "description": "IDEX to US Dollar spot trading pair",
+    "tags": [
+      "idex",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IMX_EUR": {
+    "normalized_id": "IMX/EUR",
+    "base": "IMX",
+    "quote": "EUR",
+    "display_name": "IMX / Euro",
+    "description": "IMX to Euro spot trading pair",
+    "tags": [
+      "imx",
+      "layer2",
+      "gaming",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "IMX_USD": {
+    "normalized_id": "IMX/USD",
+    "base": "IMX",
+    "quote": "USD",
+    "display_name": "IMX / US Dollar",
+    "description": "IMX to US Dollar spot trading pair",
+    "tags": [
+      "imx",
+      "layer2",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "INIT_EUR": {
+    "normalized_id": "INIT/EUR",
+    "base": "INIT",
+    "quote": "EUR",
+    "display_name": "INIT / Euro",
+    "description": "INIT to Euro spot trading pair",
+    "tags": [
+      "init",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "INIT_USD": {
+    "normalized_id": "INIT/USD",
+    "base": "INIT",
+    "quote": "USD",
+    "display_name": "INIT / US Dollar",
+    "description": "INIT to US Dollar spot trading pair",
+    "tags": [
+      "init",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "INJ_EUR": {
+    "normalized_id": "INJ/EUR",
+    "base": "INJ",
+    "quote": "EUR",
+    "display_name": "Injective / Euro",
+    "description": "Injective to Euro spot trading pair",
+    "tags": [
+      "inj",
+      "injective",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "INJ_USD": {
+    "normalized_id": "INJ/USD",
+    "base": "INJ",
+    "quote": "USD",
+    "display_name": "Injective / US Dollar",
+    "description": "Injective to US Dollar spot trading pair",
+    "tags": [
+      "inj",
+      "injective",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "INTR_EUR": {
+    "normalized_id": "INTR/EUR",
+    "base": "INTR",
+    "quote": "EUR",
+    "display_name": "INTR / Euro",
+    "description": "INTR to Euro spot trading pair",
+    "tags": [
+      "intr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "INTR_USD": {
+    "normalized_id": "INTR/USD",
+    "base": "INTR",
+    "quote": "USD",
+    "display_name": "INTR / US Dollar",
+    "description": "INTR to US Dollar spot trading pair",
+    "tags": [
+      "intr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IP_EUR": {
+    "normalized_id": "IP/EUR",
+    "base": "IP",
+    "quote": "EUR",
+    "display_name": "IP / Euro",
+    "description": "IP to Euro spot trading pair",
+    "tags": [
+      "ip",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "IP_USD": {
+    "normalized_id": "IP/USD",
+    "base": "IP",
+    "quote": "USD",
+    "display_name": "IP / US Dollar",
+    "description": "IP to US Dollar spot trading pair",
+    "tags": [
+      "ip",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JAILSTOOL_EUR": {
+    "normalized_id": "JAILSTOOL/EUR",
+    "base": "JAILSTOOL",
+    "quote": "EUR",
+    "display_name": "JAILSTOOL / Euro",
+    "description": "JAILSTOOL to Euro spot trading pair",
+    "tags": [
+      "jailstool",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "JAILSTOOL_USD": {
+    "normalized_id": "JAILSTOOL/USD",
+    "base": "JAILSTOOL",
+    "quote": "USD",
+    "display_name": "JAILSTOOL / US Dollar",
+    "description": "JAILSTOOL to US Dollar spot trading pair",
+    "tags": [
+      "jailstool",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JASMY_EUR": {
+    "normalized_id": "JASMY/EUR",
+    "base": "JASMY",
+    "quote": "EUR",
+    "display_name": "JASMY / Euro",
+    "description": "JASMY to Euro spot trading pair",
+    "tags": [
+      "jasmy",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "JASMY_USD": {
+    "normalized_id": "JASMY/USD",
+    "base": "JASMY",
+    "quote": "USD",
+    "display_name": "JASMY / US Dollar",
+    "description": "JASMY to US Dollar spot trading pair",
+    "tags": [
+      "jasmy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JITOSOL_EUR": {
+    "normalized_id": "JITOSOL/EUR",
+    "base": "JITOSOL",
+    "quote": "EUR",
+    "display_name": "JITOSOL / Euro",
+    "description": "JITOSOL to Euro spot trading pair",
+    "tags": [
+      "jitosol",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "JITOSOL_SOL": {
+    "normalized_id": "JITOSOL/SOL",
+    "base": "JITOSOL",
+    "quote": "SOL",
+    "display_name": "JITOSOL / Solana",
+    "description": "JITOSOL to Solana spot trading pair",
+    "tags": [
+      "jitosol",
+      "sol"
+    ],
+    "category": "crypto"
+  },
+  "JITOSOL_USD": {
+    "normalized_id": "JITOSOL/USD",
+    "base": "JITOSOL",
+    "quote": "USD",
+    "display_name": "JITOSOL / US Dollar",
+    "description": "JITOSOL to US Dollar spot trading pair",
+    "tags": [
+      "jitosol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JOE_EUR": {
+    "normalized_id": "JOE/EUR",
+    "base": "JOE",
+    "quote": "EUR",
+    "display_name": "JOE / Euro",
+    "description": "JOE to Euro spot trading pair",
+    "tags": [
+      "joe",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "JOE_USD": {
+    "normalized_id": "JOE/USD",
+    "base": "JOE",
+    "quote": "USD",
+    "display_name": "JOE / US Dollar",
+    "description": "JOE to US Dollar spot trading pair",
+    "tags": [
+      "joe",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JST_EUR": {
+    "normalized_id": "JST/EUR",
+    "base": "JST",
+    "quote": "EUR",
+    "display_name": "JST / Euro",
+    "description": "JST to Euro spot trading pair",
+    "tags": [
+      "jst",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "JST_USD": {
+    "normalized_id": "JST/USD",
+    "base": "JST",
+    "quote": "USD",
+    "display_name": "JST / US Dollar",
+    "description": "JST to US Dollar spot trading pair",
+    "tags": [
+      "jst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JTO_EUR": {
+    "normalized_id": "JTO/EUR",
+    "base": "JTO",
+    "quote": "EUR",
+    "display_name": "JTO / Euro",
+    "description": "JTO to Euro spot trading pair",
+    "tags": [
+      "jto",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "JTO_USD": {
+    "normalized_id": "JTO/USD",
+    "base": "JTO",
+    "quote": "USD",
+    "display_name": "JTO / US Dollar",
+    "description": "JTO to US Dollar spot trading pair",
+    "tags": [
+      "jto",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JUNO_EUR": {
+    "normalized_id": "JUNO/EUR",
+    "base": "JUNO",
+    "quote": "EUR",
+    "display_name": "JUNO / Euro",
+    "description": "JUNO to Euro spot trading pair",
+    "tags": [
+      "juno",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "JUNO_USD": {
+    "normalized_id": "JUNO/USD",
+    "base": "JUNO",
+    "quote": "USD",
+    "display_name": "JUNO / US Dollar",
+    "description": "JUNO to US Dollar spot trading pair",
+    "tags": [
+      "juno",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JUP_EUR": {
+    "normalized_id": "JUP/EUR",
+    "base": "JUP",
+    "quote": "EUR",
+    "display_name": "Jupiter / Euro",
+    "description": "Jupiter to Euro spot trading pair",
+    "tags": [
+      "jup",
+      "jupiter",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "JUP_USD": {
+    "normalized_id": "JUP/USD",
+    "base": "JUP",
+    "quote": "USD",
+    "display_name": "Jupiter / US Dollar",
+    "description": "Jupiter to US Dollar spot trading pair",
+    "tags": [
+      "jup",
+      "jupiter",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAITO_EUR": {
+    "normalized_id": "KAITO/EUR",
+    "base": "KAITO",
+    "quote": "EUR",
+    "display_name": "KAITO / Euro",
+    "description": "KAITO to Euro spot trading pair",
+    "tags": [
+      "kaito",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "KAITO_USD": {
+    "normalized_id": "KAITO/USD",
+    "base": "KAITO",
+    "quote": "USD",
+    "display_name": "KAITO / US Dollar",
+    "description": "KAITO to US Dollar spot trading pair",
+    "tags": [
+      "kaito",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAR_EUR": {
+    "normalized_id": "KAR/EUR",
+    "base": "KAR",
+    "quote": "EUR",
+    "display_name": "KAR / Euro",
+    "description": "KAR to Euro spot trading pair",
+    "tags": [
+      "kar",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "KAR_USD": {
+    "normalized_id": "KAR/USD",
+    "base": "KAR",
+    "quote": "USD",
+    "display_name": "KAR / US Dollar",
+    "description": "KAR to US Dollar spot trading pair",
+    "tags": [
+      "kar",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAS_EUR": {
+    "normalized_id": "KAS/EUR",
+    "base": "KAS",
+    "quote": "EUR",
+    "display_name": "KAS / Euro",
+    "description": "KAS to Euro spot trading pair",
+    "tags": [
+      "kas",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "KAS_USD": {
+    "normalized_id": "KAS/USD",
+    "base": "KAS",
+    "quote": "USD",
+    "display_name": "KAS / US Dollar",
+    "description": "KAS to US Dollar spot trading pair",
+    "tags": [
+      "kas",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAVA_EUR": {
+    "normalized_id": "KAVA/EUR",
+    "base": "KAVA",
+    "quote": "EUR",
+    "display_name": "KAVA / Euro",
+    "description": "KAVA to Euro spot trading pair",
+    "tags": [
+      "kava",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "KAVA_USD": {
+    "normalized_id": "KAVA/USD",
+    "base": "KAVA",
+    "quote": "USD",
+    "display_name": "KAVA / US Dollar",
+    "description": "KAVA to US Dollar spot trading pair",
+    "tags": [
+      "kava",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KERNEL_EUR": {
+    "normalized_id": "KERNEL/EUR",
+    "base": "KERNEL",
+    "quote": "EUR",
+    "display_name": "KERNEL / Euro",
+    "description": "KERNEL to Euro spot trading pair",
+    "tags": [
+      "kernel",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "KERNEL_USD": {
+    "normalized_id": "KERNEL/USD",
+    "base": "KERNEL",
+    "quote": "USD",
+    "display_name": "KERNEL / US Dollar",
+    "description": "KERNEL to US Dollar spot trading pair",
+    "tags": [
+      "kernel",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KET_EUR": {
+    "normalized_id": "KET/EUR",
+    "base": "KET",
+    "quote": "EUR",
+    "display_name": "KET / Euro",
+    "description": "KET to Euro spot trading pair",
+    "tags": [
+      "ket",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "KET_USD": {
+    "normalized_id": "KET/USD",
+    "base": "KET",
+    "quote": "USD",
+    "display_name": "KET / US Dollar",
+    "description": "KET to US Dollar spot trading pair",
+    "tags": [
+      "ket",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KEY_EUR": {
+    "normalized_id": "KEY/EUR",
+    "base": "KEY",
+    "quote": "EUR",
+    "display_name": "KEY / Euro",
+    "description": "KEY to Euro spot trading pair",
+    "tags": [
+      "key",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "KEY_USD": {
+    "normalized_id": "KEY/USD",
+    "base": "KEY",
+    "quote": "USD",
+    "display_name": "KEY / US Dollar",
+    "description": "KEY to US Dollar spot trading pair",
+    "tags": [
+      "key",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KINT_EUR": {
+    "normalized_id": "KINT/EUR",
+    "base": "KINT",
+    "quote": "EUR",
+    "display_name": "KINT / Euro",
+    "description": "KINT to Euro spot trading pair",
+    "tags": [
+      "kint",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "KINT_USD": {
+    "normalized_id": "KINT/USD",
+    "base": "KINT",
+    "quote": "USD",
+    "display_name": "KINT / US Dollar",
+    "description": "KINT to US Dollar spot trading pair",
+    "tags": [
+      "kint",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KIN_EUR": {
+    "normalized_id": "KIN/EUR",
+    "base": "KIN",
+    "quote": "EUR",
+    "display_name": "KIN / Euro",
+    "description": "KIN to Euro spot trading pair",
+    "tags": [
+      "kin",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "KIN_USD": {
+    "normalized_id": "KIN/USD",
+    "base": "KIN",
+    "quote": "USD",
+    "display_name": "KIN / US Dollar",
+    "description": "KIN to US Dollar spot trading pair",
+    "tags": [
+      "kin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KMNO_EUR": {
+    "normalized_id": "KMNO/EUR",
+    "base": "KMNO",
+    "quote": "EUR",
+    "display_name": "KMNO / Euro",
+    "description": "KMNO to Euro spot trading pair",
+    "tags": [
+      "kmno",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "KMNO_USD": {
+    "normalized_id": "KMNO/USD",
+    "base": "KMNO",
+    "quote": "USD",
+    "display_name": "KMNO / US Dollar",
+    "description": "KMNO to US Dollar spot trading pair",
+    "tags": [
+      "kmno",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KNC_EUR": {
+    "normalized_id": "KNC/EUR",
+    "base": "KNC",
+    "quote": "EUR",
+    "display_name": "KNC / Euro",
+    "description": "KNC to Euro spot trading pair",
+    "tags": [
+      "knc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "KNC_USD": {
+    "normalized_id": "KNC/USD",
+    "base": "KNC",
+    "quote": "USD",
+    "display_name": "KNC / US Dollar",
+    "description": "KNC to US Dollar spot trading pair",
+    "tags": [
+      "knc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KOBAN_EUR": {
+    "normalized_id": "KOBAN/EUR",
+    "base": "KOBAN",
+    "quote": "EUR",
+    "display_name": "KOBAN / Euro",
+    "description": "KOBAN to Euro spot trading pair",
+    "tags": [
+      "koban",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "KOBAN_USD": {
+    "normalized_id": "KOBAN/USD",
+    "base": "KOBAN",
+    "quote": "USD",
+    "display_name": "KOBAN / US Dollar",
+    "description": "KOBAN to US Dollar spot trading pair",
+    "tags": [
+      "koban",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KP3R_EUR": {
+    "normalized_id": "KP3R/EUR",
+    "base": "KP3R",
+    "quote": "EUR",
+    "display_name": "KP3R / Euro",
+    "description": "KP3R to Euro spot trading pair",
+    "tags": [
+      "kp3r",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "KP3R_USD": {
+    "normalized_id": "KP3R/USD",
+    "base": "KP3R",
+    "quote": "USD",
+    "display_name": "KP3R / US Dollar",
+    "description": "KP3R to US Dollar spot trading pair",
+    "tags": [
+      "kp3r",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KSM_EUR": {
+    "normalized_id": "KSM/EUR",
+    "base": "KSM",
+    "quote": "EUR",
+    "display_name": "KSM / Euro",
+    "description": "KSM to Euro spot trading pair",
+    "tags": [
+      "ksm",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "KSM_GBP": {
+    "normalized_id": "KSM/GBP",
+    "base": "KSM",
+    "quote": "GBP",
+    "display_name": "KSM / British Pound",
+    "description": "KSM to British Pound spot trading pair",
+    "tags": [
+      "ksm",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "KSM_USD": {
+    "normalized_id": "KSM/USD",
+    "base": "KSM",
+    "quote": "USD",
+    "display_name": "KSM / US Dollar",
+    "description": "KSM to US Dollar spot trading pair",
+    "tags": [
+      "ksm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KTA_EUR": {
+    "normalized_id": "KTA/EUR",
+    "base": "KTA",
+    "quote": "EUR",
+    "display_name": "KTA / Euro",
+    "description": "KTA to Euro spot trading pair",
+    "tags": [
+      "kta",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "KTA_USD": {
+    "normalized_id": "KTA/USD",
+    "base": "KTA",
+    "quote": "USD",
+    "display_name": "KTA / US Dollar",
+    "description": "KTA to US Dollar spot trading pair",
+    "tags": [
+      "kta",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "L3_EUR": {
+    "normalized_id": "L3/EUR",
+    "base": "L3",
+    "quote": "EUR",
+    "display_name": "L3 / Euro",
+    "description": "L3 to Euro spot trading pair",
+    "tags": [
+      "l3",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "L3_USD": {
+    "normalized_id": "L3/USD",
+    "base": "L3",
+    "quote": "USD",
+    "display_name": "L3 / US Dollar",
+    "description": "L3 to US Dollar spot trading pair",
+    "tags": [
+      "l3",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LAYER_EUR": {
+    "normalized_id": "LAYER/EUR",
+    "base": "LAYER",
+    "quote": "EUR",
+    "display_name": "LAYER / Euro",
+    "description": "LAYER to Euro spot trading pair",
+    "tags": [
+      "layer",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LAYER_USD": {
+    "normalized_id": "LAYER/USD",
+    "base": "LAYER",
+    "quote": "USD",
+    "display_name": "LAYER / US Dollar",
+    "description": "LAYER to US Dollar spot trading pair",
+    "tags": [
+      "layer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LCX_EUR": {
+    "normalized_id": "LCX/EUR",
+    "base": "LCX",
+    "quote": "EUR",
+    "display_name": "LCX / Euro",
+    "description": "LCX to Euro spot trading pair",
+    "tags": [
+      "lcx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LCX_USD": {
+    "normalized_id": "LCX/USD",
+    "base": "LCX",
+    "quote": "USD",
+    "display_name": "LCX / US Dollar",
+    "description": "LCX to US Dollar spot trading pair",
+    "tags": [
+      "lcx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LDO_EUR": {
+    "normalized_id": "LDO/EUR",
+    "base": "LDO",
+    "quote": "EUR",
+    "display_name": "LDO / Euro",
+    "description": "LDO to Euro spot trading pair",
+    "tags": [
+      "ldo",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LDO_USD": {
+    "normalized_id": "LDO/USD",
+    "base": "LDO",
+    "quote": "USD",
+    "display_name": "LDO / US Dollar",
+    "description": "LDO to US Dollar spot trading pair",
+    "tags": [
+      "ldo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LINK_AUD": {
+    "normalized_id": "LINK/AUD",
+    "base": "LINK",
+    "quote": "AUD",
+    "display_name": "Chainlink / Australian Dollar",
+    "description": "Chainlink to Australian Dollar spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "LINK_ETH": {
+    "normalized_id": "LINK/ETH",
+    "base": "LINK",
+    "quote": "ETH",
+    "display_name": "Chainlink / Ethereum",
+    "description": "Chainlink to Ethereum spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "LINK_EUR": {
+    "normalized_id": "LINK/EUR",
+    "base": "LINK",
+    "quote": "EUR",
+    "display_name": "Chainlink / Euro",
+    "description": "Chainlink to Euro spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LINK_GBP": {
+    "normalized_id": "LINK/GBP",
+    "base": "LINK",
+    "quote": "GBP",
+    "display_name": "Chainlink / British Pound",
+    "description": "Chainlink to British Pound spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "LINK_JPY": {
+    "normalized_id": "LINK/JPY",
+    "base": "LINK",
+    "quote": "JPY",
+    "display_name": "Chainlink / Japanese Yen",
+    "description": "Chainlink to Japanese Yen spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "LINK_USD": {
+    "normalized_id": "LINK/USD",
+    "base": "LINK",
+    "quote": "USD",
+    "display_name": "Chainlink / US Dollar",
+    "description": "Chainlink to US Dollar spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LINK_USDC": {
+    "normalized_id": "LINK/USD",
+    "base": "LINK",
+    "quote": "USD",
+    "display_name": "Chainlink / US Dollar",
+    "description": "Chainlink to US Dollar spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LINK_USDT": {
+    "normalized_id": "LINK/USD",
+    "base": "LINK",
+    "quote": "USD",
+    "display_name": "Chainlink / US Dollar",
+    "description": "Chainlink to US Dollar spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LINK_XBT": {
+    "normalized_id": "LINK/XBT",
+    "base": "LINK",
+    "quote": "XBT",
+    "display_name": "Chainlink / XBT",
+    "description": "Chainlink to XBT spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "LIT_EUR": {
+    "normalized_id": "LIT/EUR",
+    "base": "LIT",
+    "quote": "EUR",
+    "display_name": "LIT / Euro",
+    "description": "LIT to Euro spot trading pair",
+    "tags": [
+      "lit",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LIT_USD": {
+    "normalized_id": "LIT/USD",
+    "base": "LIT",
+    "quote": "USD",
+    "display_name": "LIT / US Dollar",
+    "description": "LIT to US Dollar spot trading pair",
+    "tags": [
+      "lit",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LMWR_EUR": {
+    "normalized_id": "LMWR/EUR",
+    "base": "LMWR",
+    "quote": "EUR",
+    "display_name": "LMWR / Euro",
+    "description": "LMWR to Euro spot trading pair",
+    "tags": [
+      "lmwr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LMWR_USD": {
+    "normalized_id": "LMWR/USD",
+    "base": "LMWR",
+    "quote": "USD",
+    "display_name": "LMWR / US Dollar",
+    "description": "LMWR to US Dollar spot trading pair",
+    "tags": [
+      "lmwr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LOBO_USD": {
+    "normalized_id": "LOBO/USD",
+    "base": "LOBO",
+    "quote": "USD",
+    "display_name": "LOBO / US Dollar",
+    "description": "LOBO to US Dollar spot trading pair",
+    "tags": [
+      "lobo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LOCKIN_EUR": {
+    "normalized_id": "LOCKIN/EUR",
+    "base": "LOCKIN",
+    "quote": "EUR",
+    "display_name": "LOCKIN / Euro",
+    "description": "LOCKIN to Euro spot trading pair",
+    "tags": [
+      "lockin",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LOCKIN_USD": {
+    "normalized_id": "LOCKIN/USD",
+    "base": "LOCKIN",
+    "quote": "USD",
+    "display_name": "LOCKIN / US Dollar",
+    "description": "LOCKIN to US Dollar spot trading pair",
+    "tags": [
+      "lockin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LOFI_EUR": {
+    "normalized_id": "LOFI/EUR",
+    "base": "LOFI",
+    "quote": "EUR",
+    "display_name": "LOFI / Euro",
+    "description": "LOFI to Euro spot trading pair",
+    "tags": [
+      "lofi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LOFI_USD": {
+    "normalized_id": "LOFI/USD",
+    "base": "LOFI",
+    "quote": "USD",
+    "display_name": "LOFI / US Dollar",
+    "description": "LOFI to US Dollar spot trading pair",
+    "tags": [
+      "lofi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LPT_EUR": {
+    "normalized_id": "LPT/EUR",
+    "base": "LPT",
+    "quote": "EUR",
+    "display_name": "LPT / Euro",
+    "description": "LPT to Euro spot trading pair",
+    "tags": [
+      "lpt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LPT_USD": {
+    "normalized_id": "LPT/USD",
+    "base": "LPT",
+    "quote": "USD",
+    "display_name": "LPT / US Dollar",
+    "description": "LPT to US Dollar spot trading pair",
+    "tags": [
+      "lpt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LQTY_EUR": {
+    "normalized_id": "LQTY/EUR",
+    "base": "LQTY",
+    "quote": "EUR",
+    "display_name": "LQTY / Euro",
+    "description": "LQTY to Euro spot trading pair",
+    "tags": [
+      "lqty",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LQTY_USD": {
+    "normalized_id": "LQTY/USD",
+    "base": "LQTY",
+    "quote": "USD",
+    "display_name": "LQTY / US Dollar",
+    "description": "LQTY to US Dollar spot trading pair",
+    "tags": [
+      "lqty",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LRC_EUR": {
+    "normalized_id": "LRC/EUR",
+    "base": "LRC",
+    "quote": "EUR",
+    "display_name": "LRC / Euro",
+    "description": "LRC to Euro spot trading pair",
+    "tags": [
+      "lrc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LRC_USD": {
+    "normalized_id": "LRC/USD",
+    "base": "LRC",
+    "quote": "USD",
+    "display_name": "LRC / US Dollar",
+    "description": "LRC to US Dollar spot trading pair",
+    "tags": [
+      "lrc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LSETH_ETH": {
+    "normalized_id": "LSETH/ETH",
+    "base": "LSETH",
+    "quote": "ETH",
+    "display_name": "LSETH / Ethereum",
+    "description": "LSETH to Ethereum spot trading pair",
+    "tags": [
+      "lseth",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "LSETH_EUR": {
+    "normalized_id": "LSETH/EUR",
+    "base": "LSETH",
+    "quote": "EUR",
+    "display_name": "LSETH / Euro",
+    "description": "LSETH to Euro spot trading pair",
+    "tags": [
+      "lseth",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LSETH_USD": {
+    "normalized_id": "LSETH/USD",
+    "base": "LSETH",
+    "quote": "USD",
+    "display_name": "LSETH / US Dollar",
+    "description": "LSETH to US Dollar spot trading pair",
+    "tags": [
+      "lseth",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LSK_EUR": {
+    "normalized_id": "LSK/EUR",
+    "base": "LSK",
+    "quote": "EUR",
+    "display_name": "LSK / Euro",
+    "description": "LSK to Euro spot trading pair",
+    "tags": [
+      "lsk",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LSK_USD": {
+    "normalized_id": "LSK/USD",
+    "base": "LSK",
+    "quote": "USD",
+    "display_name": "LSK / US Dollar",
+    "description": "LSK to US Dollar spot trading pair",
+    "tags": [
+      "lsk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LTC_AUD": {
+    "normalized_id": "LTC/AUD",
+    "base": "LTC",
+    "quote": "AUD",
+    "display_name": "Litecoin / Australian Dollar",
+    "description": "Litecoin to Australian Dollar spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "LTC_ETH": {
+    "normalized_id": "LTC/ETH",
+    "base": "LTC",
+    "quote": "ETH",
+    "display_name": "Litecoin / Ethereum",
+    "description": "Litecoin to Ethereum spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "LTC_EUR": {
+    "normalized_id": "LTC/EUR",
+    "base": "LTC",
+    "quote": "EUR",
+    "display_name": "Litecoin / Euro",
+    "description": "Litecoin to Euro spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LTC_GBP": {
+    "normalized_id": "LTC/GBP",
+    "base": "LTC",
+    "quote": "GBP",
+    "display_name": "Litecoin / British Pound",
+    "description": "Litecoin to British Pound spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "LTC_JPY": {
+    "normalized_id": "LTC/JPY",
+    "base": "LTC",
+    "quote": "JPY",
+    "display_name": "Litecoin / Japanese Yen",
+    "description": "Litecoin to Japanese Yen spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "LTC_USD": {
+    "normalized_id": "LTC/USD",
+    "base": "LTC",
+    "quote": "USD",
+    "display_name": "Litecoin / US Dollar",
+    "description": "Litecoin to US Dollar spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LTC_USDC": {
+    "normalized_id": "LTC/USD",
+    "base": "LTC",
+    "quote": "USD",
+    "display_name": "Litecoin / US Dollar",
+    "description": "Litecoin to US Dollar spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LTC_USDT": {
+    "normalized_id": "LTC/USD",
+    "base": "LTC",
+    "quote": "USD",
+    "display_name": "Litecoin / US Dollar",
+    "description": "Litecoin to US Dollar spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LTC_XBT": {
+    "normalized_id": "LTC/XBT",
+    "base": "LTC",
+    "quote": "XBT",
+    "display_name": "Litecoin / XBT",
+    "description": "Litecoin to XBT spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "LUNA2_EUR": {
+    "normalized_id": "LUNA2/EUR",
+    "base": "LUNA2",
+    "quote": "EUR",
+    "display_name": "LUNA2 / Euro",
+    "description": "LUNA2 to Euro spot trading pair",
+    "tags": [
+      "luna2",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LUNA2_USD": {
+    "normalized_id": "LUNA2/USD",
+    "base": "LUNA2",
+    "quote": "USD",
+    "display_name": "LUNA2 / US Dollar",
+    "description": "LUNA2 to US Dollar spot trading pair",
+    "tags": [
+      "luna2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LUNA_EUR": {
+    "normalized_id": "LUNA/EUR",
+    "base": "LUNA",
+    "quote": "EUR",
+    "display_name": "LUNA / Euro",
+    "description": "LUNA to Euro spot trading pair",
+    "tags": [
+      "luna",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LUNA_USD": {
+    "normalized_id": "LUNA/USD",
+    "base": "LUNA",
+    "quote": "USD",
+    "display_name": "LUNA / US Dollar",
+    "description": "LUNA to US Dollar spot trading pair",
+    "tags": [
+      "luna",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MANA_EUR": {
+    "normalized_id": "MANA/EUR",
+    "base": "MANA",
+    "quote": "EUR",
+    "display_name": "Decentraland / Euro",
+    "description": "Decentraland to Euro spot trading pair",
+    "tags": [
+      "mana",
+      "decentraland",
+      "gaming",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MANA_USD": {
+    "normalized_id": "MANA/USD",
+    "base": "MANA",
+    "quote": "USD",
+    "display_name": "Decentraland / US Dollar",
+    "description": "Decentraland to US Dollar spot trading pair",
+    "tags": [
+      "mana",
+      "decentraland",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MANA_USDC": {
+    "normalized_id": "MANA/USD",
+    "base": "MANA",
+    "quote": "USD",
+    "display_name": "Decentraland / US Dollar",
+    "description": "Decentraland to US Dollar spot trading pair",
+    "tags": [
+      "mana",
+      "decentraland",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MANA_USDT": {
+    "normalized_id": "MANA/USD",
+    "base": "MANA",
+    "quote": "USD",
+    "display_name": "Decentraland / US Dollar",
+    "description": "Decentraland to US Dollar spot trading pair",
+    "tags": [
+      "mana",
+      "decentraland",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MANA_XBT": {
+    "normalized_id": "MANA/XBT",
+    "base": "MANA",
+    "quote": "XBT",
+    "display_name": "Decentraland / XBT",
+    "description": "Decentraland to XBT spot trading pair",
+    "tags": [
+      "mana",
+      "decentraland",
+      "gaming",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "MASK_EUR": {
+    "normalized_id": "MASK/EUR",
+    "base": "MASK",
+    "quote": "EUR",
+    "display_name": "MASK / Euro",
+    "description": "MASK to Euro spot trading pair",
+    "tags": [
+      "mask",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MASK_USD": {
+    "normalized_id": "MASK/USD",
+    "base": "MASK",
+    "quote": "USD",
+    "display_name": "MASK / US Dollar",
+    "description": "MASK to US Dollar spot trading pair",
+    "tags": [
+      "mask",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MAT_EUR": {
+    "normalized_id": "MAT/EUR",
+    "base": "MAT",
+    "quote": "EUR",
+    "display_name": "MAT / Euro",
+    "description": "MAT to Euro spot trading pair",
+    "tags": [
+      "mat",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MAT_USD": {
+    "normalized_id": "MAT/USD",
+    "base": "MAT",
+    "quote": "USD",
+    "display_name": "MAT / US Dollar",
+    "description": "MAT to US Dollar spot trading pair",
+    "tags": [
+      "mat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MC_EUR": {
+    "normalized_id": "MC/EUR",
+    "base": "MC",
+    "quote": "EUR",
+    "display_name": "MC / Euro",
+    "description": "MC to Euro spot trading pair",
+    "tags": [
+      "mc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MC_USD": {
+    "normalized_id": "MC/USD",
+    "base": "MC",
+    "quote": "USD",
+    "display_name": "MC / US Dollar",
+    "description": "MC to US Dollar spot trading pair",
+    "tags": [
+      "mc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MELANIA_EUR": {
+    "normalized_id": "MELANIA/EUR",
+    "base": "MELANIA",
+    "quote": "EUR",
+    "display_name": "MELANIA / Euro",
+    "description": "MELANIA to Euro spot trading pair",
+    "tags": [
+      "melania",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MELANIA_USD": {
+    "normalized_id": "MELANIA/USD",
+    "base": "MELANIA",
+    "quote": "USD",
+    "display_name": "MELANIA / US Dollar",
+    "description": "MELANIA to US Dollar spot trading pair",
+    "tags": [
+      "melania",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MELANIA_USDC": {
+    "normalized_id": "MELANIA/USD",
+    "base": "MELANIA",
+    "quote": "USD",
+    "display_name": "MELANIA / US Dollar",
+    "description": "MELANIA to US Dollar spot trading pair",
+    "tags": [
+      "melania",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MELANIA_USDT": {
+    "normalized_id": "MELANIA/USD",
+    "base": "MELANIA",
+    "quote": "USD",
+    "display_name": "MELANIA / US Dollar",
+    "description": "MELANIA to US Dollar spot trading pair",
+    "tags": [
+      "melania",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MEME_EUR": {
+    "normalized_id": "MEME/EUR",
+    "base": "MEME",
+    "quote": "EUR",
+    "display_name": "MEME / Euro",
+    "description": "MEME to Euro spot trading pair",
+    "tags": [
+      "meme",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MEME_USD": {
+    "normalized_id": "MEME/USD",
+    "base": "MEME",
+    "quote": "USD",
+    "display_name": "MEME / US Dollar",
+    "description": "MEME to US Dollar spot trading pair",
+    "tags": [
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MERL_EUR": {
+    "normalized_id": "MERL/EUR",
+    "base": "MERL",
+    "quote": "EUR",
+    "display_name": "MERL / Euro",
+    "description": "MERL to Euro spot trading pair",
+    "tags": [
+      "merl",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MERL_USD": {
+    "normalized_id": "MERL/USD",
+    "base": "MERL",
+    "quote": "USD",
+    "display_name": "MERL / US Dollar",
+    "description": "MERL to US Dollar spot trading pair",
+    "tags": [
+      "merl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "METH_ETH": {
+    "normalized_id": "METH/ETH",
+    "base": "METH",
+    "quote": "ETH",
+    "display_name": "METH / Ethereum",
+    "description": "METH to Ethereum spot trading pair",
+    "tags": [
+      "meth",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "METH_USD": {
+    "normalized_id": "METH/USD",
+    "base": "METH",
+    "quote": "USD",
+    "display_name": "METH / US Dollar",
+    "description": "METH to US Dollar spot trading pair",
+    "tags": [
+      "meth",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "METIS_EUR": {
+    "normalized_id": "METIS/EUR",
+    "base": "METIS",
+    "quote": "EUR",
+    "display_name": "METIS / Euro",
+    "description": "METIS to Euro spot trading pair",
+    "tags": [
+      "metis",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "METIS_USD": {
+    "normalized_id": "METIS/USD",
+    "base": "METIS",
+    "quote": "USD",
+    "display_name": "METIS / US Dollar",
+    "description": "METIS to US Dollar spot trading pair",
+    "tags": [
+      "metis",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MEW_EUR": {
+    "normalized_id": "MEW/EUR",
+    "base": "MEW",
+    "quote": "EUR",
+    "display_name": "MEW / Euro",
+    "description": "MEW to Euro spot trading pair",
+    "tags": [
+      "mew",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MEW_USD": {
+    "normalized_id": "MEW/USD",
+    "base": "MEW",
+    "quote": "USD",
+    "display_name": "MEW / US Dollar",
+    "description": "MEW to US Dollar spot trading pair",
+    "tags": [
+      "mew",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ME_EUR": {
+    "normalized_id": "ME/EUR",
+    "base": "ME",
+    "quote": "EUR",
+    "display_name": "ME / Euro",
+    "description": "ME to Euro spot trading pair",
+    "tags": [
+      "me",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ME_USD": {
+    "normalized_id": "ME/USD",
+    "base": "ME",
+    "quote": "USD",
+    "display_name": "ME / US Dollar",
+    "description": "ME to US Dollar spot trading pair",
+    "tags": [
+      "me",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MICHI_EUR": {
+    "normalized_id": "MICHI/EUR",
+    "base": "MICHI",
+    "quote": "EUR",
+    "display_name": "MICHI / Euro",
+    "description": "MICHI to Euro spot trading pair",
+    "tags": [
+      "michi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MICHI_USD": {
+    "normalized_id": "MICHI/USD",
+    "base": "MICHI",
+    "quote": "USD",
+    "display_name": "MICHI / US Dollar",
+    "description": "MICHI to US Dollar spot trading pair",
+    "tags": [
+      "michi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MIM_EUR": {
+    "normalized_id": "MIM/EUR",
+    "base": "MIM",
+    "quote": "EUR",
+    "display_name": "MIM / Euro",
+    "description": "MIM to Euro spot trading pair",
+    "tags": [
+      "mim",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MIM_USD": {
+    "normalized_id": "MIM/USD",
+    "base": "MIM",
+    "quote": "USD",
+    "display_name": "MIM / US Dollar",
+    "description": "MIM to US Dollar spot trading pair",
+    "tags": [
+      "mim",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MINA_EUR": {
+    "normalized_id": "MINA/EUR",
+    "base": "MINA",
+    "quote": "EUR",
+    "display_name": "MINA / Euro",
+    "description": "MINA to Euro spot trading pair",
+    "tags": [
+      "mina",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MINA_GBP": {
+    "normalized_id": "MINA/GBP",
+    "base": "MINA",
+    "quote": "GBP",
+    "display_name": "MINA / British Pound",
+    "description": "MINA to British Pound spot trading pair",
+    "tags": [
+      "mina",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "MINA_USD": {
+    "normalized_id": "MINA/USD",
+    "base": "MINA",
+    "quote": "USD",
+    "display_name": "MINA / US Dollar",
+    "description": "MINA to US Dollar spot trading pair",
+    "tags": [
+      "mina",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MINA_XBT": {
+    "normalized_id": "MINA/XBT",
+    "base": "MINA",
+    "quote": "XBT",
+    "display_name": "MINA / XBT",
+    "description": "MINA to XBT spot trading pair",
+    "tags": [
+      "mina",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "MIR_EUR": {
+    "normalized_id": "MIR/EUR",
+    "base": "MIR",
+    "quote": "EUR",
+    "display_name": "MIR / Euro",
+    "description": "MIR to Euro spot trading pair",
+    "tags": [
+      "mir",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MIR_USD": {
+    "normalized_id": "MIR/USD",
+    "base": "MIR",
+    "quote": "USD",
+    "display_name": "MIR / US Dollar",
+    "description": "MIR to US Dollar spot trading pair",
+    "tags": [
+      "mir",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MKR_EUR": {
+    "normalized_id": "MKR/EUR",
+    "base": "MKR",
+    "quote": "EUR",
+    "display_name": "Maker / Euro",
+    "description": "Maker to Euro spot trading pair",
+    "tags": [
+      "mkr",
+      "maker",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MKR_USD": {
+    "normalized_id": "MKR/USD",
+    "base": "MKR",
+    "quote": "USD",
+    "display_name": "Maker / US Dollar",
+    "description": "Maker to US Dollar spot trading pair",
+    "tags": [
+      "mkr",
+      "maker",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MKR_XBT": {
+    "normalized_id": "MKR/XBT",
+    "base": "MKR",
+    "quote": "XBT",
+    "display_name": "Maker / XBT",
+    "description": "Maker to XBT spot trading pair",
+    "tags": [
+      "mkr",
+      "maker",
+      "defi",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "MLN_EUR": {
+    "normalized_id": "MLN/EUR",
+    "base": "MLN",
+    "quote": "EUR",
+    "display_name": "MLN / Euro",
+    "description": "MLN to Euro spot trading pair",
+    "tags": [
+      "mln",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MLN_USD": {
+    "normalized_id": "MLN/USD",
+    "base": "MLN",
+    "quote": "USD",
+    "display_name": "MLN / US Dollar",
+    "description": "MLN to US Dollar spot trading pair",
+    "tags": [
+      "mln",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MLN_XBT": {
+    "normalized_id": "MLN/XBT",
+    "base": "MLN",
+    "quote": "XBT",
+    "display_name": "MLN / XBT",
+    "description": "MLN to XBT spot trading pair",
+    "tags": [
+      "mln",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "MNGO_EUR": {
+    "normalized_id": "MNGO/EUR",
+    "base": "MNGO",
+    "quote": "EUR",
+    "display_name": "MNGO / Euro",
+    "description": "MNGO to Euro spot trading pair",
+    "tags": [
+      "mngo",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MNGO_USD": {
+    "normalized_id": "MNGO/USD",
+    "base": "MNGO",
+    "quote": "USD",
+    "display_name": "MNGO / US Dollar",
+    "description": "MNGO to US Dollar spot trading pair",
+    "tags": [
+      "mngo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MNT_EUR": {
+    "normalized_id": "MNT/EUR",
+    "base": "MNT",
+    "quote": "EUR",
+    "display_name": "MNT / Euro",
+    "description": "MNT to Euro spot trading pair",
+    "tags": [
+      "mnt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MNT_USD": {
+    "normalized_id": "MNT/USD",
+    "base": "MNT",
+    "quote": "USD",
+    "display_name": "MNT / US Dollar",
+    "description": "MNT to US Dollar spot trading pair",
+    "tags": [
+      "mnt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOG_EUR": {
+    "normalized_id": "MOG/EUR",
+    "base": "MOG",
+    "quote": "EUR",
+    "display_name": "MOG / Euro",
+    "description": "MOG to Euro spot trading pair",
+    "tags": [
+      "mog",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MOG_USD": {
+    "normalized_id": "MOG/USD",
+    "base": "MOG",
+    "quote": "USD",
+    "display_name": "MOG / US Dollar",
+    "description": "MOG to US Dollar spot trading pair",
+    "tags": [
+      "mog",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOODENG_EUR": {
+    "normalized_id": "MOODENG/EUR",
+    "base": "MOODENG",
+    "quote": "EUR",
+    "display_name": "MOODENG / Euro",
+    "description": "MOODENG to Euro spot trading pair",
+    "tags": [
+      "moodeng",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MOODENG_USD": {
+    "normalized_id": "MOODENG/USD",
+    "base": "MOODENG",
+    "quote": "USD",
+    "display_name": "MOODENG / US Dollar",
+    "description": "MOODENG to US Dollar spot trading pair",
+    "tags": [
+      "moodeng",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOON_EUR": {
+    "normalized_id": "MOON/EUR",
+    "base": "MOON",
+    "quote": "EUR",
+    "display_name": "MOON / Euro",
+    "description": "MOON to Euro spot trading pair",
+    "tags": [
+      "moon",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MOON_USD": {
+    "normalized_id": "MOON/USD",
+    "base": "MOON",
+    "quote": "USD",
+    "display_name": "MOON / US Dollar",
+    "description": "MOON to US Dollar spot trading pair",
+    "tags": [
+      "moon",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MORPHO_EUR": {
+    "normalized_id": "MORPHO/EUR",
+    "base": "MORPHO",
+    "quote": "EUR",
+    "display_name": "MORPHO / Euro",
+    "description": "MORPHO to Euro spot trading pair",
+    "tags": [
+      "morpho",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MORPHO_USD": {
+    "normalized_id": "MORPHO/USD",
+    "base": "MORPHO",
+    "quote": "USD",
+    "display_name": "MORPHO / US Dollar",
+    "description": "MORPHO to US Dollar spot trading pair",
+    "tags": [
+      "morpho",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOVE_EUR": {
+    "normalized_id": "MOVE/EUR",
+    "base": "MOVE",
+    "quote": "EUR",
+    "display_name": "MOVE / Euro",
+    "description": "MOVE to Euro spot trading pair",
+    "tags": [
+      "move",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MOVE_USD": {
+    "normalized_id": "MOVE/USD",
+    "base": "MOVE",
+    "quote": "USD",
+    "display_name": "MOVE / US Dollar",
+    "description": "MOVE to US Dollar spot trading pair",
+    "tags": [
+      "move",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOVR_EUR": {
+    "normalized_id": "MOVR/EUR",
+    "base": "MOVR",
+    "quote": "EUR",
+    "display_name": "MOVR / Euro",
+    "description": "MOVR to Euro spot trading pair",
+    "tags": [
+      "movr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MOVR_USD": {
+    "normalized_id": "MOVR/USD",
+    "base": "MOVR",
+    "quote": "USD",
+    "display_name": "MOVR / US Dollar",
+    "description": "MOVR to US Dollar spot trading pair",
+    "tags": [
+      "movr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MSOL_EUR": {
+    "normalized_id": "MSOL/EUR",
+    "base": "MSOL",
+    "quote": "EUR",
+    "display_name": "MSOL / Euro",
+    "description": "MSOL to Euro spot trading pair",
+    "tags": [
+      "msol",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MSOL_USD": {
+    "normalized_id": "MSOL/USD",
+    "base": "MSOL",
+    "quote": "USD",
+    "display_name": "MSOL / US Dollar",
+    "description": "MSOL to US Dollar spot trading pair",
+    "tags": [
+      "msol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MUBARAK_EUR": {
+    "normalized_id": "MUBARAK/EUR",
+    "base": "MUBARAK",
+    "quote": "EUR",
+    "display_name": "MUBARAK / Euro",
+    "description": "MUBARAK to Euro spot trading pair",
+    "tags": [
+      "mubarak",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MUBARAK_USD": {
+    "normalized_id": "MUBARAK/USD",
+    "base": "MUBARAK",
+    "quote": "USD",
+    "display_name": "MUBARAK / US Dollar",
+    "description": "MUBARAK to US Dollar spot trading pair",
+    "tags": [
+      "mubarak",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MULTI_EUR": {
+    "normalized_id": "MULTI/EUR",
+    "base": "MULTI",
+    "quote": "EUR",
+    "display_name": "MULTI / Euro",
+    "description": "MULTI to Euro spot trading pair",
+    "tags": [
+      "multi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MULTI_USD": {
+    "normalized_id": "MULTI/USD",
+    "base": "MULTI",
+    "quote": "USD",
+    "display_name": "MULTI / US Dollar",
+    "description": "MULTI to US Dollar spot trading pair",
+    "tags": [
+      "multi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MV_EUR": {
+    "normalized_id": "MV/EUR",
+    "base": "MV",
+    "quote": "EUR",
+    "display_name": "MV / Euro",
+    "description": "MV to Euro spot trading pair",
+    "tags": [
+      "mv",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MV_USD": {
+    "normalized_id": "MV/USD",
+    "base": "MV",
+    "quote": "USD",
+    "display_name": "MV / US Dollar",
+    "description": "MV to US Dollar spot trading pair",
+    "tags": [
+      "mv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MXC_EUR": {
+    "normalized_id": "MXC/EUR",
+    "base": "MXC",
+    "quote": "EUR",
+    "display_name": "MXC / Euro",
+    "description": "MXC to Euro spot trading pair",
+    "tags": [
+      "mxc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MXC_USD": {
+    "normalized_id": "MXC/USD",
+    "base": "MXC",
+    "quote": "USD",
+    "display_name": "MXC / US Dollar",
+    "description": "MXC to US Dollar spot trading pair",
+    "tags": [
+      "mxc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "M_EUR": {
+    "normalized_id": "M/EUR",
+    "base": "M",
+    "quote": "EUR",
+    "display_name": "M / Euro",
+    "description": "M to Euro spot trading pair",
+    "tags": [
+      "m",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "M_USD": {
+    "normalized_id": "M/USD",
+    "base": "M",
+    "quote": "USD",
+    "display_name": "M / US Dollar",
+    "description": "M to US Dollar spot trading pair",
+    "tags": [
+      "m",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NANO_EUR": {
+    "normalized_id": "NANO/EUR",
+    "base": "NANO",
+    "quote": "EUR",
+    "display_name": "NANO / Euro",
+    "description": "NANO to Euro spot trading pair",
+    "tags": [
+      "nano",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "NANO_USD": {
+    "normalized_id": "NANO/USD",
+    "base": "NANO",
+    "quote": "USD",
+    "display_name": "NANO / US Dollar",
+    "description": "NANO to US Dollar spot trading pair",
+    "tags": [
+      "nano",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEAR_EUR": {
+    "normalized_id": "NEAR/EUR",
+    "base": "NEAR",
+    "quote": "EUR",
+    "display_name": "NEAR Protocol / Euro",
+    "description": "NEAR Protocol to Euro spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "NEAR_USD": {
+    "normalized_id": "NEAR/USD",
+    "base": "NEAR",
+    "quote": "USD",
+    "display_name": "NEAR Protocol / US Dollar",
+    "description": "NEAR Protocol to US Dollar spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEIRO_EUR": {
+    "normalized_id": "NEIRO/EUR",
+    "base": "NEIRO",
+    "quote": "EUR",
+    "display_name": "NEIRO / Euro",
+    "description": "NEIRO to Euro spot trading pair",
+    "tags": [
+      "neiro",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "NEIRO_USD": {
+    "normalized_id": "NEIRO/USD",
+    "base": "NEIRO",
+    "quote": "USD",
+    "display_name": "NEIRO / US Dollar",
+    "description": "NEIRO to US Dollar spot trading pair",
+    "tags": [
+      "neiro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NIL_EUR": {
+    "normalized_id": "NIL/EUR",
+    "base": "NIL",
+    "quote": "EUR",
+    "display_name": "NIL / Euro",
+    "description": "NIL to Euro spot trading pair",
+    "tags": [
+      "nil",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "NIL_USD": {
+    "normalized_id": "NIL/USD",
+    "base": "NIL",
+    "quote": "USD",
+    "display_name": "NIL / US Dollar",
+    "description": "NIL to US Dollar spot trading pair",
+    "tags": [
+      "nil",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NMR_EUR": {
+    "normalized_id": "NMR/EUR",
+    "base": "NMR",
+    "quote": "EUR",
+    "display_name": "NMR / Euro",
+    "description": "NMR to Euro spot trading pair",
+    "tags": [
+      "nmr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "NMR_USD": {
+    "normalized_id": "NMR/USD",
+    "base": "NMR",
+    "quote": "USD",
+    "display_name": "NMR / US Dollar",
+    "description": "NMR to US Dollar spot trading pair",
+    "tags": [
+      "nmr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NODE_USD": {
+    "normalized_id": "NODE/USD",
+    "base": "NODE",
+    "quote": "USD",
+    "display_name": "NODE / US Dollar",
+    "description": "NODE to US Dollar spot trading pair",
+    "tags": [
+      "node",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NODL_EUR": {
+    "normalized_id": "NODL/EUR",
+    "base": "NODL",
+    "quote": "EUR",
+    "display_name": "NODL / Euro",
+    "description": "NODL to Euro spot trading pair",
+    "tags": [
+      "nodl",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "NODL_USD": {
+    "normalized_id": "NODL/USD",
+    "base": "NODL",
+    "quote": "USD",
+    "display_name": "NODL / US Dollar",
+    "description": "NODL to US Dollar spot trading pair",
+    "tags": [
+      "nodl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NOS_EUR": {
+    "normalized_id": "NOS/EUR",
+    "base": "NOS",
+    "quote": "EUR",
+    "display_name": "NOS / Euro",
+    "description": "NOS to Euro spot trading pair",
+    "tags": [
+      "nos",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "NOS_USD": {
+    "normalized_id": "NOS/USD",
+    "base": "NOS",
+    "quote": "USD",
+    "display_name": "NOS / US Dollar",
+    "description": "NOS to US Dollar spot trading pair",
+    "tags": [
+      "nos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NOT_EUR": {
+    "normalized_id": "NOT/EUR",
+    "base": "NOT",
+    "quote": "EUR",
+    "display_name": "NOT / Euro",
+    "description": "NOT to Euro spot trading pair",
+    "tags": [
+      "not",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "NOT_USD": {
+    "normalized_id": "NOT/USD",
+    "base": "NOT",
+    "quote": "USD",
+    "display_name": "NOT / US Dollar",
+    "description": "NOT to US Dollar spot trading pair",
+    "tags": [
+      "not",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NPC_EUR": {
+    "normalized_id": "NPC/EUR",
+    "base": "NPC",
+    "quote": "EUR",
+    "display_name": "NPC / Euro",
+    "description": "NPC to Euro spot trading pair",
+    "tags": [
+      "npc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "NPC_USD": {
+    "normalized_id": "NPC/USD",
+    "base": "NPC",
+    "quote": "USD",
+    "display_name": "NPC / US Dollar",
+    "description": "NPC to US Dollar spot trading pair",
+    "tags": [
+      "npc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NTRN_EUR": {
+    "normalized_id": "NTRN/EUR",
+    "base": "NTRN",
+    "quote": "EUR",
+    "display_name": "NTRN / Euro",
+    "description": "NTRN to Euro spot trading pair",
+    "tags": [
+      "ntrn",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "NTRN_USD": {
+    "normalized_id": "NTRN/USD",
+    "base": "NTRN",
+    "quote": "USD",
+    "display_name": "NTRN / US Dollar",
+    "description": "NTRN to US Dollar spot trading pair",
+    "tags": [
+      "ntrn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NYM_EUR": {
+    "normalized_id": "NYM/EUR",
+    "base": "NYM",
+    "quote": "EUR",
+    "display_name": "NYM / Euro",
+    "description": "NYM to Euro spot trading pair",
+    "tags": [
+      "nym",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "NYM_USD": {
+    "normalized_id": "NYM/USD",
+    "base": "NYM",
+    "quote": "USD",
+    "display_name": "NYM / US Dollar",
+    "description": "NYM to US Dollar spot trading pair",
+    "tags": [
+      "nym",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OCEAN_EUR": {
+    "normalized_id": "OCEAN/EUR",
+    "base": "OCEAN",
+    "quote": "EUR",
+    "display_name": "OCEAN / Euro",
+    "description": "OCEAN to Euro spot trading pair",
+    "tags": [
+      "ocean",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "OCEAN_USD": {
+    "normalized_id": "OCEAN/USD",
+    "base": "OCEAN",
+    "quote": "USD",
+    "display_name": "OCEAN / US Dollar",
+    "description": "OCEAN to US Dollar spot trading pair",
+    "tags": [
+      "ocean",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ODOS_EUR": {
+    "normalized_id": "ODOS/EUR",
+    "base": "ODOS",
+    "quote": "EUR",
+    "display_name": "ODOS / Euro",
+    "description": "ODOS to Euro spot trading pair",
+    "tags": [
+      "odos",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ODOS_USD": {
+    "normalized_id": "ODOS/USD",
+    "base": "ODOS",
+    "quote": "USD",
+    "display_name": "ODOS / US Dollar",
+    "description": "ODOS to US Dollar spot trading pair",
+    "tags": [
+      "odos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OGN_EUR": {
+    "normalized_id": "OGN/EUR",
+    "base": "OGN",
+    "quote": "EUR",
+    "display_name": "OGN / Euro",
+    "description": "OGN to Euro spot trading pair",
+    "tags": [
+      "ogn",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "OGN_USD": {
+    "normalized_id": "OGN/USD",
+    "base": "OGN",
+    "quote": "USD",
+    "display_name": "OGN / US Dollar",
+    "description": "OGN to US Dollar spot trading pair",
+    "tags": [
+      "ogn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OMG_EUR": {
+    "normalized_id": "OMG/EUR",
+    "base": "OMG",
+    "quote": "EUR",
+    "display_name": "OMG / Euro",
+    "description": "OMG to Euro spot trading pair",
+    "tags": [
+      "omg",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "OMG_USD": {
+    "normalized_id": "OMG/USD",
+    "base": "OMG",
+    "quote": "USD",
+    "display_name": "OMG / US Dollar",
+    "description": "OMG to US Dollar spot trading pair",
+    "tags": [
+      "omg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OMNI_EUR": {
+    "normalized_id": "OMNI/EUR",
+    "base": "OMNI",
+    "quote": "EUR",
+    "display_name": "OMNI / Euro",
+    "description": "OMNI to Euro spot trading pair",
+    "tags": [
+      "omni",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "OMNI_USD": {
+    "normalized_id": "OMNI/USD",
+    "base": "OMNI",
+    "quote": "USD",
+    "display_name": "OMNI / US Dollar",
+    "description": "OMNI to US Dollar spot trading pair",
+    "tags": [
+      "omni",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OM_EUR": {
+    "normalized_id": "OM/EUR",
+    "base": "OM",
+    "quote": "EUR",
+    "display_name": "OM / Euro",
+    "description": "OM to Euro spot trading pair",
+    "tags": [
+      "om",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "OM_USD": {
+    "normalized_id": "OM/USD",
+    "base": "OM",
+    "quote": "USD",
+    "display_name": "OM / US Dollar",
+    "description": "OM to US Dollar spot trading pair",
+    "tags": [
+      "om",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ONDO_EUR": {
+    "normalized_id": "ONDO/EUR",
+    "base": "ONDO",
+    "quote": "EUR",
+    "display_name": "ONDO / Euro",
+    "description": "ONDO to Euro spot trading pair",
+    "tags": [
+      "ondo",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ONDO_USD": {
+    "normalized_id": "ONDO/USD",
+    "base": "ONDO",
+    "quote": "USD",
+    "display_name": "ONDO / US Dollar",
+    "description": "ONDO to US Dollar spot trading pair",
+    "tags": [
+      "ondo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OP_EUR": {
+    "normalized_id": "OP/EUR",
+    "base": "OP",
+    "quote": "EUR",
+    "display_name": "Optimism / Euro",
+    "description": "Optimism to Euro spot trading pair",
+    "tags": [
+      "op",
+      "optimism",
+      "layer2",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "OP_USD": {
+    "normalized_id": "OP/USD",
+    "base": "OP",
+    "quote": "USD",
+    "display_name": "Optimism / US Dollar",
+    "description": "Optimism to US Dollar spot trading pair",
+    "tags": [
+      "op",
+      "optimism",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ORCA_EUR": {
+    "normalized_id": "ORCA/EUR",
+    "base": "ORCA",
+    "quote": "EUR",
+    "display_name": "ORCA / Euro",
+    "description": "ORCA to Euro spot trading pair",
+    "tags": [
+      "orca",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ORCA_USD": {
+    "normalized_id": "ORCA/USD",
+    "base": "ORCA",
+    "quote": "USD",
+    "display_name": "ORCA / US Dollar",
+    "description": "ORCA to US Dollar spot trading pair",
+    "tags": [
+      "orca",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ORDER_EUR": {
+    "normalized_id": "ORDER/EUR",
+    "base": "ORDER",
+    "quote": "EUR",
+    "display_name": "ORDER / Euro",
+    "description": "ORDER to Euro spot trading pair",
+    "tags": [
+      "order",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ORDER_USD": {
+    "normalized_id": "ORDER/USD",
+    "base": "ORDER",
+    "quote": "USD",
+    "display_name": "ORDER / US Dollar",
+    "description": "ORDER to US Dollar spot trading pair",
+    "tags": [
+      "order",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OSMO_EUR": {
+    "normalized_id": "OSMO/EUR",
+    "base": "OSMO",
+    "quote": "EUR",
+    "display_name": "OSMO / Euro",
+    "description": "OSMO to Euro spot trading pair",
+    "tags": [
+      "osmo",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "OSMO_USD": {
+    "normalized_id": "OSMO/USD",
+    "base": "OSMO",
+    "quote": "USD",
+    "display_name": "OSMO / US Dollar",
+    "description": "OSMO to US Dollar spot trading pair",
+    "tags": [
+      "osmo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OXT_EUR": {
+    "normalized_id": "OXT/EUR",
+    "base": "OXT",
+    "quote": "EUR",
+    "display_name": "OXT / Euro",
+    "description": "OXT to Euro spot trading pair",
+    "tags": [
+      "oxt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "OXT_USD": {
+    "normalized_id": "OXT/USD",
+    "base": "OXT",
+    "quote": "USD",
+    "display_name": "OXT / US Dollar",
+    "description": "OXT to US Dollar spot trading pair",
+    "tags": [
+      "oxt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OXY_EUR": {
+    "normalized_id": "OXY/EUR",
+    "base": "OXY",
+    "quote": "EUR",
+    "display_name": "OXY / Euro",
+    "description": "OXY to Euro spot trading pair",
+    "tags": [
+      "oxy",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "OXY_USD": {
+    "normalized_id": "OXY/USD",
+    "base": "OXY",
+    "quote": "USD",
+    "display_name": "OXY / US Dollar",
+    "description": "OXY to US Dollar spot trading pair",
+    "tags": [
+      "oxy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PARTI_EUR": {
+    "normalized_id": "PARTI/EUR",
+    "base": "PARTI",
+    "quote": "EUR",
+    "display_name": "PARTI / Euro",
+    "description": "PARTI to Euro spot trading pair",
+    "tags": [
+      "parti",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PARTI_USD": {
+    "normalized_id": "PARTI/USD",
+    "base": "PARTI",
+    "quote": "USD",
+    "display_name": "PARTI / US Dollar",
+    "description": "PARTI to US Dollar spot trading pair",
+    "tags": [
+      "parti",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PAXG_ETH": {
+    "normalized_id": "PAXG/ETH",
+    "base": "PAXG",
+    "quote": "ETH",
+    "display_name": "PAXG / Ethereum",
+    "description": "PAXG to Ethereum spot trading pair",
+    "tags": [
+      "paxg",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "PAXG_EUR": {
+    "normalized_id": "PAXG/EUR",
+    "base": "PAXG",
+    "quote": "EUR",
+    "display_name": "PAXG / Euro",
+    "description": "PAXG to Euro spot trading pair",
+    "tags": [
+      "paxg",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PAXG_USD": {
+    "normalized_id": "PAXG/USD",
+    "base": "PAXG",
+    "quote": "USD",
+    "display_name": "PAXG / US Dollar",
+    "description": "PAXG to US Dollar spot trading pair",
+    "tags": [
+      "paxg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PAXG_XBT": {
+    "normalized_id": "PAXG/XBT",
+    "base": "PAXG",
+    "quote": "XBT",
+    "display_name": "PAXG / XBT",
+    "description": "PAXG to XBT spot trading pair",
+    "tags": [
+      "paxg",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "PDA_EUR": {
+    "normalized_id": "PDA/EUR",
+    "base": "PDA",
+    "quote": "EUR",
+    "display_name": "PDA / Euro",
+    "description": "PDA to Euro spot trading pair",
+    "tags": [
+      "pda",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PDA_USD": {
+    "normalized_id": "PDA/USD",
+    "base": "PDA",
+    "quote": "USD",
+    "display_name": "PDA / US Dollar",
+    "description": "PDA to US Dollar spot trading pair",
+    "tags": [
+      "pda",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PEAQ_EUR": {
+    "normalized_id": "PEAQ/EUR",
+    "base": "PEAQ",
+    "quote": "EUR",
+    "display_name": "PEAQ / Euro",
+    "description": "PEAQ to Euro spot trading pair",
+    "tags": [
+      "peaq",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PEAQ_USD": {
+    "normalized_id": "PEAQ/USD",
+    "base": "PEAQ",
+    "quote": "USD",
+    "display_name": "PEAQ / US Dollar",
+    "description": "PEAQ to US Dollar spot trading pair",
+    "tags": [
+      "peaq",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENDLE_EUR": {
+    "normalized_id": "PENDLE/EUR",
+    "base": "PENDLE",
+    "quote": "EUR",
+    "display_name": "PENDLE / Euro",
+    "description": "PENDLE to Euro spot trading pair",
+    "tags": [
+      "pendle",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PENDLE_USD": {
+    "normalized_id": "PENDLE/USD",
+    "base": "PENDLE",
+    "quote": "USD",
+    "display_name": "PENDLE / US Dollar",
+    "description": "PENDLE to US Dollar spot trading pair",
+    "tags": [
+      "pendle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENGU_EUR": {
+    "normalized_id": "PENGU/EUR",
+    "base": "PENGU",
+    "quote": "EUR",
+    "display_name": "PENGU / Euro",
+    "description": "PENGU to Euro spot trading pair",
+    "tags": [
+      "pengu",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PENGU_USD": {
+    "normalized_id": "PENGU/USD",
+    "base": "PENGU",
+    "quote": "USD",
+    "display_name": "PENGU / US Dollar",
+    "description": "PENGU to US Dollar spot trading pair",
+    "tags": [
+      "pengu",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENGU_USDC": {
+    "normalized_id": "PENGU/USD",
+    "base": "PENGU",
+    "quote": "USD",
+    "display_name": "PENGU / US Dollar",
+    "description": "PENGU to US Dollar spot trading pair",
+    "tags": [
+      "pengu",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENGU_USDT": {
+    "normalized_id": "PENGU/USD",
+    "base": "PENGU",
+    "quote": "USD",
+    "display_name": "PENGU / US Dollar",
+    "description": "PENGU to US Dollar spot trading pair",
+    "tags": [
+      "pengu",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PEPE_AUD": {
+    "normalized_id": "PEPE/AUD",
+    "base": "PEPE",
+    "quote": "AUD",
+    "display_name": "Pepe / Australian Dollar",
+    "description": "Pepe to Australian Dollar spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "PEPE_CAD": {
+    "normalized_id": "PEPE/CAD",
+    "base": "PEPE",
+    "quote": "CAD",
+    "display_name": "Pepe / Canadian Dollar",
+    "description": "Pepe to Canadian Dollar spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "cad",
+      "fiat",
+      "canadian dollar"
+    ],
+    "category": "crypto"
+  },
+  "PEPE_EUR": {
+    "normalized_id": "PEPE/EUR",
+    "base": "PEPE",
+    "quote": "EUR",
+    "display_name": "Pepe / Euro",
+    "description": "Pepe to Euro spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PEPE_GBP": {
+    "normalized_id": "PEPE/GBP",
+    "base": "PEPE",
+    "quote": "GBP",
+    "display_name": "Pepe / British Pound",
+    "description": "Pepe to British Pound spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "PEPE_USD": {
+    "normalized_id": "PEPE/USD",
+    "base": "PEPE",
+    "quote": "USD",
+    "display_name": "Pepe / US Dollar",
+    "description": "Pepe to US Dollar spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PERP_EUR": {
+    "normalized_id": "PERP/EUR",
+    "base": "PERP",
+    "quote": "EUR",
+    "display_name": "PERP / Euro",
+    "description": "PERP to Euro spot trading pair",
+    "tags": [
+      "perp",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PERP_USD": {
+    "normalized_id": "PERP/USD",
+    "base": "PERP",
+    "quote": "USD",
+    "display_name": "PERP / US Dollar",
+    "description": "PERP to US Dollar spot trading pair",
+    "tags": [
+      "perp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PHA_EUR": {
+    "normalized_id": "PHA/EUR",
+    "base": "PHA",
+    "quote": "EUR",
+    "display_name": "PHA / Euro",
+    "description": "PHA to Euro spot trading pair",
+    "tags": [
+      "pha",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PHA_USD": {
+    "normalized_id": "PHA/USD",
+    "base": "PHA",
+    "quote": "USD",
+    "display_name": "PHA / US Dollar",
+    "description": "PHA to US Dollar spot trading pair",
+    "tags": [
+      "pha",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PLUME_EUR": {
+    "normalized_id": "PLUME/EUR",
+    "base": "PLUME",
+    "quote": "EUR",
+    "display_name": "PLUME / Euro",
+    "description": "PLUME to Euro spot trading pair",
+    "tags": [
+      "plume",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PLUME_USD": {
+    "normalized_id": "PLUME/USD",
+    "base": "PLUME",
+    "quote": "USD",
+    "display_name": "PLUME / US Dollar",
+    "description": "PLUME to US Dollar spot trading pair",
+    "tags": [
+      "plume",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PNUT_EUR": {
+    "normalized_id": "PNUT/EUR",
+    "base": "PNUT",
+    "quote": "EUR",
+    "display_name": "PNUT / Euro",
+    "description": "PNUT to Euro spot trading pair",
+    "tags": [
+      "pnut",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PNUT_USD": {
+    "normalized_id": "PNUT/USD",
+    "base": "PNUT",
+    "quote": "USD",
+    "display_name": "PNUT / US Dollar",
+    "description": "PNUT to US Dollar spot trading pair",
+    "tags": [
+      "pnut",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POLIS_EUR": {
+    "normalized_id": "POLIS/EUR",
+    "base": "POLIS",
+    "quote": "EUR",
+    "display_name": "POLIS / Euro",
+    "description": "POLIS to Euro spot trading pair",
+    "tags": [
+      "polis",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "POLIS_USD": {
+    "normalized_id": "POLIS/USD",
+    "base": "POLIS",
+    "quote": "USD",
+    "display_name": "POLIS / US Dollar",
+    "description": "POLIS to US Dollar spot trading pair",
+    "tags": [
+      "polis",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POLS_EUR": {
+    "normalized_id": "POLS/EUR",
+    "base": "POLS",
+    "quote": "EUR",
+    "display_name": "POLS / Euro",
+    "description": "POLS to Euro spot trading pair",
+    "tags": [
+      "pols",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "POLS_USD": {
+    "normalized_id": "POLS/USD",
+    "base": "POLS",
+    "quote": "USD",
+    "display_name": "POLS / US Dollar",
+    "description": "POLS to US Dollar spot trading pair",
+    "tags": [
+      "pols",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POL_EUR": {
+    "normalized_id": "POL/EUR",
+    "base": "POL",
+    "quote": "EUR",
+    "display_name": "POL / Euro",
+    "description": "POL to Euro spot trading pair",
+    "tags": [
+      "pol",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "POL_USD": {
+    "normalized_id": "POL/USD",
+    "base": "POL",
+    "quote": "USD",
+    "display_name": "POL / US Dollar",
+    "description": "POL to US Dollar spot trading pair",
+    "tags": [
+      "pol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POND_EUR": {
+    "normalized_id": "POND/EUR",
+    "base": "POND",
+    "quote": "EUR",
+    "display_name": "POND / Euro",
+    "description": "POND to Euro spot trading pair",
+    "tags": [
+      "pond",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "POND_USD": {
+    "normalized_id": "POND/USD",
+    "base": "POND",
+    "quote": "USD",
+    "display_name": "POND / US Dollar",
+    "description": "POND to US Dollar spot trading pair",
+    "tags": [
+      "pond",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PONKE_EUR": {
+    "normalized_id": "PONKE/EUR",
+    "base": "PONKE",
+    "quote": "EUR",
+    "display_name": "PONKE / Euro",
+    "description": "PONKE to Euro spot trading pair",
+    "tags": [
+      "ponke",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PONKE_USD": {
+    "normalized_id": "PONKE/USD",
+    "base": "PONKE",
+    "quote": "USD",
+    "display_name": "PONKE / US Dollar",
+    "description": "PONKE to US Dollar spot trading pair",
+    "tags": [
+      "ponke",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POPCAT_EUR": {
+    "normalized_id": "POPCAT/EUR",
+    "base": "POPCAT",
+    "quote": "EUR",
+    "display_name": "POPCAT / Euro",
+    "description": "POPCAT to Euro spot trading pair",
+    "tags": [
+      "popcat",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "POPCAT_GBP": {
+    "normalized_id": "POPCAT/GBP",
+    "base": "POPCAT",
+    "quote": "GBP",
+    "display_name": "POPCAT / British Pound",
+    "description": "POPCAT to British Pound spot trading pair",
+    "tags": [
+      "popcat",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "POPCAT_USD": {
+    "normalized_id": "POPCAT/USD",
+    "base": "POPCAT",
+    "quote": "USD",
+    "display_name": "POPCAT / US Dollar",
+    "description": "POPCAT to US Dollar spot trading pair",
+    "tags": [
+      "popcat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PORTAL_EUR": {
+    "normalized_id": "PORTAL/EUR",
+    "base": "PORTAL",
+    "quote": "EUR",
+    "display_name": "PORTAL / Euro",
+    "description": "PORTAL to Euro spot trading pair",
+    "tags": [
+      "portal",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PORTAL_USD": {
+    "normalized_id": "PORTAL/USD",
+    "base": "PORTAL",
+    "quote": "USD",
+    "display_name": "PORTAL / US Dollar",
+    "description": "PORTAL to US Dollar spot trading pair",
+    "tags": [
+      "portal",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POWR_EUR": {
+    "normalized_id": "POWR/EUR",
+    "base": "POWR",
+    "quote": "EUR",
+    "display_name": "POWR / Euro",
+    "description": "POWR to Euro spot trading pair",
+    "tags": [
+      "powr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "POWR_USD": {
+    "normalized_id": "POWR/USD",
+    "base": "POWR",
+    "quote": "USD",
+    "display_name": "POWR / US Dollar",
+    "description": "POWR to US Dollar spot trading pair",
+    "tags": [
+      "powr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PRCL_EUR": {
+    "normalized_id": "PRCL/EUR",
+    "base": "PRCL",
+    "quote": "EUR",
+    "display_name": "PRCL / Euro",
+    "description": "PRCL to Euro spot trading pair",
+    "tags": [
+      "prcl",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PRCL_USD": {
+    "normalized_id": "PRCL/USD",
+    "base": "PRCL",
+    "quote": "USD",
+    "display_name": "PRCL / US Dollar",
+    "description": "PRCL to US Dollar spot trading pair",
+    "tags": [
+      "prcl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PRIME_EUR": {
+    "normalized_id": "PRIME/EUR",
+    "base": "PRIME",
+    "quote": "EUR",
+    "display_name": "PRIME / Euro",
+    "description": "PRIME to Euro spot trading pair",
+    "tags": [
+      "prime",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PRIME_USD": {
+    "normalized_id": "PRIME/USD",
+    "base": "PRIME",
+    "quote": "USD",
+    "display_name": "PRIME / US Dollar",
+    "description": "PRIME to US Dollar spot trading pair",
+    "tags": [
+      "prime",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PROMPT_EUR": {
+    "normalized_id": "PROMPT/EUR",
+    "base": "PROMPT",
+    "quote": "EUR",
+    "display_name": "PROMPT / Euro",
+    "description": "PROMPT to Euro spot trading pair",
+    "tags": [
+      "prompt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PROMPT_USD": {
+    "normalized_id": "PROMPT/USD",
+    "base": "PROMPT",
+    "quote": "USD",
+    "display_name": "PROMPT / US Dollar",
+    "description": "PROMPT to US Dollar spot trading pair",
+    "tags": [
+      "prompt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PSTAKE_EUR": {
+    "normalized_id": "PSTAKE/EUR",
+    "base": "PSTAKE",
+    "quote": "EUR",
+    "display_name": "PSTAKE / Euro",
+    "description": "PSTAKE to Euro spot trading pair",
+    "tags": [
+      "pstake",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PSTAKE_USD": {
+    "normalized_id": "PSTAKE/USD",
+    "base": "PSTAKE",
+    "quote": "USD",
+    "display_name": "PSTAKE / US Dollar",
+    "description": "PSTAKE to US Dollar spot trading pair",
+    "tags": [
+      "pstake",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PUFFER_EUR": {
+    "normalized_id": "PUFFER/EUR",
+    "base": "PUFFER",
+    "quote": "EUR",
+    "display_name": "PUFFER / Euro",
+    "description": "PUFFER to Euro spot trading pair",
+    "tags": [
+      "puffer",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PUFFER_USD": {
+    "normalized_id": "PUFFER/USD",
+    "base": "PUFFER",
+    "quote": "USD",
+    "display_name": "PUFFER / US Dollar",
+    "description": "PUFFER to US Dollar spot trading pair",
+    "tags": [
+      "puffer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PUMP_EUR": {
+    "normalized_id": "PUMP/EUR",
+    "base": "PUMP",
+    "quote": "EUR",
+    "display_name": "PUMP / Euro",
+    "description": "PUMP to Euro spot trading pair",
+    "tags": [
+      "pump",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PUMP_SOL": {
+    "normalized_id": "PUMP/SOL",
+    "base": "PUMP",
+    "quote": "SOL",
+    "display_name": "PUMP / Solana",
+    "description": "PUMP to Solana spot trading pair",
+    "tags": [
+      "pump",
+      "sol"
+    ],
+    "category": "crypto"
+  },
+  "PUMP_USD": {
+    "normalized_id": "PUMP/USD",
+    "base": "PUMP",
+    "quote": "USD",
+    "display_name": "PUMP / US Dollar",
+    "description": "PUMP to US Dollar spot trading pair",
+    "tags": [
+      "pump",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PUPS_EUR": {
+    "normalized_id": "PUPS/EUR",
+    "base": "PUPS",
+    "quote": "EUR",
+    "display_name": "PUPS / Euro",
+    "description": "PUPS to Euro spot trading pair",
+    "tags": [
+      "pups",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PUPS_USD": {
+    "normalized_id": "PUPS/USD",
+    "base": "PUPS",
+    "quote": "USD",
+    "display_name": "PUPS / US Dollar",
+    "description": "PUPS to US Dollar spot trading pair",
+    "tags": [
+      "pups",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PYTH_EUR": {
+    "normalized_id": "PYTH/EUR",
+    "base": "PYTH",
+    "quote": "EUR",
+    "display_name": "Pyth Network / Euro",
+    "description": "Pyth Network to Euro spot trading pair",
+    "tags": [
+      "pyth",
+      "pyth network",
+      "oracle",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PYTH_USD": {
+    "normalized_id": "PYTH/USD",
+    "base": "PYTH",
+    "quote": "USD",
+    "display_name": "Pyth Network / US Dollar",
+    "description": "Pyth Network to US Dollar spot trading pair",
+    "tags": [
+      "pyth",
+      "pyth network",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PYUSD_EUR": {
+    "normalized_id": "PYUSD/EUR",
+    "base": "PYUSD",
+    "quote": "EUR",
+    "display_name": "PYUSD / Euro",
+    "description": "PYUSD to Euro spot trading pair",
+    "tags": [
+      "pyusd",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PYUSD_USD": {
+    "normalized_id": "PYUSD/USD",
+    "base": "PYUSD",
+    "quote": "USD",
+    "display_name": "PYUSD / US Dollar",
+    "description": "PYUSD to US Dollar spot trading pair",
+    "tags": [
+      "pyusd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "QI_EUR": {
+    "normalized_id": "QI/EUR",
+    "base": "QI",
+    "quote": "EUR",
+    "display_name": "QI / Euro",
+    "description": "QI to Euro spot trading pair",
+    "tags": [
+      "qi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "QI_USD": {
+    "normalized_id": "QI/USD",
+    "base": "QI",
+    "quote": "USD",
+    "display_name": "QI / US Dollar",
+    "description": "QI to US Dollar spot trading pair",
+    "tags": [
+      "qi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "QNT_EUR": {
+    "normalized_id": "QNT/EUR",
+    "base": "QNT",
+    "quote": "EUR",
+    "display_name": "Quant / Euro",
+    "description": "Quant to Euro spot trading pair",
+    "tags": [
+      "qnt",
+      "quant",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "QNT_USD": {
+    "normalized_id": "QNT/USD",
+    "base": "QNT",
+    "quote": "USD",
+    "display_name": "Quant / US Dollar",
+    "description": "Quant to US Dollar spot trading pair",
+    "tags": [
+      "qnt",
+      "quant",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "QTUM_EUR": {
+    "normalized_id": "QTUM/EUR",
+    "base": "QTUM",
+    "quote": "EUR",
+    "display_name": "QTUM / Euro",
+    "description": "QTUM to Euro spot trading pair",
+    "tags": [
+      "qtum",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "QTUM_USD": {
+    "normalized_id": "QTUM/USD",
+    "base": "QTUM",
+    "quote": "USD",
+    "display_name": "QTUM / US Dollar",
+    "description": "QTUM to US Dollar spot trading pair",
+    "tags": [
+      "qtum",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RAD_EUR": {
+    "normalized_id": "RAD/EUR",
+    "base": "RAD",
+    "quote": "EUR",
+    "display_name": "RAD / Euro",
+    "description": "RAD to Euro spot trading pair",
+    "tags": [
+      "rad",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RAD_USD": {
+    "normalized_id": "RAD/USD",
+    "base": "RAD",
+    "quote": "USD",
+    "display_name": "RAD / US Dollar",
+    "description": "RAD to US Dollar spot trading pair",
+    "tags": [
+      "rad",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RAIIN_EUR": {
+    "normalized_id": "RAIIN/EUR",
+    "base": "RAIIN",
+    "quote": "EUR",
+    "display_name": "RAIIN / Euro",
+    "description": "RAIIN to Euro spot trading pair",
+    "tags": [
+      "raiin",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RAIIN_USD": {
+    "normalized_id": "RAIIN/USD",
+    "base": "RAIIN",
+    "quote": "USD",
+    "display_name": "RAIIN / US Dollar",
+    "description": "RAIIN to US Dollar spot trading pair",
+    "tags": [
+      "raiin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RARE_EUR": {
+    "normalized_id": "RARE/EUR",
+    "base": "RARE",
+    "quote": "EUR",
+    "display_name": "RARE / Euro",
+    "description": "RARE to Euro spot trading pair",
+    "tags": [
+      "rare",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RARE_USD": {
+    "normalized_id": "RARE/USD",
+    "base": "RARE",
+    "quote": "USD",
+    "display_name": "RARE / US Dollar",
+    "description": "RARE to US Dollar spot trading pair",
+    "tags": [
+      "rare",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RARI_EUR": {
+    "normalized_id": "RARI/EUR",
+    "base": "RARI",
+    "quote": "EUR",
+    "display_name": "RARI / Euro",
+    "description": "RARI to Euro spot trading pair",
+    "tags": [
+      "rari",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RARI_USD": {
+    "normalized_id": "RARI/USD",
+    "base": "RARI",
+    "quote": "USD",
+    "display_name": "RARI / US Dollar",
+    "description": "RARI to US Dollar spot trading pair",
+    "tags": [
+      "rari",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RAY_EUR": {
+    "normalized_id": "RAY/EUR",
+    "base": "RAY",
+    "quote": "EUR",
+    "display_name": "RAY / Euro",
+    "description": "RAY to Euro spot trading pair",
+    "tags": [
+      "ray",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RAY_USD": {
+    "normalized_id": "RAY/USD",
+    "base": "RAY",
+    "quote": "USD",
+    "display_name": "RAY / US Dollar",
+    "description": "RAY to US Dollar spot trading pair",
+    "tags": [
+      "ray",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RBC_EUR": {
+    "normalized_id": "RBC/EUR",
+    "base": "RBC",
+    "quote": "EUR",
+    "display_name": "RBC / Euro",
+    "description": "RBC to Euro spot trading pair",
+    "tags": [
+      "rbc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RBC_USD": {
+    "normalized_id": "RBC/USD",
+    "base": "RBC",
+    "quote": "USD",
+    "display_name": "RBC / US Dollar",
+    "description": "RBC to US Dollar spot trading pair",
+    "tags": [
+      "rbc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RED_EUR": {
+    "normalized_id": "RED/EUR",
+    "base": "RED",
+    "quote": "EUR",
+    "display_name": "RED / Euro",
+    "description": "RED to Euro spot trading pair",
+    "tags": [
+      "red",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RED_USD": {
+    "normalized_id": "RED/USD",
+    "base": "RED",
+    "quote": "USD",
+    "display_name": "RED / US Dollar",
+    "description": "RED to US Dollar spot trading pair",
+    "tags": [
+      "red",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RENDER_EUR": {
+    "normalized_id": "RENDER/EUR",
+    "base": "RENDER",
+    "quote": "EUR",
+    "display_name": "RENDER / Euro",
+    "description": "RENDER to Euro spot trading pair",
+    "tags": [
+      "render",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RENDER_USD": {
+    "normalized_id": "RENDER/USD",
+    "base": "RENDER",
+    "quote": "USD",
+    "display_name": "RENDER / US Dollar",
+    "description": "RENDER to US Dollar spot trading pair",
+    "tags": [
+      "render",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "REN_EUR": {
+    "normalized_id": "REN/EUR",
+    "base": "REN",
+    "quote": "EUR",
+    "display_name": "REN / Euro",
+    "description": "REN to Euro spot trading pair",
+    "tags": [
+      "ren",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "REN_USD": {
+    "normalized_id": "REN/USD",
+    "base": "REN",
+    "quote": "USD",
+    "display_name": "REN / US Dollar",
+    "description": "REN to US Dollar spot trading pair",
+    "tags": [
+      "ren",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "REPV2_EUR": {
+    "normalized_id": "REPV2/EUR",
+    "base": "REPV2",
+    "quote": "EUR",
+    "display_name": "REPV2 / Euro",
+    "description": "REPV2 to Euro spot trading pair",
+    "tags": [
+      "repv2",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "REPV2_USD": {
+    "normalized_id": "REPV2/USD",
+    "base": "REPV2",
+    "quote": "USD",
+    "display_name": "REPV2 / US Dollar",
+    "description": "REPV2 to US Dollar spot trading pair",
+    "tags": [
+      "repv2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "REP_USD": {
+    "normalized_id": "REP/USD",
+    "base": "REP",
+    "quote": "USD",
+    "display_name": "REP / US Dollar",
+    "description": "REP to US Dollar spot trading pair",
+    "tags": [
+      "rep",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "REQ_EUR": {
+    "normalized_id": "REQ/EUR",
+    "base": "REQ",
+    "quote": "EUR",
+    "display_name": "REQ / Euro",
+    "description": "REQ to Euro spot trading pair",
+    "tags": [
+      "req",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "REQ_USD": {
+    "normalized_id": "REQ/USD",
+    "base": "REQ",
+    "quote": "USD",
+    "display_name": "REQ / US Dollar",
+    "description": "REQ to US Dollar spot trading pair",
+    "tags": [
+      "req",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RETARDIO_EUR": {
+    "normalized_id": "RETARDIO/EUR",
+    "base": "RETARDIO",
+    "quote": "EUR",
+    "display_name": "RETARDIO / Euro",
+    "description": "RETARDIO to Euro spot trading pair",
+    "tags": [
+      "retardio",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RETARDIO_USD": {
+    "normalized_id": "RETARDIO/USD",
+    "base": "RETARDIO",
+    "quote": "USD",
+    "display_name": "RETARDIO / US Dollar",
+    "description": "RETARDIO to US Dollar spot trading pair",
+    "tags": [
+      "retardio",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "REZ_EUR": {
+    "normalized_id": "REZ/EUR",
+    "base": "REZ",
+    "quote": "EUR",
+    "display_name": "REZ / Euro",
+    "description": "REZ to Euro spot trading pair",
+    "tags": [
+      "rez",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "REZ_USD": {
+    "normalized_id": "REZ/USD",
+    "base": "REZ",
+    "quote": "USD",
+    "display_name": "REZ / US Dollar",
+    "description": "REZ to US Dollar spot trading pair",
+    "tags": [
+      "rez",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RIZE_EUR": {
+    "normalized_id": "RIZE/EUR",
+    "base": "RIZE",
+    "quote": "EUR",
+    "display_name": "RIZE / Euro",
+    "description": "RIZE to Euro spot trading pair",
+    "tags": [
+      "rize",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RIZE_USD": {
+    "normalized_id": "RIZE/USD",
+    "base": "RIZE",
+    "quote": "USD",
+    "display_name": "RIZE / US Dollar",
+    "description": "RIZE to US Dollar spot trading pair",
+    "tags": [
+      "rize",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RLC_EUR": {
+    "normalized_id": "RLC/EUR",
+    "base": "RLC",
+    "quote": "EUR",
+    "display_name": "RLC / Euro",
+    "description": "RLC to Euro spot trading pair",
+    "tags": [
+      "rlc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RLC_USD": {
+    "normalized_id": "RLC/USD",
+    "base": "RLC",
+    "quote": "USD",
+    "display_name": "RLC / US Dollar",
+    "description": "RLC to US Dollar spot trading pair",
+    "tags": [
+      "rlc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RLUSD_USD": {
+    "normalized_id": "RLUSD/USD",
+    "base": "RLUSD",
+    "quote": "USD",
+    "display_name": "RLUSD / US Dollar",
+    "description": "RLUSD to US Dollar spot trading pair",
+    "tags": [
+      "rlusd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RLUSD_USDC": {
+    "normalized_id": "RLUSD/USD",
+    "base": "RLUSD",
+    "quote": "USD",
+    "display_name": "RLUSD / US Dollar",
+    "description": "RLUSD to US Dollar spot trading pair",
+    "tags": [
+      "rlusd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RLUSD_USDT": {
+    "normalized_id": "RLUSD/USD",
+    "base": "RLUSD",
+    "quote": "USD",
+    "display_name": "RLUSD / US Dollar",
+    "description": "RLUSD to US Dollar spot trading pair",
+    "tags": [
+      "rlusd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ROOK_EUR": {
+    "normalized_id": "ROOK/EUR",
+    "base": "ROOK",
+    "quote": "EUR",
+    "display_name": "ROOK / Euro",
+    "description": "ROOK to Euro spot trading pair",
+    "tags": [
+      "rook",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ROOK_USD": {
+    "normalized_id": "ROOK/USD",
+    "base": "ROOK",
+    "quote": "USD",
+    "display_name": "ROOK / US Dollar",
+    "description": "ROOK to US Dollar spot trading pair",
+    "tags": [
+      "rook",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RPL_EUR": {
+    "normalized_id": "RPL/EUR",
+    "base": "RPL",
+    "quote": "EUR",
+    "display_name": "RPL / Euro",
+    "description": "RPL to Euro spot trading pair",
+    "tags": [
+      "rpl",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RPL_USD": {
+    "normalized_id": "RPL/USD",
+    "base": "RPL",
+    "quote": "USD",
+    "display_name": "RPL / US Dollar",
+    "description": "RPL to US Dollar spot trading pair",
+    "tags": [
+      "rpl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RSR_EUR": {
+    "normalized_id": "RSR/EUR",
+    "base": "RSR",
+    "quote": "EUR",
+    "display_name": "RSR / Euro",
+    "description": "RSR to Euro spot trading pair",
+    "tags": [
+      "rsr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RSR_USD": {
+    "normalized_id": "RSR/USD",
+    "base": "RSR",
+    "quote": "USD",
+    "display_name": "RSR / US Dollar",
+    "description": "RSR to US Dollar spot trading pair",
+    "tags": [
+      "rsr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RUJI_EUR": {
+    "normalized_id": "RUJI/EUR",
+    "base": "RUJI",
+    "quote": "EUR",
+    "display_name": "RUJI / Euro",
+    "description": "RUJI to Euro spot trading pair",
+    "tags": [
+      "ruji",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RUJI_USD": {
+    "normalized_id": "RUJI/USD",
+    "base": "RUJI",
+    "quote": "USD",
+    "display_name": "RUJI / US Dollar",
+    "description": "RUJI to US Dollar spot trading pair",
+    "tags": [
+      "ruji",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RUNE_EUR": {
+    "normalized_id": "RUNE/EUR",
+    "base": "RUNE",
+    "quote": "EUR",
+    "display_name": "RUNE / Euro",
+    "description": "RUNE to Euro spot trading pair",
+    "tags": [
+      "rune",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "RUNE_USD": {
+    "normalized_id": "RUNE/USD",
+    "base": "RUNE",
+    "quote": "USD",
+    "display_name": "RUNE / US Dollar",
+    "description": "RUNE to US Dollar spot trading pair",
+    "tags": [
+      "rune",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAFE_EUR": {
+    "normalized_id": "SAFE/EUR",
+    "base": "SAFE",
+    "quote": "EUR",
+    "display_name": "SAFE / Euro",
+    "description": "SAFE to Euro spot trading pair",
+    "tags": [
+      "safe",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SAFE_USD": {
+    "normalized_id": "SAFE/USD",
+    "base": "SAFE",
+    "quote": "USD",
+    "display_name": "SAFE / US Dollar",
+    "description": "SAFE to US Dollar spot trading pair",
+    "tags": [
+      "safe",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAGA_EUR": {
+    "normalized_id": "SAGA/EUR",
+    "base": "SAGA",
+    "quote": "EUR",
+    "display_name": "SAGA / Euro",
+    "description": "SAGA to Euro spot trading pair",
+    "tags": [
+      "saga",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SAGA_USD": {
+    "normalized_id": "SAGA/USD",
+    "base": "SAGA",
+    "quote": "USD",
+    "display_name": "SAGA / US Dollar",
+    "description": "SAGA to US Dollar spot trading pair",
+    "tags": [
+      "saga",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAHARA_EUR": {
+    "normalized_id": "SAHARA/EUR",
+    "base": "SAHARA",
+    "quote": "EUR",
+    "display_name": "SAHARA / Euro",
+    "description": "SAHARA to Euro spot trading pair",
+    "tags": [
+      "sahara",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SAHARA_USD": {
+    "normalized_id": "SAHARA/USD",
+    "base": "SAHARA",
+    "quote": "USD",
+    "display_name": "SAHARA / US Dollar",
+    "description": "SAHARA to US Dollar spot trading pair",
+    "tags": [
+      "sahara",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAMO_EUR": {
+    "normalized_id": "SAMO/EUR",
+    "base": "SAMO",
+    "quote": "EUR",
+    "display_name": "SAMO / Euro",
+    "description": "SAMO to Euro spot trading pair",
+    "tags": [
+      "samo",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SAMO_USD": {
+    "normalized_id": "SAMO/USD",
+    "base": "SAMO",
+    "quote": "USD",
+    "display_name": "SAMO / US Dollar",
+    "description": "SAMO to US Dollar spot trading pair",
+    "tags": [
+      "samo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAND_EUR": {
+    "normalized_id": "SAND/EUR",
+    "base": "SAND",
+    "quote": "EUR",
+    "display_name": "The Sandbox / Euro",
+    "description": "The Sandbox to Euro spot trading pair",
+    "tags": [
+      "sand",
+      "the sandbox",
+      "gaming",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SAND_GBP": {
+    "normalized_id": "SAND/GBP",
+    "base": "SAND",
+    "quote": "GBP",
+    "display_name": "The Sandbox / British Pound",
+    "description": "The Sandbox to British Pound spot trading pair",
+    "tags": [
+      "sand",
+      "the sandbox",
+      "gaming",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "SAND_USD": {
+    "normalized_id": "SAND/USD",
+    "base": "SAND",
+    "quote": "USD",
+    "display_name": "The Sandbox / US Dollar",
+    "description": "The Sandbox to US Dollar spot trading pair",
+    "tags": [
+      "sand",
+      "the sandbox",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAND_XBT": {
+    "normalized_id": "SAND/XBT",
+    "base": "SAND",
+    "quote": "XBT",
+    "display_name": "The Sandbox / XBT",
+    "description": "The Sandbox to XBT spot trading pair",
+    "tags": [
+      "sand",
+      "the sandbox",
+      "gaming",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "SBR_EUR": {
+    "normalized_id": "SBR/EUR",
+    "base": "SBR",
+    "quote": "EUR",
+    "display_name": "SBR / Euro",
+    "description": "SBR to Euro spot trading pair",
+    "tags": [
+      "sbr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SBR_USD": {
+    "normalized_id": "SBR/USD",
+    "base": "SBR",
+    "quote": "USD",
+    "display_name": "SBR / US Dollar",
+    "description": "SBR to US Dollar spot trading pair",
+    "tags": [
+      "sbr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SCRT_EUR": {
+    "normalized_id": "SCRT/EUR",
+    "base": "SCRT",
+    "quote": "EUR",
+    "display_name": "SCRT / Euro",
+    "description": "SCRT to Euro spot trading pair",
+    "tags": [
+      "scrt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SCRT_USD": {
+    "normalized_id": "SCRT/USD",
+    "base": "SCRT",
+    "quote": "USD",
+    "display_name": "SCRT / US Dollar",
+    "description": "SCRT to US Dollar spot trading pair",
+    "tags": [
+      "scrt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SC_EUR": {
+    "normalized_id": "SC/EUR",
+    "base": "SC",
+    "quote": "EUR",
+    "display_name": "SC / Euro",
+    "description": "SC to Euro spot trading pair",
+    "tags": [
+      "sc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SC_USD": {
+    "normalized_id": "SC/USD",
+    "base": "SC",
+    "quote": "USD",
+    "display_name": "SC / US Dollar",
+    "description": "SC to US Dollar spot trading pair",
+    "tags": [
+      "sc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SC_XBT": {
+    "normalized_id": "SC/XBT",
+    "base": "SC",
+    "quote": "XBT",
+    "display_name": "SC / XBT",
+    "description": "SC to XBT spot trading pair",
+    "tags": [
+      "sc",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "SDN_EUR": {
+    "normalized_id": "SDN/EUR",
+    "base": "SDN",
+    "quote": "EUR",
+    "display_name": "SDN / Euro",
+    "description": "SDN to Euro spot trading pair",
+    "tags": [
+      "sdn",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SDN_USD": {
+    "normalized_id": "SDN/USD",
+    "base": "SDN",
+    "quote": "USD",
+    "display_name": "SDN / US Dollar",
+    "description": "SDN to US Dollar spot trading pair",
+    "tags": [
+      "sdn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SEI_EUR": {
+    "normalized_id": "SEI/EUR",
+    "base": "SEI",
+    "quote": "EUR",
+    "display_name": "Sei / Euro",
+    "description": "Sei to Euro spot trading pair",
+    "tags": [
+      "sei",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SEI_USD": {
+    "normalized_id": "SEI/USD",
+    "base": "SEI",
+    "quote": "USD",
+    "display_name": "Sei / US Dollar",
+    "description": "Sei to US Dollar spot trading pair",
+    "tags": [
+      "sei",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SGB_EUR": {
+    "normalized_id": "SGB/EUR",
+    "base": "SGB",
+    "quote": "EUR",
+    "display_name": "SGB / Euro",
+    "description": "SGB to Euro spot trading pair",
+    "tags": [
+      "sgb",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SGB_USD": {
+    "normalized_id": "SGB/USD",
+    "base": "SGB",
+    "quote": "USD",
+    "display_name": "SGB / US Dollar",
+    "description": "SGB to US Dollar spot trading pair",
+    "tags": [
+      "sgb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHIB_EUR": {
+    "normalized_id": "SHIB/EUR",
+    "base": "SHIB",
+    "quote": "EUR",
+    "display_name": "Shiba Inu / Euro",
+    "description": "Shiba Inu to Euro spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SHIB_USD": {
+    "normalized_id": "SHIB/USD",
+    "base": "SHIB",
+    "quote": "USD",
+    "display_name": "Shiba Inu / US Dollar",
+    "description": "Shiba Inu to US Dollar spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHIB_USDC": {
+    "normalized_id": "SHIB/USD",
+    "base": "SHIB",
+    "quote": "USD",
+    "display_name": "Shiba Inu / US Dollar",
+    "description": "Shiba Inu to US Dollar spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHIB_USDT": {
+    "normalized_id": "SHIB/USD",
+    "base": "SHIB",
+    "quote": "USD",
+    "display_name": "Shiba Inu / US Dollar",
+    "description": "Shiba Inu to US Dollar spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SIGMA_EUR": {
+    "normalized_id": "SIGMA/EUR",
+    "base": "SIGMA",
+    "quote": "EUR",
+    "display_name": "SIGMA / Euro",
+    "description": "SIGMA to Euro spot trading pair",
+    "tags": [
+      "sigma",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SIGMA_USD": {
+    "normalized_id": "SIGMA/USD",
+    "base": "SIGMA",
+    "quote": "USD",
+    "display_name": "SIGMA / US Dollar",
+    "description": "SIGMA to US Dollar spot trading pair",
+    "tags": [
+      "sigma",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SKY_EUR": {
+    "normalized_id": "SKY/EUR",
+    "base": "SKY",
+    "quote": "EUR",
+    "display_name": "SKY / Euro",
+    "description": "SKY to Euro spot trading pair",
+    "tags": [
+      "sky",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SKY_USD": {
+    "normalized_id": "SKY/USD",
+    "base": "SKY",
+    "quote": "USD",
+    "display_name": "SKY / US Dollar",
+    "description": "SKY to US Dollar spot trading pair",
+    "tags": [
+      "sky",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SLAY_EUR": {
+    "normalized_id": "SLAY/EUR",
+    "base": "SLAY",
+    "quote": "EUR",
+    "display_name": "SLAY / Euro",
+    "description": "SLAY to Euro spot trading pair",
+    "tags": [
+      "slay",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SLAY_USD": {
+    "normalized_id": "SLAY/USD",
+    "base": "SLAY",
+    "quote": "USD",
+    "display_name": "SLAY / US Dollar",
+    "description": "SLAY to US Dollar spot trading pair",
+    "tags": [
+      "slay",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SNEK_EUR": {
+    "normalized_id": "SNEK/EUR",
+    "base": "SNEK",
+    "quote": "EUR",
+    "display_name": "SNEK / Euro",
+    "description": "SNEK to Euro spot trading pair",
+    "tags": [
+      "snek",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SNEK_USD": {
+    "normalized_id": "SNEK/USD",
+    "base": "SNEK",
+    "quote": "USD",
+    "display_name": "SNEK / US Dollar",
+    "description": "SNEK to US Dollar spot trading pair",
+    "tags": [
+      "snek",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SNX_EUR": {
+    "normalized_id": "SNX/EUR",
+    "base": "SNX",
+    "quote": "EUR",
+    "display_name": "Synthetix / Euro",
+    "description": "Synthetix to Euro spot trading pair",
+    "tags": [
+      "snx",
+      "synthetix",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SNX_USD": {
+    "normalized_id": "SNX/USD",
+    "base": "SNX",
+    "quote": "USD",
+    "display_name": "Synthetix / US Dollar",
+    "description": "Synthetix to US Dollar spot trading pair",
+    "tags": [
+      "snx",
+      "synthetix",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SNX_XBT": {
+    "normalized_id": "SNX/XBT",
+    "base": "SNX",
+    "quote": "XBT",
+    "display_name": "Synthetix / XBT",
+    "description": "Synthetix to XBT spot trading pair",
+    "tags": [
+      "snx",
+      "synthetix",
+      "defi",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "SOGNI_EUR": {
+    "normalized_id": "SOGNI/EUR",
+    "base": "SOGNI",
+    "quote": "EUR",
+    "display_name": "SOGNI / Euro",
+    "description": "SOGNI to Euro spot trading pair",
+    "tags": [
+      "sogni",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SOGNI_USD": {
+    "normalized_id": "SOGNI/USD",
+    "base": "SOGNI",
+    "quote": "USD",
+    "display_name": "SOGNI / US Dollar",
+    "description": "SOGNI to US Dollar spot trading pair",
+    "tags": [
+      "sogni",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOL_AUD": {
+    "normalized_id": "SOL/AUD",
+    "base": "SOL",
+    "quote": "AUD",
+    "display_name": "Solana / Australian Dollar",
+    "description": "Solana to Australian Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "SOL_CAD": {
+    "normalized_id": "SOL/CAD",
+    "base": "SOL",
+    "quote": "CAD",
+    "display_name": "Solana / Canadian Dollar",
+    "description": "Solana to Canadian Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "cad",
+      "fiat",
+      "canadian dollar"
+    ],
+    "category": "crypto"
+  },
+  "SOL_ETH": {
+    "normalized_id": "SOL/ETH",
+    "base": "SOL",
+    "quote": "ETH",
+    "display_name": "Solana / Ethereum",
+    "description": "Solana to Ethereum spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "SOL_EUR": {
+    "normalized_id": "SOL/EUR",
+    "base": "SOL",
+    "quote": "EUR",
+    "display_name": "Solana / Euro",
+    "description": "Solana to Euro spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SOL_GBP": {
+    "normalized_id": "SOL/GBP",
+    "base": "SOL",
+    "quote": "GBP",
+    "display_name": "Solana / British Pound",
+    "description": "Solana to British Pound spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "SOL_USD": {
+    "normalized_id": "SOL/USD",
+    "base": "SOL",
+    "quote": "USD",
+    "display_name": "Solana / US Dollar",
+    "description": "Solana to US Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOL_USDC": {
+    "normalized_id": "SOL/USD",
+    "base": "SOL",
+    "quote": "USD",
+    "display_name": "Solana / US Dollar",
+    "description": "Solana to US Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOL_USDT": {
+    "normalized_id": "SOL/USD",
+    "base": "SOL",
+    "quote": "USD",
+    "display_name": "Solana / US Dollar",
+    "description": "Solana to US Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOL_XBT": {
+    "normalized_id": "SOL/XBT",
+    "base": "SOL",
+    "quote": "XBT",
+    "display_name": "Solana / XBT",
+    "description": "Solana to XBT spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "SONIC_EUR": {
+    "normalized_id": "SONIC/EUR",
+    "base": "SONIC",
+    "quote": "EUR",
+    "display_name": "SONIC / Euro",
+    "description": "SONIC to Euro spot trading pair",
+    "tags": [
+      "sonic",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SONIC_USD": {
+    "normalized_id": "SONIC/USD",
+    "base": "SONIC",
+    "quote": "USD",
+    "display_name": "SONIC / US Dollar",
+    "description": "SONIC to US Dollar spot trading pair",
+    "tags": [
+      "sonic",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOSO_EUR": {
+    "normalized_id": "SOSO/EUR",
+    "base": "SOSO",
+    "quote": "EUR",
+    "display_name": "SOSO / Euro",
+    "description": "SOSO to Euro spot trading pair",
+    "tags": [
+      "soso",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SOSO_USD": {
+    "normalized_id": "SOSO/USD",
+    "base": "SOSO",
+    "quote": "USD",
+    "display_name": "SOSO / US Dollar",
+    "description": "SOSO to US Dollar spot trading pair",
+    "tags": [
+      "soso",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SPELL_EUR": {
+    "normalized_id": "SPELL/EUR",
+    "base": "SPELL",
+    "quote": "EUR",
+    "display_name": "SPELL / Euro",
+    "description": "SPELL to Euro spot trading pair",
+    "tags": [
+      "spell",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SPELL_USD": {
+    "normalized_id": "SPELL/USD",
+    "base": "SPELL",
+    "quote": "USD",
+    "display_name": "SPELL / US Dollar",
+    "description": "SPELL to US Dollar spot trading pair",
+    "tags": [
+      "spell",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SPICE_EUR": {
+    "normalized_id": "SPICE/EUR",
+    "base": "SPICE",
+    "quote": "EUR",
+    "display_name": "SPICE / Euro",
+    "description": "SPICE to Euro spot trading pair",
+    "tags": [
+      "spice",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SPICE_USD": {
+    "normalized_id": "SPICE/USD",
+    "base": "SPICE",
+    "quote": "USD",
+    "display_name": "SPICE / US Dollar",
+    "description": "SPICE to US Dollar spot trading pair",
+    "tags": [
+      "spice",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SPK_EUR": {
+    "normalized_id": "SPK/EUR",
+    "base": "SPK",
+    "quote": "EUR",
+    "display_name": "SPK / Euro",
+    "description": "SPK to Euro spot trading pair",
+    "tags": [
+      "spk",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SPK_USD": {
+    "normalized_id": "SPK/USD",
+    "base": "SPK",
+    "quote": "USD",
+    "display_name": "SPK / US Dollar",
+    "description": "SPK to US Dollar spot trading pair",
+    "tags": [
+      "spk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SPX_EUR": {
+    "normalized_id": "SPX/EUR",
+    "base": "SPX",
+    "quote": "EUR",
+    "display_name": "SPX / Euro",
+    "description": "SPX to Euro spot trading pair",
+    "tags": [
+      "spx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SPX_USD": {
+    "normalized_id": "SPX/USD",
+    "base": "SPX",
+    "quote": "USD",
+    "display_name": "SPX / US Dollar",
+    "description": "SPX to US Dollar spot trading pair",
+    "tags": [
+      "spx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SRM_EUR": {
+    "normalized_id": "SRM/EUR",
+    "base": "SRM",
+    "quote": "EUR",
+    "display_name": "SRM / Euro",
+    "description": "SRM to Euro spot trading pair",
+    "tags": [
+      "srm",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SRM_USD": {
+    "normalized_id": "SRM/USD",
+    "base": "SRM",
+    "quote": "USD",
+    "display_name": "SRM / US Dollar",
+    "description": "SRM to US Dollar spot trading pair",
+    "tags": [
+      "srm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SSV_EUR": {
+    "normalized_id": "SSV/EUR",
+    "base": "SSV",
+    "quote": "EUR",
+    "display_name": "SSV / Euro",
+    "description": "SSV to Euro spot trading pair",
+    "tags": [
+      "ssv",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SSV_USD": {
+    "normalized_id": "SSV/USD",
+    "base": "SSV",
+    "quote": "USD",
+    "display_name": "SSV / US Dollar",
+    "description": "SSV to US Dollar spot trading pair",
+    "tags": [
+      "ssv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STEP_EUR": {
+    "normalized_id": "STEP/EUR",
+    "base": "STEP",
+    "quote": "EUR",
+    "display_name": "STEP / Euro",
+    "description": "STEP to Euro spot trading pair",
+    "tags": [
+      "step",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "STEP_USD": {
+    "normalized_id": "STEP/USD",
+    "base": "STEP",
+    "quote": "USD",
+    "display_name": "STEP / US Dollar",
+    "description": "STEP to US Dollar spot trading pair",
+    "tags": [
+      "step",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STG_EUR": {
+    "normalized_id": "STG/EUR",
+    "base": "STG",
+    "quote": "EUR",
+    "display_name": "STG / Euro",
+    "description": "STG to Euro spot trading pair",
+    "tags": [
+      "stg",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "STG_USD": {
+    "normalized_id": "STG/USD",
+    "base": "STG",
+    "quote": "USD",
+    "display_name": "STG / US Dollar",
+    "description": "STG to US Dollar spot trading pair",
+    "tags": [
+      "stg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STORJ_EUR": {
+    "normalized_id": "STORJ/EUR",
+    "base": "STORJ",
+    "quote": "EUR",
+    "display_name": "STORJ / Euro",
+    "description": "STORJ to Euro spot trading pair",
+    "tags": [
+      "storj",
+      "storage",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "STORJ_USD": {
+    "normalized_id": "STORJ/USD",
+    "base": "STORJ",
+    "quote": "USD",
+    "display_name": "STORJ / US Dollar",
+    "description": "STORJ to US Dollar spot trading pair",
+    "tags": [
+      "storj",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STRD_EUR": {
+    "normalized_id": "STRD/EUR",
+    "base": "STRD",
+    "quote": "EUR",
+    "display_name": "STRD / Euro",
+    "description": "STRD to Euro spot trading pair",
+    "tags": [
+      "strd",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "STRD_USD": {
+    "normalized_id": "STRD/USD",
+    "base": "STRD",
+    "quote": "USD",
+    "display_name": "STRD / US Dollar",
+    "description": "STRD to US Dollar spot trading pair",
+    "tags": [
+      "strd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STRK_EUR": {
+    "normalized_id": "STRK/EUR",
+    "base": "STRK",
+    "quote": "EUR",
+    "display_name": "STRK / Euro",
+    "description": "STRK to Euro spot trading pair",
+    "tags": [
+      "strk",
+      "layer2",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "STRK_USD": {
+    "normalized_id": "STRK/USD",
+    "base": "STRK",
+    "quote": "USD",
+    "display_name": "STRK / US Dollar",
+    "description": "STRK to US Dollar spot trading pair",
+    "tags": [
+      "strk",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STX_EUR": {
+    "normalized_id": "STX/EUR",
+    "base": "STX",
+    "quote": "EUR",
+    "display_name": "STX / Euro",
+    "description": "STX to Euro spot trading pair",
+    "tags": [
+      "stx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "STX_USD": {
+    "normalized_id": "STX/USD",
+    "base": "STX",
+    "quote": "USD",
+    "display_name": "STX / US Dollar",
+    "description": "STX to US Dollar spot trading pair",
+    "tags": [
+      "stx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUI_EUR": {
+    "normalized_id": "SUI/EUR",
+    "base": "SUI",
+    "quote": "EUR",
+    "display_name": "Sui / Euro",
+    "description": "Sui to Euro spot trading pair",
+    "tags": [
+      "sui",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SUI_GBP": {
+    "normalized_id": "SUI/GBP",
+    "base": "SUI",
+    "quote": "GBP",
+    "display_name": "Sui / British Pound",
+    "description": "Sui to British Pound spot trading pair",
+    "tags": [
+      "sui",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "SUI_USD": {
+    "normalized_id": "SUI/USD",
+    "base": "SUI",
+    "quote": "USD",
+    "display_name": "Sui / US Dollar",
+    "description": "Sui to US Dollar spot trading pair",
+    "tags": [
+      "sui",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUNDOG_EUR": {
+    "normalized_id": "SUNDOG/EUR",
+    "base": "SUNDOG",
+    "quote": "EUR",
+    "display_name": "SUNDOG / Euro",
+    "description": "SUNDOG to Euro spot trading pair",
+    "tags": [
+      "sundog",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SUNDOG_USD": {
+    "normalized_id": "SUNDOG/USD",
+    "base": "SUNDOG",
+    "quote": "USD",
+    "display_name": "SUNDOG / US Dollar",
+    "description": "SUNDOG to US Dollar spot trading pair",
+    "tags": [
+      "sundog",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUN_EUR": {
+    "normalized_id": "SUN/EUR",
+    "base": "SUN",
+    "quote": "EUR",
+    "display_name": "SUN / Euro",
+    "description": "SUN to Euro spot trading pair",
+    "tags": [
+      "sun",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SUN_USD": {
+    "normalized_id": "SUN/USD",
+    "base": "SUN",
+    "quote": "USD",
+    "display_name": "SUN / US Dollar",
+    "description": "SUN to US Dollar spot trading pair",
+    "tags": [
+      "sun",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUPER_EUR": {
+    "normalized_id": "SUPER/EUR",
+    "base": "SUPER",
+    "quote": "EUR",
+    "display_name": "SUPER / Euro",
+    "description": "SUPER to Euro spot trading pair",
+    "tags": [
+      "super",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SUPER_USD": {
+    "normalized_id": "SUPER/USD",
+    "base": "SUPER",
+    "quote": "USD",
+    "display_name": "SUPER / US Dollar",
+    "description": "SUPER to US Dollar spot trading pair",
+    "tags": [
+      "super",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUSHI_EUR": {
+    "normalized_id": "SUSHI/EUR",
+    "base": "SUSHI",
+    "quote": "EUR",
+    "display_name": "SUSHI / Euro",
+    "description": "SUSHI to Euro spot trading pair",
+    "tags": [
+      "sushi",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SUSHI_USD": {
+    "normalized_id": "SUSHI/USD",
+    "base": "SUSHI",
+    "quote": "USD",
+    "display_name": "SUSHI / US Dollar",
+    "description": "SUSHI to US Dollar spot trading pair",
+    "tags": [
+      "sushi",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SWARMS_EUR": {
+    "normalized_id": "SWARMS/EUR",
+    "base": "SWARMS",
+    "quote": "EUR",
+    "display_name": "SWARMS / Euro",
+    "description": "SWARMS to Euro spot trading pair",
+    "tags": [
+      "swarms",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SWARMS_USD": {
+    "normalized_id": "SWARMS/USD",
+    "base": "SWARMS",
+    "quote": "USD",
+    "display_name": "SWARMS / US Dollar",
+    "description": "SWARMS to US Dollar spot trading pair",
+    "tags": [
+      "swarms",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SWEAT_EUR": {
+    "normalized_id": "SWEAT/EUR",
+    "base": "SWEAT",
+    "quote": "EUR",
+    "display_name": "SWEAT / Euro",
+    "description": "SWEAT to Euro spot trading pair",
+    "tags": [
+      "sweat",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SWEAT_USD": {
+    "normalized_id": "SWEAT/USD",
+    "base": "SWEAT",
+    "quote": "USD",
+    "display_name": "SWEAT / US Dollar",
+    "description": "SWEAT to US Dollar spot trading pair",
+    "tags": [
+      "sweat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SWELL_EUR": {
+    "normalized_id": "SWELL/EUR",
+    "base": "SWELL",
+    "quote": "EUR",
+    "display_name": "SWELL / Euro",
+    "description": "SWELL to Euro spot trading pair",
+    "tags": [
+      "swell",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SWELL_USD": {
+    "normalized_id": "SWELL/USD",
+    "base": "SWELL",
+    "quote": "USD",
+    "display_name": "SWELL / US Dollar",
+    "description": "SWELL to US Dollar spot trading pair",
+    "tags": [
+      "swell",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SXT_EUR": {
+    "normalized_id": "SXT/EUR",
+    "base": "SXT",
+    "quote": "EUR",
+    "display_name": "SXT / Euro",
+    "description": "SXT to Euro spot trading pair",
+    "tags": [
+      "sxt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SXT_USD": {
+    "normalized_id": "SXT/USD",
+    "base": "SXT",
+    "quote": "USD",
+    "display_name": "SXT / US Dollar",
+    "description": "SXT to US Dollar spot trading pair",
+    "tags": [
+      "sxt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SYN_EUR": {
+    "normalized_id": "SYN/EUR",
+    "base": "SYN",
+    "quote": "EUR",
+    "display_name": "SYN / Euro",
+    "description": "SYN to Euro spot trading pair",
+    "tags": [
+      "syn",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SYN_USD": {
+    "normalized_id": "SYN/USD",
+    "base": "SYN",
+    "quote": "USD",
+    "display_name": "SYN / US Dollar",
+    "description": "SYN to US Dollar spot trading pair",
+    "tags": [
+      "syn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SYRUP_EUR": {
+    "normalized_id": "SYRUP/EUR",
+    "base": "SYRUP",
+    "quote": "EUR",
+    "display_name": "SYRUP / Euro",
+    "description": "SYRUP to Euro spot trading pair",
+    "tags": [
+      "syrup",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SYRUP_USD": {
+    "normalized_id": "SYRUP/USD",
+    "base": "SYRUP",
+    "quote": "USD",
+    "display_name": "SYRUP / US Dollar",
+    "description": "SYRUP to US Dollar spot trading pair",
+    "tags": [
+      "syrup",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "S_EUR": {
+    "normalized_id": "S/EUR",
+    "base": "S",
+    "quote": "EUR",
+    "display_name": "S / Euro",
+    "description": "S to Euro spot trading pair",
+    "tags": [
+      "s",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "S_USD": {
+    "normalized_id": "S/USD",
+    "base": "S",
+    "quote": "USD",
+    "display_name": "S / US Dollar",
+    "description": "S to US Dollar spot trading pair",
+    "tags": [
+      "s",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "S_USDC": {
+    "normalized_id": "S/USD",
+    "base": "S",
+    "quote": "USD",
+    "display_name": "S / US Dollar",
+    "description": "S to US Dollar spot trading pair",
+    "tags": [
+      "s",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "S_USDT": {
+    "normalized_id": "S/USD",
+    "base": "S",
+    "quote": "USD",
+    "display_name": "S / US Dollar",
+    "description": "S to US Dollar spot trading pair",
+    "tags": [
+      "s",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TAC_EUR": {
+    "normalized_id": "TAC/EUR",
+    "base": "TAC",
+    "quote": "EUR",
+    "display_name": "TAC / Euro",
+    "description": "TAC to Euro spot trading pair",
+    "tags": [
+      "tac",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TAC_USD": {
+    "normalized_id": "TAC/USD",
+    "base": "TAC",
+    "quote": "USD",
+    "display_name": "TAC / US Dollar",
+    "description": "TAC to US Dollar spot trading pair",
+    "tags": [
+      "tac",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TANSSI_EUR": {
+    "normalized_id": "TANSSI/EUR",
+    "base": "TANSSI",
+    "quote": "EUR",
+    "display_name": "TANSSI / Euro",
+    "description": "TANSSI to Euro spot trading pair",
+    "tags": [
+      "tanssi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TANSSI_USD": {
+    "normalized_id": "TANSSI/USD",
+    "base": "TANSSI",
+    "quote": "USD",
+    "display_name": "TANSSI / US Dollar",
+    "description": "TANSSI to US Dollar spot trading pair",
+    "tags": [
+      "tanssi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TAO_EUR": {
+    "normalized_id": "TAO/EUR",
+    "base": "TAO",
+    "quote": "EUR",
+    "display_name": "TAO / Euro",
+    "description": "TAO to Euro spot trading pair",
+    "tags": [
+      "tao",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TAO_USD": {
+    "normalized_id": "TAO/USD",
+    "base": "TAO",
+    "quote": "USD",
+    "display_name": "TAO / US Dollar",
+    "description": "TAO to US Dollar spot trading pair",
+    "tags": [
+      "tao",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TBTC_EUR": {
+    "normalized_id": "TBTC/EUR",
+    "base": "TBTC",
+    "quote": "EUR",
+    "display_name": "TBTC / Euro",
+    "description": "TBTC to Euro spot trading pair",
+    "tags": [
+      "tbtc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TBTC_USD": {
+    "normalized_id": "TBTC/USD",
+    "base": "TBTC",
+    "quote": "USD",
+    "display_name": "TBTC / US Dollar",
+    "description": "TBTC to US Dollar spot trading pair",
+    "tags": [
+      "tbtc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TBTC_XBT": {
+    "normalized_id": "TBTC/XBT",
+    "base": "TBTC",
+    "quote": "XBT",
+    "display_name": "TBTC / XBT",
+    "description": "TBTC to XBT spot trading pair",
+    "tags": [
+      "tbtc",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "TEER_EUR": {
+    "normalized_id": "TEER/EUR",
+    "base": "TEER",
+    "quote": "EUR",
+    "display_name": "TEER / Euro",
+    "description": "TEER to Euro spot trading pair",
+    "tags": [
+      "teer",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TEER_USD": {
+    "normalized_id": "TEER/USD",
+    "base": "TEER",
+    "quote": "USD",
+    "display_name": "TEER / US Dollar",
+    "description": "TEER to US Dollar spot trading pair",
+    "tags": [
+      "teer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TERM_EUR": {
+    "normalized_id": "TERM/EUR",
+    "base": "TERM",
+    "quote": "EUR",
+    "display_name": "TERM / Euro",
+    "description": "TERM to Euro spot trading pair",
+    "tags": [
+      "term",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TERM_USD": {
+    "normalized_id": "TERM/USD",
+    "base": "TERM",
+    "quote": "USD",
+    "display_name": "TERM / US Dollar",
+    "description": "TERM to US Dollar spot trading pair",
+    "tags": [
+      "term",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TIA_EUR": {
+    "normalized_id": "TIA/EUR",
+    "base": "TIA",
+    "quote": "EUR",
+    "display_name": "Celestia / Euro",
+    "description": "Celestia to Euro spot trading pair",
+    "tags": [
+      "tia",
+      "celestia",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TIA_USD": {
+    "normalized_id": "TIA/USD",
+    "base": "TIA",
+    "quote": "USD",
+    "display_name": "Celestia / US Dollar",
+    "description": "Celestia to US Dollar spot trading pair",
+    "tags": [
+      "tia",
+      "celestia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TITCOIN_EUR": {
+    "normalized_id": "TITCOIN/EUR",
+    "base": "TITCOIN",
+    "quote": "EUR",
+    "display_name": "TITCOIN / Euro",
+    "description": "TITCOIN to Euro spot trading pair",
+    "tags": [
+      "titcoin",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TITCOIN_USD": {
+    "normalized_id": "TITCOIN/USD",
+    "base": "TITCOIN",
+    "quote": "USD",
+    "display_name": "TITCOIN / US Dollar",
+    "description": "TITCOIN to US Dollar spot trading pair",
+    "tags": [
+      "titcoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TLM_EUR": {
+    "normalized_id": "TLM/EUR",
+    "base": "TLM",
+    "quote": "EUR",
+    "display_name": "TLM / Euro",
+    "description": "TLM to Euro spot trading pair",
+    "tags": [
+      "tlm",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TLM_USD": {
+    "normalized_id": "TLM/USD",
+    "base": "TLM",
+    "quote": "USD",
+    "display_name": "TLM / US Dollar",
+    "description": "TLM to US Dollar spot trading pair",
+    "tags": [
+      "tlm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TNSR_EUR": {
+    "normalized_id": "TNSR/EUR",
+    "base": "TNSR",
+    "quote": "EUR",
+    "display_name": "TNSR / Euro",
+    "description": "TNSR to Euro spot trading pair",
+    "tags": [
+      "tnsr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TNSR_USD": {
+    "normalized_id": "TNSR/USD",
+    "base": "TNSR",
+    "quote": "USD",
+    "display_name": "TNSR / US Dollar",
+    "description": "TNSR to US Dollar spot trading pair",
+    "tags": [
+      "tnsr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TOKEN_EUR": {
+    "normalized_id": "TOKEN/EUR",
+    "base": "TOKEN",
+    "quote": "EUR",
+    "display_name": "TOKEN / Euro",
+    "description": "TOKEN to Euro spot trading pair",
+    "tags": [
+      "token",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TOKEN_USD": {
+    "normalized_id": "TOKEN/USD",
+    "base": "TOKEN",
+    "quote": "USD",
+    "display_name": "TOKEN / US Dollar",
+    "description": "TOKEN to US Dollar spot trading pair",
+    "tags": [
+      "token",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TOKE_EUR": {
+    "normalized_id": "TOKE/EUR",
+    "base": "TOKE",
+    "quote": "EUR",
+    "display_name": "TOKE / Euro",
+    "description": "TOKE to Euro spot trading pair",
+    "tags": [
+      "toke",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TOKE_USD": {
+    "normalized_id": "TOKE/USD",
+    "base": "TOKE",
+    "quote": "USD",
+    "display_name": "TOKE / US Dollar",
+    "description": "TOKE to US Dollar spot trading pair",
+    "tags": [
+      "toke",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TON_EUR": {
+    "normalized_id": "TON/EUR",
+    "base": "TON",
+    "quote": "EUR",
+    "display_name": "Toncoin / Euro",
+    "description": "Toncoin to Euro spot trading pair",
+    "tags": [
+      "ton",
+      "toncoin",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TON_USD": {
+    "normalized_id": "TON/USD",
+    "base": "TON",
+    "quote": "USD",
+    "display_name": "Toncoin / US Dollar",
+    "description": "Toncoin to US Dollar spot trading pair",
+    "tags": [
+      "ton",
+      "toncoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TON_USDC": {
+    "normalized_id": "TON/USD",
+    "base": "TON",
+    "quote": "USD",
+    "display_name": "Toncoin / US Dollar",
+    "description": "Toncoin to US Dollar spot trading pair",
+    "tags": [
+      "ton",
+      "toncoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TON_USDT": {
+    "normalized_id": "TON/USD",
+    "base": "TON",
+    "quote": "USD",
+    "display_name": "Toncoin / US Dollar",
+    "description": "Toncoin to US Dollar spot trading pair",
+    "tags": [
+      "ton",
+      "toncoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TOSHI_EUR": {
+    "normalized_id": "TOSHI/EUR",
+    "base": "TOSHI",
+    "quote": "EUR",
+    "display_name": "TOSHI / Euro",
+    "description": "TOSHI to Euro spot trading pair",
+    "tags": [
+      "toshi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TOSHI_USD": {
+    "normalized_id": "TOSHI/USD",
+    "base": "TOSHI",
+    "quote": "USD",
+    "display_name": "TOSHI / US Dollar",
+    "description": "TOSHI to US Dollar spot trading pair",
+    "tags": [
+      "toshi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRAC_EUR": {
+    "normalized_id": "TRAC/EUR",
+    "base": "TRAC",
+    "quote": "EUR",
+    "display_name": "TRAC / Euro",
+    "description": "TRAC to Euro spot trading pair",
+    "tags": [
+      "trac",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TRAC_USD": {
+    "normalized_id": "TRAC/USD",
+    "base": "TRAC",
+    "quote": "USD",
+    "display_name": "TRAC / US Dollar",
+    "description": "TRAC to US Dollar spot trading pair",
+    "tags": [
+      "trac",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TREE_EUR": {
+    "normalized_id": "TREE/EUR",
+    "base": "TREE",
+    "quote": "EUR",
+    "display_name": "TREE / Euro",
+    "description": "TREE to Euro spot trading pair",
+    "tags": [
+      "tree",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TREE_USD": {
+    "normalized_id": "TREE/USD",
+    "base": "TREE",
+    "quote": "USD",
+    "display_name": "TREE / US Dollar",
+    "description": "TREE to US Dollar spot trading pair",
+    "tags": [
+      "tree",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TREMP_EUR": {
+    "normalized_id": "TREMP/EUR",
+    "base": "TREMP",
+    "quote": "EUR",
+    "display_name": "TREMP / Euro",
+    "description": "TREMP to Euro spot trading pair",
+    "tags": [
+      "tremp",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TREMP_USD": {
+    "normalized_id": "TREMP/USD",
+    "base": "TREMP",
+    "quote": "USD",
+    "display_name": "TREMP / US Dollar",
+    "description": "TREMP to US Dollar spot trading pair",
+    "tags": [
+      "tremp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRUMP_EUR": {
+    "normalized_id": "TRUMP/EUR",
+    "base": "TRUMP",
+    "quote": "EUR",
+    "display_name": "TRUMP / Euro",
+    "description": "TRUMP to Euro spot trading pair",
+    "tags": [
+      "trump",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TRUMP_USD": {
+    "normalized_id": "TRUMP/USD",
+    "base": "TRUMP",
+    "quote": "USD",
+    "display_name": "TRUMP / US Dollar",
+    "description": "TRUMP to US Dollar spot trading pair",
+    "tags": [
+      "trump",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRUMP_USDC": {
+    "normalized_id": "TRUMP/USD",
+    "base": "TRUMP",
+    "quote": "USD",
+    "display_name": "TRUMP / US Dollar",
+    "description": "TRUMP to US Dollar spot trading pair",
+    "tags": [
+      "trump",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRUMP_USDT": {
+    "normalized_id": "TRUMP/USD",
+    "base": "TRUMP",
+    "quote": "USD",
+    "display_name": "TRUMP / US Dollar",
+    "description": "TRUMP to US Dollar spot trading pair",
+    "tags": [
+      "trump",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRU_EUR": {
+    "normalized_id": "TRU/EUR",
+    "base": "TRU",
+    "quote": "EUR",
+    "display_name": "TRU / Euro",
+    "description": "TRU to Euro spot trading pair",
+    "tags": [
+      "tru",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TRU_USD": {
+    "normalized_id": "TRU/USD",
+    "base": "TRU",
+    "quote": "USD",
+    "display_name": "TRU / US Dollar",
+    "description": "TRU to US Dollar spot trading pair",
+    "tags": [
+      "tru",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRX_ETH": {
+    "normalized_id": "TRX/ETH",
+    "base": "TRX",
+    "quote": "ETH",
+    "display_name": "TRON / Ethereum",
+    "description": "TRON to Ethereum spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "TRX_EUR": {
+    "normalized_id": "TRX/EUR",
+    "base": "TRX",
+    "quote": "EUR",
+    "display_name": "TRON / Euro",
+    "description": "TRON to Euro spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TRX_USD": {
+    "normalized_id": "TRX/USD",
+    "base": "TRX",
+    "quote": "USD",
+    "display_name": "TRON / US Dollar",
+    "description": "TRON to US Dollar spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRX_USDD": {
+    "normalized_id": "TRX/USDD",
+    "base": "TRX",
+    "quote": "USDD",
+    "display_name": "TRON / USDD",
+    "description": "TRON to USDD spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "usdd"
+    ],
+    "category": "crypto"
+  },
+  "TRX_XBT": {
+    "normalized_id": "TRX/XBT",
+    "base": "TRX",
+    "quote": "XBT",
+    "display_name": "TRON / XBT",
+    "description": "TRON to XBT spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "TURBO_EUR": {
+    "normalized_id": "TURBO/EUR",
+    "base": "TURBO",
+    "quote": "EUR",
+    "display_name": "TURBO / Euro",
+    "description": "TURBO to Euro spot trading pair",
+    "tags": [
+      "turbo",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TURBO_USD": {
+    "normalized_id": "TURBO/USD",
+    "base": "TURBO",
+    "quote": "USD",
+    "display_name": "TURBO / US Dollar",
+    "description": "TURBO to US Dollar spot trading pair",
+    "tags": [
+      "turbo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TUSD_EUR": {
+    "normalized_id": "TUSD/EUR",
+    "base": "TUSD",
+    "quote": "EUR",
+    "display_name": "TUSD / Euro",
+    "description": "TUSD to Euro spot trading pair",
+    "tags": [
+      "tusd",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TUSD_USD": {
+    "normalized_id": "TUSD/USD",
+    "base": "TUSD",
+    "quote": "USD",
+    "display_name": "TUSD / US Dollar",
+    "description": "TUSD to US Dollar spot trading pair",
+    "tags": [
+      "tusd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TVK_EUR": {
+    "normalized_id": "TVK/EUR",
+    "base": "TVK",
+    "quote": "EUR",
+    "display_name": "TVK / Euro",
+    "description": "TVK to Euro spot trading pair",
+    "tags": [
+      "tvk",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TVK_USD": {
+    "normalized_id": "TVK/USD",
+    "base": "TVK",
+    "quote": "USD",
+    "display_name": "TVK / US Dollar",
+    "description": "TVK to US Dollar spot trading pair",
+    "tags": [
+      "tvk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "T_EUR": {
+    "normalized_id": "T/EUR",
+    "base": "T",
+    "quote": "EUR",
+    "display_name": "T / Euro",
+    "description": "T to Euro spot trading pair",
+    "tags": [
+      "t",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "T_USD": {
+    "normalized_id": "T/USD",
+    "base": "T",
+    "quote": "USD",
+    "display_name": "T / US Dollar",
+    "description": "T to US Dollar spot trading pair",
+    "tags": [
+      "t",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UFD_EUR": {
+    "normalized_id": "UFD/EUR",
+    "base": "UFD",
+    "quote": "EUR",
+    "display_name": "UFD / Euro",
+    "description": "UFD to Euro spot trading pair",
+    "tags": [
+      "ufd",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "UFD_USD": {
+    "normalized_id": "UFD/USD",
+    "base": "UFD",
+    "quote": "USD",
+    "display_name": "UFD / US Dollar",
+    "description": "UFD to US Dollar spot trading pair",
+    "tags": [
+      "ufd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UMA_EUR": {
+    "normalized_id": "UMA/EUR",
+    "base": "UMA",
+    "quote": "EUR",
+    "display_name": "UMA / Euro",
+    "description": "UMA to Euro spot trading pair",
+    "tags": [
+      "uma",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "UMA_USD": {
+    "normalized_id": "UMA/USD",
+    "base": "UMA",
+    "quote": "USD",
+    "display_name": "UMA / US Dollar",
+    "description": "UMA to US Dollar spot trading pair",
+    "tags": [
+      "uma",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UNFI_EUR": {
+    "normalized_id": "UNFI/EUR",
+    "base": "UNFI",
+    "quote": "EUR",
+    "display_name": "UNFI / Euro",
+    "description": "UNFI to Euro spot trading pair",
+    "tags": [
+      "unfi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "UNFI_USD": {
+    "normalized_id": "UNFI/USD",
+    "base": "UNFI",
+    "quote": "USD",
+    "display_name": "UNFI / US Dollar",
+    "description": "UNFI to US Dollar spot trading pair",
+    "tags": [
+      "unfi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UNITE_EUR": {
+    "normalized_id": "UNITE/EUR",
+    "base": "UNITE",
+    "quote": "EUR",
+    "display_name": "UNITE / Euro",
+    "description": "UNITE to Euro spot trading pair",
+    "tags": [
+      "unite",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "UNITE_USD": {
+    "normalized_id": "UNITE/USD",
+    "base": "UNITE",
+    "quote": "USD",
+    "display_name": "UNITE / US Dollar",
+    "description": "UNITE to US Dollar spot trading pair",
+    "tags": [
+      "unite",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UNI_ETH": {
+    "normalized_id": "UNI/ETH",
+    "base": "UNI",
+    "quote": "ETH",
+    "display_name": "Uniswap / Ethereum",
+    "description": "Uniswap to Ethereum spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "UNI_EUR": {
+    "normalized_id": "UNI/EUR",
+    "base": "UNI",
+    "quote": "EUR",
+    "display_name": "Uniswap / Euro",
+    "description": "Uniswap to Euro spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "UNI_USD": {
+    "normalized_id": "UNI/USD",
+    "base": "UNI",
+    "quote": "USD",
+    "display_name": "Uniswap / US Dollar",
+    "description": "Uniswap to US Dollar spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UNI_XBT": {
+    "normalized_id": "UNI/XBT",
+    "base": "UNI",
+    "quote": "XBT",
+    "display_name": "Uniswap / XBT",
+    "description": "Uniswap to XBT spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "USDC_AUD": {
+    "normalized_id": "USDC/AUD",
+    "base": "USDC",
+    "quote": "AUD",
+    "display_name": "USD Coin / Australian Dollar",
+    "description": "USD Coin to Australian Dollar spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "USDC_CAD": {
+    "normalized_id": "USDC/CAD",
+    "base": "USDC",
+    "quote": "CAD",
+    "display_name": "USD Coin / Canadian Dollar",
+    "description": "USD Coin to Canadian Dollar spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "cad",
+      "fiat",
+      "canadian dollar"
+    ],
+    "category": "crypto"
+  },
+  "USDC_CHF": {
+    "normalized_id": "USDC/CHF",
+    "base": "USDC",
+    "quote": "CHF",
+    "display_name": "USD Coin / Swiss Franc",
+    "description": "USD Coin to Swiss Franc spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "chf"
+    ],
+    "category": "crypto"
+  },
+  "USDC_EUR": {
+    "normalized_id": "USDC/EUR",
+    "base": "USDC",
+    "quote": "EUR",
+    "display_name": "USD Coin / Euro",
+    "description": "USD Coin to Euro spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "USDC_GBP": {
+    "normalized_id": "USDC/GBP",
+    "base": "USDC",
+    "quote": "GBP",
+    "display_name": "USD Coin / British Pound",
+    "description": "USD Coin to British Pound spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "USDC_USD": {
+    "normalized_id": "USDC/USD",
+    "base": "USDC",
+    "quote": "USD",
+    "display_name": "USD Coin / US Dollar",
+    "description": "USD Coin to US Dollar spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDC_USDT": {
+    "normalized_id": "USDC/USD",
+    "base": "USDC",
+    "quote": "USD",
+    "display_name": "USD Coin / US Dollar",
+    "description": "USD Coin to US Dollar spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDD_EUR": {
+    "normalized_id": "USDD/EUR",
+    "base": "USDD",
+    "quote": "EUR",
+    "display_name": "USDD / Euro",
+    "description": "USDD to Euro spot trading pair",
+    "tags": [
+      "usdd",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "USDD_USD": {
+    "normalized_id": "USDD/USD",
+    "base": "USDD",
+    "quote": "USD",
+    "display_name": "USDD / US Dollar",
+    "description": "USDD to US Dollar spot trading pair",
+    "tags": [
+      "usdd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDG_USD": {
+    "normalized_id": "USDG/USD",
+    "base": "USDG",
+    "quote": "USD",
+    "display_name": "USDG / US Dollar",
+    "description": "USDG to US Dollar spot trading pair",
+    "tags": [
+      "usdg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDG_USDC": {
+    "normalized_id": "USDG/USD",
+    "base": "USDG",
+    "quote": "USD",
+    "display_name": "USDG / US Dollar",
+    "description": "USDG to US Dollar spot trading pair",
+    "tags": [
+      "usdg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDG_USDT": {
+    "normalized_id": "USDG/USD",
+    "base": "USDG",
+    "quote": "USD",
+    "display_name": "USDG / US Dollar",
+    "description": "USDG to US Dollar spot trading pair",
+    "tags": [
+      "usdg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDQ_EUR": {
+    "normalized_id": "USDQ/EUR",
+    "base": "USDQ",
+    "quote": "EUR",
+    "display_name": "USDQ / Euro",
+    "description": "USDQ to Euro spot trading pair",
+    "tags": [
+      "usdq",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "USDQ_USD": {
+    "normalized_id": "USDQ/USD",
+    "base": "USDQ",
+    "quote": "USD",
+    "display_name": "USDQ / US Dollar",
+    "description": "USDQ to US Dollar spot trading pair",
+    "tags": [
+      "usdq",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDQ_USDC": {
+    "normalized_id": "USDQ/USD",
+    "base": "USDQ",
+    "quote": "USD",
+    "display_name": "USDQ / US Dollar",
+    "description": "USDQ to US Dollar spot trading pair",
+    "tags": [
+      "usdq",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDQ_USDT": {
+    "normalized_id": "USDQ/USD",
+    "base": "USDQ",
+    "quote": "USD",
+    "display_name": "USDQ / US Dollar",
+    "description": "USDQ to US Dollar spot trading pair",
+    "tags": [
+      "usdq",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDR_EUR": {
+    "normalized_id": "USDR/EUR",
+    "base": "USDR",
+    "quote": "EUR",
+    "display_name": "USDR / Euro",
+    "description": "USDR to Euro spot trading pair",
+    "tags": [
+      "usdr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "USDR_USD": {
+    "normalized_id": "USDR/USD",
+    "base": "USDR",
+    "quote": "USD",
+    "display_name": "USDR / US Dollar",
+    "description": "USDR to US Dollar spot trading pair",
+    "tags": [
+      "usdr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDR_USDC": {
+    "normalized_id": "USDR/USD",
+    "base": "USDR",
+    "quote": "USD",
+    "display_name": "USDR / US Dollar",
+    "description": "USDR to US Dollar spot trading pair",
+    "tags": [
+      "usdr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDR_USDT": {
+    "normalized_id": "USDR/USD",
+    "base": "USDR",
+    "quote": "USD",
+    "display_name": "USDR / US Dollar",
+    "description": "USDR to US Dollar spot trading pair",
+    "tags": [
+      "usdr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDS_EUR": {
+    "normalized_id": "USDS/EUR",
+    "base": "USDS",
+    "quote": "EUR",
+    "display_name": "USDS / Euro",
+    "description": "USDS to Euro spot trading pair",
+    "tags": [
+      "usds",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "USDS_USD": {
+    "normalized_id": "USDS/USD",
+    "base": "USDS",
+    "quote": "USD",
+    "display_name": "USDS / US Dollar",
+    "description": "USDS to US Dollar spot trading pair",
+    "tags": [
+      "usds",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDT_AUD": {
+    "normalized_id": "USDT/AUD",
+    "base": "USDT",
+    "quote": "AUD",
+    "display_name": "Tether / Australian Dollar",
+    "description": "Tether to Australian Dollar spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "USDT_CAD": {
+    "normalized_id": "USDT/CAD",
+    "base": "USDT",
+    "quote": "CAD",
+    "display_name": "Tether / Canadian Dollar",
+    "description": "Tether to Canadian Dollar spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "cad",
+      "fiat",
+      "canadian dollar"
+    ],
+    "category": "crypto"
+  },
+  "USDT_CHF": {
+    "normalized_id": "USDT/CHF",
+    "base": "USDT",
+    "quote": "CHF",
+    "display_name": "Tether / Swiss Franc",
+    "description": "Tether to Swiss Franc spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "chf"
+    ],
+    "category": "crypto"
+  },
+  "USDT_EUR": {
+    "normalized_id": "USDT/EUR",
+    "base": "USDT",
+    "quote": "EUR",
+    "display_name": "Tether / Euro",
+    "description": "Tether to Euro spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "USDT_GBP": {
+    "normalized_id": "USDT/GBP",
+    "base": "USDT",
+    "quote": "GBP",
+    "display_name": "Tether / British Pound",
+    "description": "Tether to British Pound spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "USDT_JPY": {
+    "normalized_id": "USDT/JPY",
+    "base": "USDT",
+    "quote": "JPY",
+    "display_name": "Tether / Japanese Yen",
+    "description": "Tether to Japanese Yen spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "USDT_USD": {
+    "normalized_id": "USDT/USD",
+    "base": "USDT",
+    "quote": "USD",
+    "display_name": "Tether / US Dollar",
+    "description": "Tether to US Dollar spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDUC_EUR": {
+    "normalized_id": "USDUC/EUR",
+    "base": "USDUC",
+    "quote": "EUR",
+    "display_name": "USDUC / Euro",
+    "description": "USDUC to Euro spot trading pair",
+    "tags": [
+      "usduc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "USDUC_USD": {
+    "normalized_id": "USDUC/USD",
+    "base": "USDUC",
+    "quote": "USD",
+    "display_name": "USDUC / US Dollar",
+    "description": "USDUC to US Dollar spot trading pair",
+    "tags": [
+      "usduc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USD_CAD": {
+    "normalized_id": "USD/CAD",
+    "base": "USD",
+    "quote": "CAD",
+    "display_name": "US Dollar / Canadian Dollar",
+    "description": "US Dollar to Canadian Dollar  trading pair",
+    "tags": [
+      "usd",
+      "us dollar",
+      "cad",
+      "fiat",
+      "canadian dollar"
+    ],
+    "category": "forex"
+  },
+  "USD_CHF": {
+    "normalized_id": "USD/CHF",
+    "base": "USD",
+    "quote": "CHF",
+    "display_name": "US Dollar / Swiss Franc",
+    "description": "US Dollar to Swiss Franc  trading pair",
+    "tags": [
+      "usd",
+      "us dollar",
+      "chf"
+    ],
+    "category": "forex"
+  },
+  "USD_JPY": {
+    "normalized_id": "USD/JPY",
+    "base": "USD",
+    "quote": "JPY",
+    "display_name": "US Dollar / Japanese Yen",
+    "description": "US Dollar to Japanese Yen  trading pair",
+    "tags": [
+      "usd",
+      "us dollar",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "forex"
+  },
+  "USELESS_EUR": {
+    "normalized_id": "USELESS/EUR",
+    "base": "USELESS",
+    "quote": "EUR",
+    "display_name": "USELESS / Euro",
+    "description": "USELESS to Euro spot trading pair",
+    "tags": [
+      "useless",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "USELESS_USD": {
+    "normalized_id": "USELESS/USD",
+    "base": "USELESS",
+    "quote": "USD",
+    "display_name": "USELESS / US Dollar",
+    "description": "USELESS to US Dollar spot trading pair",
+    "tags": [
+      "useless",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UST_EUR": {
+    "normalized_id": "UST/EUR",
+    "base": "UST",
+    "quote": "EUR",
+    "display_name": "UST / Euro",
+    "description": "UST to Euro spot trading pair",
+    "tags": [
+      "ust",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "UST_USD": {
+    "normalized_id": "UST/USD",
+    "base": "UST",
+    "quote": "USD",
+    "display_name": "UST / US Dollar",
+    "description": "UST to US Dollar spot trading pair",
+    "tags": [
+      "ust",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UST_USDC": {
+    "normalized_id": "UST/USD",
+    "base": "UST",
+    "quote": "USD",
+    "display_name": "UST / US Dollar",
+    "description": "UST to US Dollar spot trading pair",
+    "tags": [
+      "ust",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UST_USDT": {
+    "normalized_id": "UST/USD",
+    "base": "UST",
+    "quote": "USD",
+    "display_name": "UST / US Dollar",
+    "description": "UST to US Dollar spot trading pair",
+    "tags": [
+      "ust",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USUAL_EUR": {
+    "normalized_id": "USUAL/EUR",
+    "base": "USUAL",
+    "quote": "EUR",
+    "display_name": "USUAL / Euro",
+    "description": "USUAL to Euro spot trading pair",
+    "tags": [
+      "usual",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "USUAL_USD": {
+    "normalized_id": "USUAL/USD",
+    "base": "USUAL",
+    "quote": "USD",
+    "display_name": "USUAL / US Dollar",
+    "description": "USUAL to US Dollar spot trading pair",
+    "tags": [
+      "usual",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VANRY_EUR": {
+    "normalized_id": "VANRY/EUR",
+    "base": "VANRY",
+    "quote": "EUR",
+    "display_name": "VANRY / Euro",
+    "description": "VANRY to Euro spot trading pair",
+    "tags": [
+      "vanry",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "VANRY_USD": {
+    "normalized_id": "VANRY/USD",
+    "base": "VANRY",
+    "quote": "USD",
+    "display_name": "VANRY / US Dollar",
+    "description": "VANRY to US Dollar spot trading pair",
+    "tags": [
+      "vanry",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VELODROME_EUR": {
+    "normalized_id": "VELODROME/EUR",
+    "base": "VELODROME",
+    "quote": "EUR",
+    "display_name": "VELODROME / Euro",
+    "description": "VELODROME to Euro spot trading pair",
+    "tags": [
+      "velodrome",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "VELODROME_USD": {
+    "normalized_id": "VELODROME/USD",
+    "base": "VELODROME",
+    "quote": "USD",
+    "display_name": "VELODROME / US Dollar",
+    "description": "VELODROME to US Dollar spot trading pair",
+    "tags": [
+      "velodrome",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VINE_EUR": {
+    "normalized_id": "VINE/EUR",
+    "base": "VINE",
+    "quote": "EUR",
+    "display_name": "VINE / Euro",
+    "description": "VINE to Euro spot trading pair",
+    "tags": [
+      "vine",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "VINE_USD": {
+    "normalized_id": "VINE/USD",
+    "base": "VINE",
+    "quote": "USD",
+    "display_name": "VINE / US Dollar",
+    "description": "VINE to US Dollar spot trading pair",
+    "tags": [
+      "vine",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VIRTUAL_EUR": {
+    "normalized_id": "VIRTUAL/EUR",
+    "base": "VIRTUAL",
+    "quote": "EUR",
+    "display_name": "VIRTUAL / Euro",
+    "description": "VIRTUAL to Euro spot trading pair",
+    "tags": [
+      "virtual",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "VIRTUAL_USD": {
+    "normalized_id": "VIRTUAL/USD",
+    "base": "VIRTUAL",
+    "quote": "USD",
+    "display_name": "VIRTUAL / US Dollar",
+    "description": "VIRTUAL to US Dollar spot trading pair",
+    "tags": [
+      "virtual",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VIRTUAL_USDC": {
+    "normalized_id": "VIRTUAL/USD",
+    "base": "VIRTUAL",
+    "quote": "USD",
+    "display_name": "VIRTUAL / US Dollar",
+    "description": "VIRTUAL to US Dollar spot trading pair",
+    "tags": [
+      "virtual",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VIRTUAL_USDT": {
+    "normalized_id": "VIRTUAL/USD",
+    "base": "VIRTUAL",
+    "quote": "USD",
+    "display_name": "VIRTUAL / US Dollar",
+    "description": "VIRTUAL to US Dollar spot trading pair",
+    "tags": [
+      "virtual",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VSN_EUR": {
+    "normalized_id": "VSN/EUR",
+    "base": "VSN",
+    "quote": "EUR",
+    "display_name": "VSN / Euro",
+    "description": "VSN to Euro spot trading pair",
+    "tags": [
+      "vsn",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "VSN_USD": {
+    "normalized_id": "VSN/USD",
+    "base": "VSN",
+    "quote": "USD",
+    "display_name": "VSN / US Dollar",
+    "description": "VSN to US Dollar spot trading pair",
+    "tags": [
+      "vsn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VVV_EUR": {
+    "normalized_id": "VVV/EUR",
+    "base": "VVV",
+    "quote": "EUR",
+    "display_name": "VVV / Euro",
+    "description": "VVV to Euro spot trading pair",
+    "tags": [
+      "vvv",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "VVV_USD": {
+    "normalized_id": "VVV/USD",
+    "base": "VVV",
+    "quote": "USD",
+    "display_name": "VVV / US Dollar",
+    "description": "VVV to US Dollar spot trading pair",
+    "tags": [
+      "vvv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WAL_EUR": {
+    "normalized_id": "WAL/EUR",
+    "base": "WAL",
+    "quote": "EUR",
+    "display_name": "WAL / Euro",
+    "description": "WAL to Euro spot trading pair",
+    "tags": [
+      "wal",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "WAL_USD": {
+    "normalized_id": "WAL/USD",
+    "base": "WAL",
+    "quote": "USD",
+    "display_name": "WAL / US Dollar",
+    "description": "WAL to US Dollar spot trading pair",
+    "tags": [
+      "wal",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WAXL_EUR": {
+    "normalized_id": "WAXL/EUR",
+    "base": "WAXL",
+    "quote": "EUR",
+    "display_name": "WAXL / Euro",
+    "description": "WAXL to Euro spot trading pair",
+    "tags": [
+      "waxl",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "WAXL_USD": {
+    "normalized_id": "WAXL/USD",
+    "base": "WAXL",
+    "quote": "USD",
+    "display_name": "WAXL / US Dollar",
+    "description": "WAXL to US Dollar spot trading pair",
+    "tags": [
+      "waxl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WBTC_EUR": {
+    "normalized_id": "WBTC/EUR",
+    "base": "WBTC",
+    "quote": "EUR",
+    "display_name": "WBTC / Euro",
+    "description": "WBTC to Euro spot trading pair",
+    "tags": [
+      "wbtc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "WBTC_USD": {
+    "normalized_id": "WBTC/USD",
+    "base": "WBTC",
+    "quote": "USD",
+    "display_name": "WBTC / US Dollar",
+    "description": "WBTC to US Dollar spot trading pair",
+    "tags": [
+      "wbtc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WBTC_XBT": {
+    "normalized_id": "WBTC/XBT",
+    "base": "WBTC",
+    "quote": "XBT",
+    "display_name": "WBTC / XBT",
+    "description": "WBTC to XBT spot trading pair",
+    "tags": [
+      "wbtc",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "WCT_EUR": {
+    "normalized_id": "WCT/EUR",
+    "base": "WCT",
+    "quote": "EUR",
+    "display_name": "WCT / Euro",
+    "description": "WCT to Euro spot trading pair",
+    "tags": [
+      "wct",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "WCT_USD": {
+    "normalized_id": "WCT/USD",
+    "base": "WCT",
+    "quote": "USD",
+    "display_name": "WCT / US Dollar",
+    "description": "WCT to US Dollar spot trading pair",
+    "tags": [
+      "wct",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WELL_EUR": {
+    "normalized_id": "WELL/EUR",
+    "base": "WELL",
+    "quote": "EUR",
+    "display_name": "WELL / Euro",
+    "description": "WELL to Euro spot trading pair",
+    "tags": [
+      "well",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "WELL_USD": {
+    "normalized_id": "WELL/USD",
+    "base": "WELL",
+    "quote": "USD",
+    "display_name": "WELL / US Dollar",
+    "description": "WELL to US Dollar spot trading pair",
+    "tags": [
+      "well",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WEN_EUR": {
+    "normalized_id": "WEN/EUR",
+    "base": "WEN",
+    "quote": "EUR",
+    "display_name": "WEN / Euro",
+    "description": "WEN to Euro spot trading pair",
+    "tags": [
+      "wen",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "WEN_USD": {
+    "normalized_id": "WEN/USD",
+    "base": "WEN",
+    "quote": "USD",
+    "display_name": "WEN / US Dollar",
+    "description": "WEN to US Dollar spot trading pair",
+    "tags": [
+      "wen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WIF_EUR": {
+    "normalized_id": "WIF/EUR",
+    "base": "WIF",
+    "quote": "EUR",
+    "display_name": "dogwifhat / Euro",
+    "description": "dogwifhat to Euro spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "WIF_GBP": {
+    "normalized_id": "WIF/GBP",
+    "base": "WIF",
+    "quote": "GBP",
+    "display_name": "dogwifhat / British Pound",
+    "description": "dogwifhat to British Pound spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "WIF_USD": {
+    "normalized_id": "WIF/USD",
+    "base": "WIF",
+    "quote": "USD",
+    "display_name": "dogwifhat / US Dollar",
+    "description": "dogwifhat to US Dollar spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WIN_EUR": {
+    "normalized_id": "WIN/EUR",
+    "base": "WIN",
+    "quote": "EUR",
+    "display_name": "WIN / Euro",
+    "description": "WIN to Euro spot trading pair",
+    "tags": [
+      "win",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "WIN_USD": {
+    "normalized_id": "WIN/USD",
+    "base": "WIN",
+    "quote": "USD",
+    "display_name": "WIN / US Dollar",
+    "description": "WIN to US Dollar spot trading pair",
+    "tags": [
+      "win",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WLD_EUR": {
+    "normalized_id": "WLD/EUR",
+    "base": "WLD",
+    "quote": "EUR",
+    "display_name": "WLD / Euro",
+    "description": "WLD to Euro spot trading pair",
+    "tags": [
+      "wld",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "WLD_USD": {
+    "normalized_id": "WLD/USD",
+    "base": "WLD",
+    "quote": "USD",
+    "display_name": "WLD / US Dollar",
+    "description": "WLD to US Dollar spot trading pair",
+    "tags": [
+      "wld",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WOO_EUR": {
+    "normalized_id": "WOO/EUR",
+    "base": "WOO",
+    "quote": "EUR",
+    "display_name": "WOO / Euro",
+    "description": "WOO to Euro spot trading pair",
+    "tags": [
+      "woo",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "WOO_USD": {
+    "normalized_id": "WOO/USD",
+    "base": "WOO",
+    "quote": "USD",
+    "display_name": "WOO / US Dollar",
+    "description": "WOO to US Dollar spot trading pair",
+    "tags": [
+      "woo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "W_EUR": {
+    "normalized_id": "W/EUR",
+    "base": "W",
+    "quote": "EUR",
+    "display_name": "W / Euro",
+    "description": "W to Euro spot trading pair",
+    "tags": [
+      "w",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "W_USD": {
+    "normalized_id": "W/USD",
+    "base": "W",
+    "quote": "USD",
+    "display_name": "W / US Dollar",
+    "description": "W to US Dollar spot trading pair",
+    "tags": [
+      "w",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XBT_AUD": {
+    "normalized_id": "BTC/AUD",
+    "base": "BTC",
+    "quote": "AUD",
+    "display_name": "Bitcoin / Australian Dollar",
+    "description": "Bitcoin to Australian Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "XBT_CAD": {
+    "normalized_id": "BTC/CAD",
+    "base": "BTC",
+    "quote": "CAD",
+    "display_name": "Bitcoin / Canadian Dollar",
+    "description": "Bitcoin to Canadian Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "cad",
+      "fiat",
+      "canadian dollar"
+    ],
+    "category": "crypto"
+  },
+  "XBT_CHF": {
+    "normalized_id": "BTC/CHF",
+    "base": "BTC",
+    "quote": "CHF",
+    "display_name": "Bitcoin / Swiss Franc",
+    "description": "Bitcoin to Swiss Franc spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "chf"
+    ],
+    "category": "crypto"
+  },
+  "XBT_DAI": {
+    "normalized_id": "BTC/DAI",
+    "base": "BTC",
+    "quote": "DAI",
+    "display_name": "Bitcoin / Dai",
+    "description": "Bitcoin to Dai spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "dai"
+    ],
+    "category": "crypto"
+  },
+  "XBT_EUR": {
+    "normalized_id": "BTC/EUR",
+    "base": "BTC",
+    "quote": "EUR",
+    "display_name": "Bitcoin / Euro",
+    "description": "Bitcoin to Euro spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XBT_GBP": {
+    "normalized_id": "BTC/GBP",
+    "base": "BTC",
+    "quote": "GBP",
+    "display_name": "Bitcoin / British Pound",
+    "description": "Bitcoin to British Pound spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "XBT_JPY": {
+    "normalized_id": "BTC/JPY",
+    "base": "BTC",
+    "quote": "JPY",
+    "display_name": "Bitcoin / Japanese Yen",
+    "description": "Bitcoin to Japanese Yen spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "jpy",
+      "fiat",
+      "japanese yen"
+    ],
+    "category": "crypto"
+  },
+  "XBT_PYUSD": {
+    "normalized_id": "BTC/PYUSD",
+    "base": "BTC",
+    "quote": "PYUSD",
+    "display_name": "Bitcoin / PYUSD",
+    "description": "Bitcoin to PYUSD spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "pyusd"
+    ],
+    "category": "crypto"
+  },
+  "XBT_USD": {
+    "normalized_id": "BTC/USD",
+    "base": "BTC",
+    "quote": "USD",
+    "display_name": "Bitcoin / US Dollar",
+    "description": "Bitcoin to US Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XBT_USDC": {
+    "normalized_id": "BTC/USD",
+    "base": "BTC",
+    "quote": "USD",
+    "display_name": "Bitcoin / US Dollar",
+    "description": "Bitcoin to US Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XBT_USDQ": {
+    "normalized_id": "BTC/USDQ",
+    "base": "BTC",
+    "quote": "USDQ",
+    "display_name": "Bitcoin / USDQ",
+    "description": "Bitcoin to USDQ spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usdq"
+    ],
+    "category": "crypto"
+  },
+  "XBT_USDR": {
+    "normalized_id": "BTC/USDR",
+    "base": "BTC",
+    "quote": "USDR",
+    "display_name": "Bitcoin / USDR",
+    "description": "Bitcoin to USDR spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usdr"
+    ],
+    "category": "crypto"
+  },
+  "XBT_USDT": {
+    "normalized_id": "BTC/USD",
+    "base": "BTC",
+    "quote": "USD",
+    "display_name": "Bitcoin / US Dollar",
+    "description": "Bitcoin to US Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XCN_EUR": {
+    "normalized_id": "XCN/EUR",
+    "base": "XCN",
+    "quote": "EUR",
+    "display_name": "XCN / Euro",
+    "description": "XCN to Euro spot trading pair",
+    "tags": [
+      "xcn",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XCN_USD": {
+    "normalized_id": "XCN/USD",
+    "base": "XCN",
+    "quote": "USD",
+    "display_name": "XCN / US Dollar",
+    "description": "XCN to US Dollar spot trading pair",
+    "tags": [
+      "xcn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XDG_AUD": {
+    "normalized_id": "XDG/AUD",
+    "base": "XDG",
+    "quote": "AUD",
+    "display_name": "XDG / Australian Dollar",
+    "description": "XDG to Australian Dollar spot trading pair",
+    "tags": [
+      "xdg",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "XDG_CAD": {
+    "normalized_id": "XDG/CAD",
+    "base": "XDG",
+    "quote": "CAD",
+    "display_name": "XDG / Canadian Dollar",
+    "description": "XDG to Canadian Dollar spot trading pair",
+    "tags": [
+      "xdg",
+      "cad",
+      "fiat",
+      "canadian dollar"
+    ],
+    "category": "crypto"
+  },
+  "XDG_EUR": {
+    "normalized_id": "XDG/EUR",
+    "base": "XDG",
+    "quote": "EUR",
+    "display_name": "XDG / Euro",
+    "description": "XDG to Euro spot trading pair",
+    "tags": [
+      "xdg",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XDG_GBP": {
+    "normalized_id": "XDG/GBP",
+    "base": "XDG",
+    "quote": "GBP",
+    "display_name": "XDG / British Pound",
+    "description": "XDG to British Pound spot trading pair",
+    "tags": [
+      "xdg",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "XDG_USD": {
+    "normalized_id": "XDG/USD",
+    "base": "XDG",
+    "quote": "USD",
+    "display_name": "XDG / US Dollar",
+    "description": "XDG to US Dollar spot trading pair",
+    "tags": [
+      "xdg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XDG_USDC": {
+    "normalized_id": "XDG/USD",
+    "base": "XDG",
+    "quote": "USD",
+    "display_name": "XDG / US Dollar",
+    "description": "XDG to US Dollar spot trading pair",
+    "tags": [
+      "xdg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XDG_USDT": {
+    "normalized_id": "XDG/USD",
+    "base": "XDG",
+    "quote": "USD",
+    "display_name": "XDG / US Dollar",
+    "description": "XDG to US Dollar spot trading pair",
+    "tags": [
+      "xdg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XDG_XBT": {
+    "normalized_id": "XDG/XBT",
+    "base": "XDG",
+    "quote": "XBT",
+    "display_name": "XDG / XBT",
+    "description": "XDG to XBT spot trading pair",
+    "tags": [
+      "xdg",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "XLM_EUR": {
+    "normalized_id": "XLM/EUR",
+    "base": "XLM",
+    "quote": "EUR",
+    "display_name": "Stellar / Euro",
+    "description": "Stellar to Euro spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XLM_GBP": {
+    "normalized_id": "XLM/GBP",
+    "base": "XLM",
+    "quote": "GBP",
+    "display_name": "Stellar / British Pound",
+    "description": "Stellar to British Pound spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "XLM_USD": {
+    "normalized_id": "XLM/USD",
+    "base": "XLM",
+    "quote": "USD",
+    "display_name": "Stellar / US Dollar",
+    "description": "Stellar to US Dollar spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XLM_XBT": {
+    "normalized_id": "XLM/XBT",
+    "base": "XLM",
+    "quote": "XBT",
+    "display_name": "Stellar / XBT",
+    "description": "Stellar to XBT spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "XMR_EUR": {
+    "normalized_id": "XMR/EUR",
+    "base": "XMR",
+    "quote": "EUR",
+    "display_name": "XMR / Euro",
+    "description": "XMR to Euro spot trading pair",
+    "tags": [
+      "xmr",
+      "privacy",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XMR_USD": {
+    "normalized_id": "XMR/USD",
+    "base": "XMR",
+    "quote": "USD",
+    "display_name": "XMR / US Dollar",
+    "description": "XMR to US Dollar spot trading pair",
+    "tags": [
+      "xmr",
+      "privacy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XMR_USDC": {
+    "normalized_id": "XMR/USD",
+    "base": "XMR",
+    "quote": "USD",
+    "display_name": "XMR / US Dollar",
+    "description": "XMR to US Dollar spot trading pair",
+    "tags": [
+      "xmr",
+      "privacy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XMR_USDT": {
+    "normalized_id": "XMR/USD",
+    "base": "XMR",
+    "quote": "USD",
+    "display_name": "XMR / US Dollar",
+    "description": "XMR to US Dollar spot trading pair",
+    "tags": [
+      "xmr",
+      "privacy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XMR_XBT": {
+    "normalized_id": "XMR/XBT",
+    "base": "XMR",
+    "quote": "XBT",
+    "display_name": "XMR / XBT",
+    "description": "XMR to XBT spot trading pair",
+    "tags": [
+      "xmr",
+      "privacy",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "XNY_EUR": {
+    "normalized_id": "XNY/EUR",
+    "base": "XNY",
+    "quote": "EUR",
+    "display_name": "XNY / Euro",
+    "description": "XNY to Euro spot trading pair",
+    "tags": [
+      "xny",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XNY_USD": {
+    "normalized_id": "XNY/USD",
+    "base": "XNY",
+    "quote": "USD",
+    "display_name": "XNY / US Dollar",
+    "description": "XNY to US Dollar spot trading pair",
+    "tags": [
+      "xny",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XRP_AUD": {
+    "normalized_id": "XRP/AUD",
+    "base": "XRP",
+    "quote": "AUD",
+    "display_name": "Ripple / Australian Dollar",
+    "description": "Ripple to Australian Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "XRP_CAD": {
+    "normalized_id": "XRP/CAD",
+    "base": "XRP",
+    "quote": "CAD",
+    "display_name": "Ripple / Canadian Dollar",
+    "description": "Ripple to Canadian Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "cad",
+      "fiat",
+      "canadian dollar"
+    ],
+    "category": "crypto"
+  },
+  "XRP_ETH": {
+    "normalized_id": "XRP/ETH",
+    "base": "XRP",
+    "quote": "ETH",
+    "display_name": "Ripple / Ethereum",
+    "description": "Ripple to Ethereum spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "XRP_EUR": {
+    "normalized_id": "XRP/EUR",
+    "base": "XRP",
+    "quote": "EUR",
+    "display_name": "Ripple / Euro",
+    "description": "Ripple to Euro spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XRP_GBP": {
+    "normalized_id": "XRP/GBP",
+    "base": "XRP",
+    "quote": "GBP",
+    "display_name": "Ripple / British Pound",
+    "description": "Ripple to British Pound spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "gbp",
+      "fiat",
+      "british pound"
+    ],
+    "category": "crypto"
+  },
+  "XRP_RLUSD": {
+    "normalized_id": "XRP/RLUSD",
+    "base": "XRP",
+    "quote": "RLUSD",
+    "display_name": "Ripple / RLUSD",
+    "description": "Ripple to RLUSD spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "rlusd"
+    ],
+    "category": "crypto"
+  },
+  "XRP_USD": {
+    "normalized_id": "XRP/USD",
+    "base": "XRP",
+    "quote": "USD",
+    "display_name": "Ripple / US Dollar",
+    "description": "Ripple to US Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XRP_USDC": {
+    "normalized_id": "XRP/USD",
+    "base": "XRP",
+    "quote": "USD",
+    "display_name": "Ripple / US Dollar",
+    "description": "Ripple to US Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XRP_USDT": {
+    "normalized_id": "XRP/USD",
+    "base": "XRP",
+    "quote": "USD",
+    "display_name": "Ripple / US Dollar",
+    "description": "Ripple to US Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XRP_XBT": {
+    "normalized_id": "XRP/XBT",
+    "base": "XRP",
+    "quote": "XBT",
+    "display_name": "Ripple / XBT",
+    "description": "Ripple to XBT spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "xbt"
+    ],
+    "category": "crypto"
+  },
+  "XRT_EUR": {
+    "normalized_id": "XRT/EUR",
+    "base": "XRT",
+    "quote": "EUR",
+    "display_name": "XRT / Euro",
+    "description": "XRT to Euro spot trading pair",
+    "tags": [
+      "xrt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XRT_USD": {
+    "normalized_id": "XRT/USD",
+    "base": "XRT",
+    "quote": "USD",
+    "display_name": "XRT / US Dollar",
+    "description": "XRT to US Dollar spot trading pair",
+    "tags": [
+      "xrt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XTER_EUR": {
+    "normalized_id": "XTER/EUR",
+    "base": "XTER",
+    "quote": "EUR",
+    "display_name": "XTER / Euro",
+    "description": "XTER to Euro spot trading pair",
+    "tags": [
+      "xter",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XTER_USD": {
+    "normalized_id": "XTER/USD",
+    "base": "XTER",
+    "quote": "USD",
+    "display_name": "XTER / US Dollar",
+    "description": "XTER to US Dollar spot trading pair",
+    "tags": [
+      "xter",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XTZ_EUR": {
+    "normalized_id": "XTZ/EUR",
+    "base": "XTZ",
+    "quote": "EUR",
+    "display_name": "Tezos / Euro",
+    "description": "Tezos to Euro spot trading pair",
+    "tags": [
+      "xtz",
+      "tezos",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XTZ_USD": {
+    "normalized_id": "XTZ/USD",
+    "base": "XTZ",
+    "quote": "USD",
+    "display_name": "Tezos / US Dollar",
+    "description": "Tezos to US Dollar spot trading pair",
+    "tags": [
+      "xtz",
+      "tezos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XTZ_USDC": {
+    "normalized_id": "XTZ/USD",
+    "base": "XTZ",
+    "quote": "USD",
+    "display_name": "Tezos / US Dollar",
+    "description": "Tezos to US Dollar spot trading pair",
+    "tags": [
+      "xtz",
+      "tezos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XTZ_USDT": {
+    "normalized_id": "XTZ/USD",
+    "base": "XTZ",
+    "quote": "USD",
+    "display_name": "Tezos / US Dollar",
+    "description": "Tezos to US Dollar spot trading pair",
+    "tags": [
+      "xtz",
+      "tezos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XYO_EUR": {
+    "normalized_id": "XYO/EUR",
+    "base": "XYO",
+    "quote": "EUR",
+    "display_name": "XYO / Euro",
+    "description": "XYO to Euro spot trading pair",
+    "tags": [
+      "xyo",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XYO_USD": {
+    "normalized_id": "XYO/USD",
+    "base": "XYO",
+    "quote": "USD",
+    "display_name": "XYO / US Dollar",
+    "description": "XYO to US Dollar spot trading pair",
+    "tags": [
+      "xyo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "YFI_EUR": {
+    "normalized_id": "YFI/EUR",
+    "base": "YFI",
+    "quote": "EUR",
+    "display_name": "YFI / Euro",
+    "description": "YFI to Euro spot trading pair",
+    "tags": [
+      "yfi",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "YFI_USD": {
+    "normalized_id": "YFI/USD",
+    "base": "YFI",
+    "quote": "USD",
+    "display_name": "YFI / US Dollar",
+    "description": "YFI to US Dollar spot trading pair",
+    "tags": [
+      "yfi",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "YGG_EUR": {
+    "normalized_id": "YGG/EUR",
+    "base": "YGG",
+    "quote": "EUR",
+    "display_name": "YGG / Euro",
+    "description": "YGG to Euro spot trading pair",
+    "tags": [
+      "ygg",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "YGG_USD": {
+    "normalized_id": "YGG/USD",
+    "base": "YGG",
+    "quote": "USD",
+    "display_name": "YGG / US Dollar",
+    "description": "YGG to US Dollar spot trading pair",
+    "tags": [
+      "ygg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZEC_EUR": {
+    "normalized_id": "ZEC/EUR",
+    "base": "ZEC",
+    "quote": "EUR",
+    "display_name": "ZEC / Euro",
+    "description": "ZEC to Euro spot trading pair",
+    "tags": [
+      "zec",
+      "privacy",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ZEC_USD": {
+    "normalized_id": "ZEC/USD",
+    "base": "ZEC",
+    "quote": "USD",
+    "display_name": "ZEC / US Dollar",
+    "description": "ZEC to US Dollar spot trading pair",
+    "tags": [
+      "zec",
+      "privacy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZEREBRO_EUR": {
+    "normalized_id": "ZEREBRO/EUR",
+    "base": "ZEREBRO",
+    "quote": "EUR",
+    "display_name": "ZEREBRO / Euro",
+    "description": "ZEREBRO to Euro spot trading pair",
+    "tags": [
+      "zerebro",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ZEREBRO_USD": {
+    "normalized_id": "ZEREBRO/USD",
+    "base": "ZEREBRO",
+    "quote": "USD",
+    "display_name": "ZEREBRO / US Dollar",
+    "description": "ZEREBRO to US Dollar spot trading pair",
+    "tags": [
+      "zerebro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZETA_EUR": {
+    "normalized_id": "ZETA/EUR",
+    "base": "ZETA",
+    "quote": "EUR",
+    "display_name": "ZETA / Euro",
+    "description": "ZETA to Euro spot trading pair",
+    "tags": [
+      "zeta",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ZETA_USD": {
+    "normalized_id": "ZETA/USD",
+    "base": "ZETA",
+    "quote": "USD",
+    "display_name": "ZETA / US Dollar",
+    "description": "ZETA to US Dollar spot trading pair",
+    "tags": [
+      "zeta",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZEUS_EUR": {
+    "normalized_id": "ZEUS/EUR",
+    "base": "ZEUS",
+    "quote": "EUR",
+    "display_name": "ZEUS / Euro",
+    "description": "ZEUS to Euro spot trading pair",
+    "tags": [
+      "zeus",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ZEUS_USD": {
+    "normalized_id": "ZEUS/USD",
+    "base": "ZEUS",
+    "quote": "USD",
+    "display_name": "ZEUS / US Dollar",
+    "description": "ZEUS to US Dollar spot trading pair",
+    "tags": [
+      "zeus",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZEX_EUR": {
+    "normalized_id": "ZEX/EUR",
+    "base": "ZEX",
+    "quote": "EUR",
+    "display_name": "ZEX / Euro",
+    "description": "ZEX to Euro spot trading pair",
+    "tags": [
+      "zex",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ZEX_USD": {
+    "normalized_id": "ZEX/USD",
+    "base": "ZEX",
+    "quote": "USD",
+    "display_name": "ZEX / US Dollar",
+    "description": "ZEX to US Dollar spot trading pair",
+    "tags": [
+      "zex",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZK_EUR": {
+    "normalized_id": "ZK/EUR",
+    "base": "ZK",
+    "quote": "EUR",
+    "display_name": "ZK / Euro",
+    "description": "ZK to Euro spot trading pair",
+    "tags": [
+      "zk",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ZK_USD": {
+    "normalized_id": "ZK/USD",
+    "base": "ZK",
+    "quote": "USD",
+    "display_name": "ZK / US Dollar",
+    "description": "ZK to US Dollar spot trading pair",
+    "tags": [
+      "zk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZORA_EUR": {
+    "normalized_id": "ZORA/EUR",
+    "base": "ZORA",
+    "quote": "EUR",
+    "display_name": "ZORA / Euro",
+    "description": "ZORA to Euro spot trading pair",
+    "tags": [
+      "zora",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ZORA_USD": {
+    "normalized_id": "ZORA/USD",
+    "base": "ZORA",
+    "quote": "USD",
+    "display_name": "ZORA / US Dollar",
+    "description": "ZORA to US Dollar spot trading pair",
+    "tags": [
+      "zora",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZRO_EUR": {
+    "normalized_id": "ZRO/EUR",
+    "base": "ZRO",
+    "quote": "EUR",
+    "display_name": "ZRO / Euro",
+    "description": "ZRO to Euro spot trading pair",
+    "tags": [
+      "zro",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ZRO_USD": {
+    "normalized_id": "ZRO/USD",
+    "base": "ZRO",
+    "quote": "USD",
+    "display_name": "ZRO / US Dollar",
+    "description": "ZRO to US Dollar spot trading pair",
+    "tags": [
+      "zro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZRX_EUR": {
+    "normalized_id": "ZRX/EUR",
+    "base": "ZRX",
+    "quote": "EUR",
+    "display_name": "0x / Euro",
+    "description": "0x to Euro spot trading pair",
+    "tags": [
+      "zrx",
+      "0x",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ZRX_USD": {
+    "normalized_id": "ZRX/USD",
+    "base": "ZRX",
+    "quote": "USD",
+    "display_name": "0x / US Dollar",
+    "description": "0x to US Dollar spot trading pair",
+    "tags": [
+      "zrx",
+      "0x",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZRX_XBT": {
+    "normalized_id": "ZRX/XBT",
+    "base": "ZRX",
+    "quote": "XBT",
+    "display_name": "0x / XBT",
+    "description": "0x to XBT spot trading pair",
+    "tags": [
+      "zrx",
+      "0x",
+      "xbt"
+    ],
+    "category": "crypto"
+  }
+}

--- a/server/src/symbols/configs/okx.json
+++ b/server/src/symbols/configs/okx.json
@@ -1,0 +1,9415 @@
+{
+  "1INCH-EUR": {
+    "normalized_id": "1INCH/EUR",
+    "base": "1INCH",
+    "quote": "EUR",
+    "display_name": "1INCH / Euro",
+    "description": "1INCH to Euro spot trading pair",
+    "tags": [
+      "1inch",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "1INCH-USD": {
+    "normalized_id": "1INCH/USD",
+    "base": "1INCH",
+    "quote": "USD",
+    "display_name": "1INCH / US Dollar",
+    "description": "1INCH to US Dollar spot trading pair",
+    "tags": [
+      "1inch",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "1INCH-USDC": {
+    "normalized_id": "1INCH/USD",
+    "base": "1INCH",
+    "quote": "USD",
+    "display_name": "1INCH / US Dollar",
+    "description": "1INCH to US Dollar spot trading pair",
+    "tags": [
+      "1inch",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "1INCH-USDT": {
+    "normalized_id": "1INCH/USD",
+    "base": "1INCH",
+    "quote": "USD",
+    "display_name": "1INCH / US Dollar",
+    "description": "1INCH to US Dollar spot trading pair",
+    "tags": [
+      "1inch",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "A-USD": {
+    "normalized_id": "A/USD",
+    "base": "A",
+    "quote": "USD",
+    "display_name": "A / US Dollar",
+    "description": "A to US Dollar spot trading pair",
+    "tags": [
+      "a",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "A-USDT": {
+    "normalized_id": "A/USD",
+    "base": "A",
+    "quote": "USD",
+    "display_name": "A / US Dollar",
+    "description": "A to US Dollar spot trading pair",
+    "tags": [
+      "a",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AAVE-EUR": {
+    "normalized_id": "AAVE/EUR",
+    "base": "AAVE",
+    "quote": "EUR",
+    "display_name": "Aave / Euro",
+    "description": "Aave to Euro spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AAVE-USD": {
+    "normalized_id": "AAVE/USD",
+    "base": "AAVE",
+    "quote": "USD",
+    "display_name": "Aave / US Dollar",
+    "description": "Aave to US Dollar spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AAVE-USDC": {
+    "normalized_id": "AAVE/USD",
+    "base": "AAVE",
+    "quote": "USD",
+    "display_name": "Aave / US Dollar",
+    "description": "Aave to US Dollar spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AAVE-USDT": {
+    "normalized_id": "AAVE/USD",
+    "base": "AAVE",
+    "quote": "USD",
+    "display_name": "Aave / US Dollar",
+    "description": "Aave to US Dollar spot trading pair",
+    "tags": [
+      "aave",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACA-USD": {
+    "normalized_id": "ACA/USD",
+    "base": "ACA",
+    "quote": "USD",
+    "display_name": "ACA / US Dollar",
+    "description": "ACA to US Dollar spot trading pair",
+    "tags": [
+      "aca",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACA-USDT": {
+    "normalized_id": "ACA/USD",
+    "base": "ACA",
+    "quote": "USD",
+    "display_name": "ACA / US Dollar",
+    "description": "ACA to US Dollar spot trading pair",
+    "tags": [
+      "aca",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACE-USD": {
+    "normalized_id": "ACE/USD",
+    "base": "ACE",
+    "quote": "USD",
+    "display_name": "ACE / US Dollar",
+    "description": "ACE to US Dollar spot trading pair",
+    "tags": [
+      "ace",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACE-USDT": {
+    "normalized_id": "ACE/USD",
+    "base": "ACE",
+    "quote": "USD",
+    "display_name": "ACE / US Dollar",
+    "description": "ACE to US Dollar spot trading pair",
+    "tags": [
+      "ace",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACH-USD": {
+    "normalized_id": "ACH/USD",
+    "base": "ACH",
+    "quote": "USD",
+    "display_name": "ACH / US Dollar",
+    "description": "ACH to US Dollar spot trading pair",
+    "tags": [
+      "ach",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACH-USDT": {
+    "normalized_id": "ACH/USD",
+    "base": "ACH",
+    "quote": "USD",
+    "display_name": "ACH / US Dollar",
+    "description": "ACH to US Dollar spot trading pair",
+    "tags": [
+      "ach",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ACT-USDT": {
+    "normalized_id": "ACT/USD",
+    "base": "ACT",
+    "quote": "USD",
+    "display_name": "ACT / US Dollar",
+    "description": "ACT to US Dollar spot trading pair",
+    "tags": [
+      "act",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ADA-EUR": {
+    "normalized_id": "ADA/EUR",
+    "base": "ADA",
+    "quote": "EUR",
+    "display_name": "Cardano / Euro",
+    "description": "Cardano to Euro spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ADA-USD": {
+    "normalized_id": "ADA/USD",
+    "base": "ADA",
+    "quote": "USD",
+    "display_name": "Cardano / US Dollar",
+    "description": "Cardano to US Dollar spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ADA-USDC": {
+    "normalized_id": "ADA/USD",
+    "base": "ADA",
+    "quote": "USD",
+    "display_name": "Cardano / US Dollar",
+    "description": "Cardano to US Dollar spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ADA-USDT": {
+    "normalized_id": "ADA/USD",
+    "base": "ADA",
+    "quote": "USD",
+    "display_name": "Cardano / US Dollar",
+    "description": "Cardano to US Dollar spot trading pair",
+    "tags": [
+      "ada",
+      "cardano",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AERGO-USD": {
+    "normalized_id": "AERGO/USD",
+    "base": "AERGO",
+    "quote": "USD",
+    "display_name": "AERGO / US Dollar",
+    "description": "AERGO to US Dollar spot trading pair",
+    "tags": [
+      "aergo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AERGO-USDT": {
+    "normalized_id": "AERGO/USD",
+    "base": "AERGO",
+    "quote": "USD",
+    "display_name": "AERGO / US Dollar",
+    "description": "AERGO to US Dollar spot trading pair",
+    "tags": [
+      "aergo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AEVO-USD": {
+    "normalized_id": "AEVO/USD",
+    "base": "AEVO",
+    "quote": "USD",
+    "display_name": "AEVO / US Dollar",
+    "description": "AEVO to US Dollar spot trading pair",
+    "tags": [
+      "aevo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AEVO-USDC": {
+    "normalized_id": "AEVO/USD",
+    "base": "AEVO",
+    "quote": "USD",
+    "display_name": "AEVO / US Dollar",
+    "description": "AEVO to US Dollar spot trading pair",
+    "tags": [
+      "aevo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AEVO-USDT": {
+    "normalized_id": "AEVO/USD",
+    "base": "AEVO",
+    "quote": "USD",
+    "display_name": "AEVO / US Dollar",
+    "description": "AEVO to US Dollar spot trading pair",
+    "tags": [
+      "aevo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AGLD-USD": {
+    "normalized_id": "AGLD/USD",
+    "base": "AGLD",
+    "quote": "USD",
+    "display_name": "AGLD / US Dollar",
+    "description": "AGLD to US Dollar spot trading pair",
+    "tags": [
+      "agld",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AGLD-USDC": {
+    "normalized_id": "AGLD/USD",
+    "base": "AGLD",
+    "quote": "USD",
+    "display_name": "AGLD / US Dollar",
+    "description": "AGLD to US Dollar spot trading pair",
+    "tags": [
+      "agld",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AGLD-USDT": {
+    "normalized_id": "AGLD/USD",
+    "base": "AGLD",
+    "quote": "USD",
+    "display_name": "AGLD / US Dollar",
+    "description": "AGLD to US Dollar spot trading pair",
+    "tags": [
+      "agld",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AIDOGE-USDT": {
+    "normalized_id": "AIDOGE/USD",
+    "base": "AIDOGE",
+    "quote": "USD",
+    "display_name": "AIDOGE / US Dollar",
+    "description": "AIDOGE to US Dollar spot trading pair",
+    "tags": [
+      "aidoge",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AIXBT-USD": {
+    "normalized_id": "AIXBT/USD",
+    "base": "AIXBT",
+    "quote": "USD",
+    "display_name": "AIXBT / US Dollar",
+    "description": "AIXBT to US Dollar spot trading pair",
+    "tags": [
+      "aixbt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AIXBT-USDT": {
+    "normalized_id": "AIXBT/USD",
+    "base": "AIXBT",
+    "quote": "USD",
+    "display_name": "AIXBT / US Dollar",
+    "description": "AIXBT to US Dollar spot trading pair",
+    "tags": [
+      "aixbt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALGO-EUR": {
+    "normalized_id": "ALGO/EUR",
+    "base": "ALGO",
+    "quote": "EUR",
+    "display_name": "Algorand / Euro",
+    "description": "Algorand to Euro spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ALGO-USD": {
+    "normalized_id": "ALGO/USD",
+    "base": "ALGO",
+    "quote": "USD",
+    "display_name": "Algorand / US Dollar",
+    "description": "Algorand to US Dollar spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALGO-USDC": {
+    "normalized_id": "ALGO/USD",
+    "base": "ALGO",
+    "quote": "USD",
+    "display_name": "Algorand / US Dollar",
+    "description": "Algorand to US Dollar spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALGO-USDT": {
+    "normalized_id": "ALGO/USD",
+    "base": "ALGO",
+    "quote": "USD",
+    "display_name": "Algorand / US Dollar",
+    "description": "Algorand to US Dollar spot trading pair",
+    "tags": [
+      "algo",
+      "algorand",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALPHA-USD": {
+    "normalized_id": "ALPHA/USD",
+    "base": "ALPHA",
+    "quote": "USD",
+    "display_name": "ALPHA / US Dollar",
+    "description": "ALPHA to US Dollar spot trading pair",
+    "tags": [
+      "alpha",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ALPHA-USDT": {
+    "normalized_id": "ALPHA/USD",
+    "base": "ALPHA",
+    "quote": "USD",
+    "display_name": "ALPHA / US Dollar",
+    "description": "ALPHA to US Dollar spot trading pair",
+    "tags": [
+      "alpha",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ANIME-USD": {
+    "normalized_id": "ANIME/USD",
+    "base": "ANIME",
+    "quote": "USD",
+    "display_name": "ANIME / US Dollar",
+    "description": "ANIME to US Dollar spot trading pair",
+    "tags": [
+      "anime",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ANIME-USDT": {
+    "normalized_id": "ANIME/USD",
+    "base": "ANIME",
+    "quote": "USD",
+    "display_name": "ANIME / US Dollar",
+    "description": "ANIME to US Dollar spot trading pair",
+    "tags": [
+      "anime",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APE-EUR": {
+    "normalized_id": "APE/EUR",
+    "base": "APE",
+    "quote": "EUR",
+    "display_name": "APE / Euro",
+    "description": "APE to Euro spot trading pair",
+    "tags": [
+      "ape",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "APE-USD": {
+    "normalized_id": "APE/USD",
+    "base": "APE",
+    "quote": "USD",
+    "display_name": "APE / US Dollar",
+    "description": "APE to US Dollar spot trading pair",
+    "tags": [
+      "ape",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APE-USDC": {
+    "normalized_id": "APE/USD",
+    "base": "APE",
+    "quote": "USD",
+    "display_name": "APE / US Dollar",
+    "description": "APE to US Dollar spot trading pair",
+    "tags": [
+      "ape",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APE-USDT": {
+    "normalized_id": "APE/USD",
+    "base": "APE",
+    "quote": "USD",
+    "display_name": "APE / US Dollar",
+    "description": "APE to US Dollar spot trading pair",
+    "tags": [
+      "ape",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "API3-USD": {
+    "normalized_id": "API3/USD",
+    "base": "API3",
+    "quote": "USD",
+    "display_name": "API3 / US Dollar",
+    "description": "API3 to US Dollar spot trading pair",
+    "tags": [
+      "api3",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "API3-USDT": {
+    "normalized_id": "API3/USD",
+    "base": "API3",
+    "quote": "USD",
+    "display_name": "API3 / US Dollar",
+    "description": "API3 to US Dollar spot trading pair",
+    "tags": [
+      "api3",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APT-EUR": {
+    "normalized_id": "APT/EUR",
+    "base": "APT",
+    "quote": "EUR",
+    "display_name": "Aptos / Euro",
+    "description": "Aptos to Euro spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "APT-USD": {
+    "normalized_id": "APT/USD",
+    "base": "APT",
+    "quote": "USD",
+    "display_name": "Aptos / US Dollar",
+    "description": "Aptos to US Dollar spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APT-USDC": {
+    "normalized_id": "APT/USD",
+    "base": "APT",
+    "quote": "USD",
+    "display_name": "Aptos / US Dollar",
+    "description": "Aptos to US Dollar spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "APT-USDT": {
+    "normalized_id": "APT/USD",
+    "base": "APT",
+    "quote": "USD",
+    "display_name": "Aptos / US Dollar",
+    "description": "Aptos to US Dollar spot trading pair",
+    "tags": [
+      "apt",
+      "aptos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AR-USD": {
+    "normalized_id": "AR/USD",
+    "base": "AR",
+    "quote": "USD",
+    "display_name": "AR / US Dollar",
+    "description": "AR to US Dollar spot trading pair",
+    "tags": [
+      "ar",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AR-USDT": {
+    "normalized_id": "AR/USD",
+    "base": "AR",
+    "quote": "USD",
+    "display_name": "AR / US Dollar",
+    "description": "AR to US Dollar spot trading pair",
+    "tags": [
+      "ar",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARB-EUR": {
+    "normalized_id": "ARB/EUR",
+    "base": "ARB",
+    "quote": "EUR",
+    "display_name": "Arbitrum / Euro",
+    "description": "Arbitrum to Euro spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ARB-USD": {
+    "normalized_id": "ARB/USD",
+    "base": "ARB",
+    "quote": "USD",
+    "display_name": "Arbitrum / US Dollar",
+    "description": "Arbitrum to US Dollar spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARB-USDC": {
+    "normalized_id": "ARB/USD",
+    "base": "ARB",
+    "quote": "USD",
+    "display_name": "Arbitrum / US Dollar",
+    "description": "Arbitrum to US Dollar spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARB-USDT": {
+    "normalized_id": "ARB/USD",
+    "base": "ARB",
+    "quote": "USD",
+    "display_name": "Arbitrum / US Dollar",
+    "description": "Arbitrum to US Dollar spot trading pair",
+    "tags": [
+      "arb",
+      "arbitrum",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARG-USD": {
+    "normalized_id": "ARG/USD",
+    "base": "ARG",
+    "quote": "USD",
+    "display_name": "ARG / US Dollar",
+    "description": "ARG to US Dollar spot trading pair",
+    "tags": [
+      "arg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARG-USDT": {
+    "normalized_id": "ARG/USD",
+    "base": "ARG",
+    "quote": "USD",
+    "display_name": "ARG / US Dollar",
+    "description": "ARG to US Dollar spot trading pair",
+    "tags": [
+      "arg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARKM-USD": {
+    "normalized_id": "ARKM/USD",
+    "base": "ARKM",
+    "quote": "USD",
+    "display_name": "ARKM / US Dollar",
+    "description": "ARKM to US Dollar spot trading pair",
+    "tags": [
+      "arkm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARKM-USDC": {
+    "normalized_id": "ARKM/USD",
+    "base": "ARKM",
+    "quote": "USD",
+    "display_name": "ARKM / US Dollar",
+    "description": "ARKM to US Dollar spot trading pair",
+    "tags": [
+      "arkm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ARKM-USDT": {
+    "normalized_id": "ARKM/USD",
+    "base": "ARKM",
+    "quote": "USD",
+    "display_name": "ARKM / US Dollar",
+    "description": "ARKM to US Dollar spot trading pair",
+    "tags": [
+      "arkm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ASP-USD": {
+    "normalized_id": "ASP/USD",
+    "base": "ASP",
+    "quote": "USD",
+    "display_name": "ASP / US Dollar",
+    "description": "ASP to US Dollar spot trading pair",
+    "tags": [
+      "asp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ASP-USDT": {
+    "normalized_id": "ASP/USD",
+    "base": "ASP",
+    "quote": "USD",
+    "display_name": "ASP / US Dollar",
+    "description": "ASP to US Dollar spot trading pair",
+    "tags": [
+      "asp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ASTR-EUR": {
+    "normalized_id": "ASTR/EUR",
+    "base": "ASTR",
+    "quote": "EUR",
+    "display_name": "ASTR / Euro",
+    "description": "ASTR to Euro spot trading pair",
+    "tags": [
+      "astr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ASTR-USD": {
+    "normalized_id": "ASTR/USD",
+    "base": "ASTR",
+    "quote": "USD",
+    "display_name": "ASTR / US Dollar",
+    "description": "ASTR to US Dollar spot trading pair",
+    "tags": [
+      "astr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ASTR-USDT": {
+    "normalized_id": "ASTR/USD",
+    "base": "ASTR",
+    "quote": "USD",
+    "display_name": "ASTR / US Dollar",
+    "description": "ASTR to US Dollar spot trading pair",
+    "tags": [
+      "astr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATH-USDC": {
+    "normalized_id": "ATH/USD",
+    "base": "ATH",
+    "quote": "USD",
+    "display_name": "ATH / US Dollar",
+    "description": "ATH to US Dollar spot trading pair",
+    "tags": [
+      "ath",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATH-USDT": {
+    "normalized_id": "ATH/USD",
+    "base": "ATH",
+    "quote": "USD",
+    "display_name": "ATH / US Dollar",
+    "description": "ATH to US Dollar spot trading pair",
+    "tags": [
+      "ath",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATOM-EUR": {
+    "normalized_id": "ATOM/EUR",
+    "base": "ATOM",
+    "quote": "EUR",
+    "display_name": "Cosmos / Euro",
+    "description": "Cosmos to Euro spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ATOM-USD": {
+    "normalized_id": "ATOM/USD",
+    "base": "ATOM",
+    "quote": "USD",
+    "display_name": "Cosmos / US Dollar",
+    "description": "Cosmos to US Dollar spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATOM-USDC": {
+    "normalized_id": "ATOM/USD",
+    "base": "ATOM",
+    "quote": "USD",
+    "display_name": "Cosmos / US Dollar",
+    "description": "Cosmos to US Dollar spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ATOM-USDT": {
+    "normalized_id": "ATOM/USD",
+    "base": "ATOM",
+    "quote": "USD",
+    "display_name": "Cosmos / US Dollar",
+    "description": "Cosmos to US Dollar spot trading pair",
+    "tags": [
+      "atom",
+      "cosmos",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AUCTION-USD": {
+    "normalized_id": "AUCTION/USD",
+    "base": "AUCTION",
+    "quote": "USD",
+    "display_name": "AUCTION / US Dollar",
+    "description": "AUCTION to US Dollar spot trading pair",
+    "tags": [
+      "auction",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AUCTION-USDT": {
+    "normalized_id": "AUCTION/USD",
+    "base": "AUCTION",
+    "quote": "USD",
+    "display_name": "AUCTION / US Dollar",
+    "description": "AUCTION to US Dollar spot trading pair",
+    "tags": [
+      "auction",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AVAX-EUR": {
+    "normalized_id": "AVAX/EUR",
+    "base": "AVAX",
+    "quote": "EUR",
+    "display_name": "Avalanche / Euro",
+    "description": "Avalanche to Euro spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AVAX-USD": {
+    "normalized_id": "AVAX/USD",
+    "base": "AVAX",
+    "quote": "USD",
+    "display_name": "Avalanche / US Dollar",
+    "description": "Avalanche to US Dollar spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AVAX-USDC": {
+    "normalized_id": "AVAX/USD",
+    "base": "AVAX",
+    "quote": "USD",
+    "display_name": "Avalanche / US Dollar",
+    "description": "Avalanche to US Dollar spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AVAX-USDT": {
+    "normalized_id": "AVAX/USD",
+    "base": "AVAX",
+    "quote": "USD",
+    "display_name": "Avalanche / US Dollar",
+    "description": "Avalanche to US Dollar spot trading pair",
+    "tags": [
+      "avax",
+      "avalanche",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AXS-EUR": {
+    "normalized_id": "AXS/EUR",
+    "base": "AXS",
+    "quote": "EUR",
+    "display_name": "Axie Infinity / Euro",
+    "description": "Axie Infinity to Euro spot trading pair",
+    "tags": [
+      "axs",
+      "axie infinity",
+      "gaming",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "AXS-USD": {
+    "normalized_id": "AXS/USD",
+    "base": "AXS",
+    "quote": "USD",
+    "display_name": "Axie Infinity / US Dollar",
+    "description": "Axie Infinity to US Dollar spot trading pair",
+    "tags": [
+      "axs",
+      "axie infinity",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "AXS-USDT": {
+    "normalized_id": "AXS/USD",
+    "base": "AXS",
+    "quote": "USD",
+    "display_name": "Axie Infinity / US Dollar",
+    "description": "Axie Infinity to US Dollar spot trading pair",
+    "tags": [
+      "axs",
+      "axie infinity",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BABY-USD": {
+    "normalized_id": "BABY/USD",
+    "base": "BABY",
+    "quote": "USD",
+    "display_name": "BABY / US Dollar",
+    "description": "BABY to US Dollar spot trading pair",
+    "tags": [
+      "baby",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BABY-USDT": {
+    "normalized_id": "BABY/USD",
+    "base": "BABY",
+    "quote": "USD",
+    "display_name": "BABY / US Dollar",
+    "description": "BABY to US Dollar spot trading pair",
+    "tags": [
+      "baby",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BABYDOGE-USD": {
+    "normalized_id": "BABYDOGE/USD",
+    "base": "BABYDOGE",
+    "quote": "USD",
+    "display_name": "BABYDOGE / US Dollar",
+    "description": "BABYDOGE to US Dollar spot trading pair",
+    "tags": [
+      "babydoge",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BABYDOGE-USDT": {
+    "normalized_id": "BABYDOGE/USD",
+    "base": "BABYDOGE",
+    "quote": "USD",
+    "display_name": "BABYDOGE / US Dollar",
+    "description": "BABYDOGE to US Dollar spot trading pair",
+    "tags": [
+      "babydoge",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BADGER-USDT": {
+    "normalized_id": "BADGER/USD",
+    "base": "BADGER",
+    "quote": "USD",
+    "display_name": "BADGER / US Dollar",
+    "description": "BADGER to US Dollar spot trading pair",
+    "tags": [
+      "badger",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BAL-EUR": {
+    "normalized_id": "BAL/EUR",
+    "base": "BAL",
+    "quote": "EUR",
+    "display_name": "BAL / Euro",
+    "description": "BAL to Euro spot trading pair",
+    "tags": [
+      "bal",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BAL-USD": {
+    "normalized_id": "BAL/USD",
+    "base": "BAL",
+    "quote": "USD",
+    "display_name": "BAL / US Dollar",
+    "description": "BAL to US Dollar spot trading pair",
+    "tags": [
+      "bal",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BAL-USDT": {
+    "normalized_id": "BAL/USD",
+    "base": "BAL",
+    "quote": "USD",
+    "display_name": "BAL / US Dollar",
+    "description": "BAL to US Dollar spot trading pair",
+    "tags": [
+      "bal",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BANANA-USD": {
+    "normalized_id": "BANANA/USD",
+    "base": "BANANA",
+    "quote": "USD",
+    "display_name": "BANANA / US Dollar",
+    "description": "BANANA to US Dollar spot trading pair",
+    "tags": [
+      "banana",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BANANA-USDT": {
+    "normalized_id": "BANANA/USD",
+    "base": "BANANA",
+    "quote": "USD",
+    "display_name": "BANANA / US Dollar",
+    "description": "BANANA to US Dollar spot trading pair",
+    "tags": [
+      "banana",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BAND-USD": {
+    "normalized_id": "BAND/USD",
+    "base": "BAND",
+    "quote": "USD",
+    "display_name": "BAND / US Dollar",
+    "description": "BAND to US Dollar spot trading pair",
+    "tags": [
+      "band",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BAND-USDT": {
+    "normalized_id": "BAND/USD",
+    "base": "BAND",
+    "quote": "USD",
+    "display_name": "BAND / US Dollar",
+    "description": "BAND to US Dollar spot trading pair",
+    "tags": [
+      "band",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BAT-EUR": {
+    "normalized_id": "BAT/EUR",
+    "base": "BAT",
+    "quote": "EUR",
+    "display_name": "Basic Attention Token / Euro",
+    "description": "Basic Attention Token to Euro spot trading pair",
+    "tags": [
+      "bat",
+      "basic attention token",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BAT-USD": {
+    "normalized_id": "BAT/USD",
+    "base": "BAT",
+    "quote": "USD",
+    "display_name": "Basic Attention Token / US Dollar",
+    "description": "Basic Attention Token to US Dollar spot trading pair",
+    "tags": [
+      "bat",
+      "basic attention token",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BAT-USDT": {
+    "normalized_id": "BAT/USD",
+    "base": "BAT",
+    "quote": "USD",
+    "display_name": "Basic Attention Token / US Dollar",
+    "description": "Basic Attention Token to US Dollar spot trading pair",
+    "tags": [
+      "bat",
+      "basic attention token",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BCH-BTC": {
+    "normalized_id": "BCH/BTC",
+    "base": "BCH",
+    "quote": "BTC",
+    "display_name": "Bitcoin Cash / Bitcoin",
+    "description": "Bitcoin Cash to Bitcoin spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "BCH-USD": {
+    "normalized_id": "BCH/USD",
+    "base": "BCH",
+    "quote": "USD",
+    "display_name": "Bitcoin Cash / US Dollar",
+    "description": "Bitcoin Cash to US Dollar spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BCH-USDC": {
+    "normalized_id": "BCH/USD",
+    "base": "BCH",
+    "quote": "USD",
+    "display_name": "Bitcoin Cash / US Dollar",
+    "description": "Bitcoin Cash to US Dollar spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BCH-USDT": {
+    "normalized_id": "BCH/USD",
+    "base": "BCH",
+    "quote": "USD",
+    "display_name": "Bitcoin Cash / US Dollar",
+    "description": "Bitcoin Cash to US Dollar spot trading pair",
+    "tags": [
+      "bch",
+      "bitcoin cash",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BERA-USD": {
+    "normalized_id": "BERA/USD",
+    "base": "BERA",
+    "quote": "USD",
+    "display_name": "BERA / US Dollar",
+    "description": "BERA to US Dollar spot trading pair",
+    "tags": [
+      "bera",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BERA-USDT": {
+    "normalized_id": "BERA/USD",
+    "base": "BERA",
+    "quote": "USD",
+    "display_name": "BERA / US Dollar",
+    "description": "BERA to US Dollar spot trading pair",
+    "tags": [
+      "bera",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BETH-ETH": {
+    "normalized_id": "BETH/ETH",
+    "base": "BETH",
+    "quote": "ETH",
+    "display_name": "BETH / Ethereum",
+    "description": "BETH to Ethereum spot trading pair",
+    "tags": [
+      "beth",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "BETH-USDT": {
+    "normalized_id": "BETH/USD",
+    "base": "BETH",
+    "quote": "USD",
+    "display_name": "BETH / US Dollar",
+    "description": "BETH to US Dollar spot trading pair",
+    "tags": [
+      "beth",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BICO-USD": {
+    "normalized_id": "BICO/USD",
+    "base": "BICO",
+    "quote": "USD",
+    "display_name": "BICO / US Dollar",
+    "description": "BICO to US Dollar spot trading pair",
+    "tags": [
+      "bico",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BICO-USDT": {
+    "normalized_id": "BICO/USD",
+    "base": "BICO",
+    "quote": "USD",
+    "display_name": "BICO / US Dollar",
+    "description": "BICO to US Dollar spot trading pair",
+    "tags": [
+      "bico",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BIGTIME-USD": {
+    "normalized_id": "BIGTIME/USD",
+    "base": "BIGTIME",
+    "quote": "USD",
+    "display_name": "BIGTIME / US Dollar",
+    "description": "BIGTIME to US Dollar spot trading pair",
+    "tags": [
+      "bigtime",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BIGTIME-USDT": {
+    "normalized_id": "BIGTIME/USD",
+    "base": "BIGTIME",
+    "quote": "USD",
+    "display_name": "BIGTIME / US Dollar",
+    "description": "BIGTIME to US Dollar spot trading pair",
+    "tags": [
+      "bigtime",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BIO-USD": {
+    "normalized_id": "BIO/USD",
+    "base": "BIO",
+    "quote": "USD",
+    "display_name": "BIO / US Dollar",
+    "description": "BIO to US Dollar spot trading pair",
+    "tags": [
+      "bio",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BIO-USDT": {
+    "normalized_id": "BIO/USD",
+    "base": "BIO",
+    "quote": "USD",
+    "display_name": "BIO / US Dollar",
+    "description": "BIO to US Dollar spot trading pair",
+    "tags": [
+      "bio",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BLUR-USD": {
+    "normalized_id": "BLUR/USD",
+    "base": "BLUR",
+    "quote": "USD",
+    "display_name": "BLUR / US Dollar",
+    "description": "BLUR to US Dollar spot trading pair",
+    "tags": [
+      "blur",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BLUR-USDC": {
+    "normalized_id": "BLUR/USD",
+    "base": "BLUR",
+    "quote": "USD",
+    "display_name": "BLUR / US Dollar",
+    "description": "BLUR to US Dollar spot trading pair",
+    "tags": [
+      "blur",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BLUR-USDT": {
+    "normalized_id": "BLUR/USD",
+    "base": "BLUR",
+    "quote": "USD",
+    "display_name": "BLUR / US Dollar",
+    "description": "BLUR to US Dollar spot trading pair",
+    "tags": [
+      "blur",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNB-USD": {
+    "normalized_id": "BNB/USD",
+    "base": "BNB",
+    "quote": "USD",
+    "display_name": "Binance Coin / US Dollar",
+    "description": "Binance Coin to US Dollar spot trading pair",
+    "tags": [
+      "bnb",
+      "binance coin",
+      "major",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNB-USDT": {
+    "normalized_id": "BNB/USD",
+    "base": "BNB",
+    "quote": "USD",
+    "display_name": "Binance Coin / US Dollar",
+    "description": "Binance Coin to US Dollar spot trading pair",
+    "tags": [
+      "bnb",
+      "binance coin",
+      "major",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNT-USD": {
+    "normalized_id": "BNT/USD",
+    "base": "BNT",
+    "quote": "USD",
+    "display_name": "BNT / US Dollar",
+    "description": "BNT to US Dollar spot trading pair",
+    "tags": [
+      "bnt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BNT-USDT": {
+    "normalized_id": "BNT/USD",
+    "base": "BNT",
+    "quote": "USD",
+    "display_name": "BNT / US Dollar",
+    "description": "BNT to US Dollar spot trading pair",
+    "tags": [
+      "bnt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BOME-USD": {
+    "normalized_id": "BOME/USD",
+    "base": "BOME",
+    "quote": "USD",
+    "display_name": "BOME / US Dollar",
+    "description": "BOME to US Dollar spot trading pair",
+    "tags": [
+      "bome",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BOME-USDT": {
+    "normalized_id": "BOME/USD",
+    "base": "BOME",
+    "quote": "USD",
+    "display_name": "BOME / US Dollar",
+    "description": "BOME to US Dollar spot trading pair",
+    "tags": [
+      "bome",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BONK-USD": {
+    "normalized_id": "BONK/USD",
+    "base": "BONK",
+    "quote": "USD",
+    "display_name": "Bonk / US Dollar",
+    "description": "Bonk to US Dollar spot trading pair",
+    "tags": [
+      "bonk",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BONK-USDC": {
+    "normalized_id": "BONK/USD",
+    "base": "BONK",
+    "quote": "USD",
+    "display_name": "Bonk / US Dollar",
+    "description": "Bonk to US Dollar spot trading pair",
+    "tags": [
+      "bonk",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BONK-USDT": {
+    "normalized_id": "BONK/USD",
+    "base": "BONK",
+    "quote": "USD",
+    "display_name": "Bonk / US Dollar",
+    "description": "Bonk to US Dollar spot trading pair",
+    "tags": [
+      "bonk",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BTC-AED": {
+    "normalized_id": "BTC/AED",
+    "base": "BTC",
+    "quote": "AED",
+    "display_name": "Bitcoin / AED",
+    "description": "Bitcoin to AED spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "aed"
+    ],
+    "category": "crypto"
+  },
+  "BTC-AUD": {
+    "normalized_id": "BTC/AUD",
+    "base": "BTC",
+    "quote": "AUD",
+    "display_name": "Bitcoin / Australian Dollar",
+    "description": "Bitcoin to Australian Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "BTC-BRL": {
+    "normalized_id": "BTC/BRL",
+    "base": "BTC",
+    "quote": "BRL",
+    "display_name": "Bitcoin / Brazilian Real",
+    "description": "Bitcoin to Brazilian Real spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "BTC-EUR": {
+    "normalized_id": "BTC/EUR",
+    "base": "BTC",
+    "quote": "EUR",
+    "display_name": "Bitcoin / Euro",
+    "description": "Bitcoin to Euro spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "BTC-TRY": {
+    "normalized_id": "BTC/TRY",
+    "base": "BTC",
+    "quote": "TRY",
+    "display_name": "Bitcoin / Turkish Lira",
+    "description": "Bitcoin to Turkish Lira spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "BTC-USD": {
+    "normalized_id": "BTC/USD",
+    "base": "BTC",
+    "quote": "USD",
+    "display_name": "Bitcoin / US Dollar",
+    "description": "Bitcoin to US Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BTC-USDC": {
+    "normalized_id": "BTC/USD",
+    "base": "BTC",
+    "quote": "USD",
+    "display_name": "Bitcoin / US Dollar",
+    "description": "Bitcoin to US Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BTC-USDT": {
+    "normalized_id": "BTC/USD",
+    "base": "BTC",
+    "quote": "USD",
+    "display_name": "Bitcoin / US Dollar",
+    "description": "Bitcoin to US Dollar spot trading pair",
+    "tags": [
+      "btc",
+      "bitcoin",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "BTT-USDT": {
+    "normalized_id": "BTT/USD",
+    "base": "BTT",
+    "quote": "USD",
+    "display_name": "BTT / US Dollar",
+    "description": "BTT to US Dollar spot trading pair",
+    "tags": [
+      "btt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CAT-USD": {
+    "normalized_id": "CAT/USD",
+    "base": "CAT",
+    "quote": "USD",
+    "display_name": "CAT / US Dollar",
+    "description": "CAT to US Dollar spot trading pair",
+    "tags": [
+      "cat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CAT-USDT": {
+    "normalized_id": "CAT/USD",
+    "base": "CAT",
+    "quote": "USD",
+    "display_name": "CAT / US Dollar",
+    "description": "CAT to US Dollar spot trading pair",
+    "tags": [
+      "cat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CATI-USD": {
+    "normalized_id": "CATI/USD",
+    "base": "CATI",
+    "quote": "USD",
+    "display_name": "CATI / US Dollar",
+    "description": "CATI to US Dollar spot trading pair",
+    "tags": [
+      "cati",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CATI-USDC": {
+    "normalized_id": "CATI/USD",
+    "base": "CATI",
+    "quote": "USD",
+    "display_name": "CATI / US Dollar",
+    "description": "CATI to US Dollar spot trading pair",
+    "tags": [
+      "cati",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CATI-USDT": {
+    "normalized_id": "CATI/USD",
+    "base": "CATI",
+    "quote": "USD",
+    "display_name": "CATI / US Dollar",
+    "description": "CATI to US Dollar spot trading pair",
+    "tags": [
+      "cati",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CELO-USD": {
+    "normalized_id": "CELO/USD",
+    "base": "CELO",
+    "quote": "USD",
+    "display_name": "CELO / US Dollar",
+    "description": "CELO to US Dollar spot trading pair",
+    "tags": [
+      "celo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CELO-USDT": {
+    "normalized_id": "CELO/USD",
+    "base": "CELO",
+    "quote": "USD",
+    "display_name": "CELO / US Dollar",
+    "description": "CELO to US Dollar spot trading pair",
+    "tags": [
+      "celo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CELR-USD": {
+    "normalized_id": "CELR/USD",
+    "base": "CELR",
+    "quote": "USD",
+    "display_name": "CELR / US Dollar",
+    "description": "CELR to US Dollar spot trading pair",
+    "tags": [
+      "celr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CELR-USDT": {
+    "normalized_id": "CELR/USD",
+    "base": "CELR",
+    "quote": "USD",
+    "display_name": "CELR / US Dollar",
+    "description": "CELR to US Dollar spot trading pair",
+    "tags": [
+      "celr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CETUS-USD": {
+    "normalized_id": "CETUS/USD",
+    "base": "CETUS",
+    "quote": "USD",
+    "display_name": "CETUS / US Dollar",
+    "description": "CETUS to US Dollar spot trading pair",
+    "tags": [
+      "cetus",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CETUS-USDT": {
+    "normalized_id": "CETUS/USD",
+    "base": "CETUS",
+    "quote": "USD",
+    "display_name": "CETUS / US Dollar",
+    "description": "CETUS to US Dollar spot trading pair",
+    "tags": [
+      "cetus",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CFG-USD": {
+    "normalized_id": "CFG/USD",
+    "base": "CFG",
+    "quote": "USD",
+    "display_name": "CFG / US Dollar",
+    "description": "CFG to US Dollar spot trading pair",
+    "tags": [
+      "cfg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CFG-USDT": {
+    "normalized_id": "CFG/USD",
+    "base": "CFG",
+    "quote": "USD",
+    "display_name": "CFG / US Dollar",
+    "description": "CFG to US Dollar spot trading pair",
+    "tags": [
+      "cfg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CFX-USD": {
+    "normalized_id": "CFX/USD",
+    "base": "CFX",
+    "quote": "USD",
+    "display_name": "CFX / US Dollar",
+    "description": "CFX to US Dollar spot trading pair",
+    "tags": [
+      "cfx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CFX-USDT": {
+    "normalized_id": "CFX/USD",
+    "base": "CFX",
+    "quote": "USD",
+    "display_name": "CFX / US Dollar",
+    "description": "CFX to US Dollar spot trading pair",
+    "tags": [
+      "cfx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CHZ-EUR": {
+    "normalized_id": "CHZ/EUR",
+    "base": "CHZ",
+    "quote": "EUR",
+    "display_name": "Chiliz / Euro",
+    "description": "Chiliz to Euro spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CHZ-USD": {
+    "normalized_id": "CHZ/USD",
+    "base": "CHZ",
+    "quote": "USD",
+    "display_name": "Chiliz / US Dollar",
+    "description": "Chiliz to US Dollar spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CHZ-USDC": {
+    "normalized_id": "CHZ/USD",
+    "base": "CHZ",
+    "quote": "USD",
+    "display_name": "Chiliz / US Dollar",
+    "description": "Chiliz to US Dollar spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CHZ-USDT": {
+    "normalized_id": "CHZ/USD",
+    "base": "CHZ",
+    "quote": "USD",
+    "display_name": "Chiliz / US Dollar",
+    "description": "Chiliz to US Dollar spot trading pair",
+    "tags": [
+      "chz",
+      "chiliz",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CITY-USD": {
+    "normalized_id": "CITY/USD",
+    "base": "CITY",
+    "quote": "USD",
+    "display_name": "CITY / US Dollar",
+    "description": "CITY to US Dollar spot trading pair",
+    "tags": [
+      "city",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CITY-USDT": {
+    "normalized_id": "CITY/USD",
+    "base": "CITY",
+    "quote": "USD",
+    "display_name": "CITY / US Dollar",
+    "description": "CITY to US Dollar spot trading pair",
+    "tags": [
+      "city",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CLV-USD": {
+    "normalized_id": "CLV/USD",
+    "base": "CLV",
+    "quote": "USD",
+    "display_name": "CLV / US Dollar",
+    "description": "CLV to US Dollar spot trading pair",
+    "tags": [
+      "clv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CLV-USDT": {
+    "normalized_id": "CLV/USD",
+    "base": "CLV",
+    "quote": "USD",
+    "display_name": "CLV / US Dollar",
+    "description": "CLV to US Dollar spot trading pair",
+    "tags": [
+      "clv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COMP-EUR": {
+    "normalized_id": "COMP/EUR",
+    "base": "COMP",
+    "quote": "EUR",
+    "display_name": "Compound / Euro",
+    "description": "Compound to Euro spot trading pair",
+    "tags": [
+      "comp",
+      "compound",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "COMP-USD": {
+    "normalized_id": "COMP/USD",
+    "base": "COMP",
+    "quote": "USD",
+    "display_name": "Compound / US Dollar",
+    "description": "Compound to US Dollar spot trading pair",
+    "tags": [
+      "comp",
+      "compound",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COMP-USDC": {
+    "normalized_id": "COMP/USD",
+    "base": "COMP",
+    "quote": "USD",
+    "display_name": "Compound / US Dollar",
+    "description": "Compound to US Dollar spot trading pair",
+    "tags": [
+      "comp",
+      "compound",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "COMP-USDT": {
+    "normalized_id": "COMP/USD",
+    "base": "COMP",
+    "quote": "USD",
+    "display_name": "Compound / US Dollar",
+    "description": "Compound to US Dollar spot trading pair",
+    "tags": [
+      "comp",
+      "compound",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CORE-USD": {
+    "normalized_id": "CORE/USD",
+    "base": "CORE",
+    "quote": "USD",
+    "display_name": "CORE / US Dollar",
+    "description": "CORE to US Dollar spot trading pair",
+    "tags": [
+      "core",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CORE-USDT": {
+    "normalized_id": "CORE/USD",
+    "base": "CORE",
+    "quote": "USD",
+    "display_name": "CORE / US Dollar",
+    "description": "CORE to US Dollar spot trading pair",
+    "tags": [
+      "core",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CRO-EUR": {
+    "normalized_id": "CRO/EUR",
+    "base": "CRO",
+    "quote": "EUR",
+    "display_name": "CRO / Euro",
+    "description": "CRO to Euro spot trading pair",
+    "tags": [
+      "cro",
+      "exchange",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CRO-USD": {
+    "normalized_id": "CRO/USD",
+    "base": "CRO",
+    "quote": "USD",
+    "display_name": "CRO / US Dollar",
+    "description": "CRO to US Dollar spot trading pair",
+    "tags": [
+      "cro",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CRO-USDC": {
+    "normalized_id": "CRO/USD",
+    "base": "CRO",
+    "quote": "USD",
+    "display_name": "CRO / US Dollar",
+    "description": "CRO to US Dollar spot trading pair",
+    "tags": [
+      "cro",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CRO-USDT": {
+    "normalized_id": "CRO/USD",
+    "base": "CRO",
+    "quote": "USD",
+    "display_name": "CRO / US Dollar",
+    "description": "CRO to US Dollar spot trading pair",
+    "tags": [
+      "cro",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CRV-EUR": {
+    "normalized_id": "CRV/EUR",
+    "base": "CRV",
+    "quote": "EUR",
+    "display_name": "Curve / Euro",
+    "description": "Curve to Euro spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "CRV-USD": {
+    "normalized_id": "CRV/USD",
+    "base": "CRV",
+    "quote": "USD",
+    "display_name": "Curve / US Dollar",
+    "description": "Curve to US Dollar spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CRV-USDC": {
+    "normalized_id": "CRV/USD",
+    "base": "CRV",
+    "quote": "USD",
+    "display_name": "Curve / US Dollar",
+    "description": "Curve to US Dollar spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CRV-USDT": {
+    "normalized_id": "CRV/USD",
+    "base": "CRV",
+    "quote": "USD",
+    "display_name": "Curve / US Dollar",
+    "description": "Curve to US Dollar spot trading pair",
+    "tags": [
+      "crv",
+      "curve",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CSPR-USDT": {
+    "normalized_id": "CSPR/USD",
+    "base": "CSPR",
+    "quote": "USD",
+    "display_name": "CSPR / US Dollar",
+    "description": "CSPR to US Dollar spot trading pair",
+    "tags": [
+      "cspr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CTC-USD": {
+    "normalized_id": "CTC/USD",
+    "base": "CTC",
+    "quote": "USD",
+    "display_name": "CTC / US Dollar",
+    "description": "CTC to US Dollar spot trading pair",
+    "tags": [
+      "ctc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CTC-USDT": {
+    "normalized_id": "CTC/USD",
+    "base": "CTC",
+    "quote": "USD",
+    "display_name": "CTC / US Dollar",
+    "description": "CTC to US Dollar spot trading pair",
+    "tags": [
+      "ctc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CVC-USD": {
+    "normalized_id": "CVC/USD",
+    "base": "CVC",
+    "quote": "USD",
+    "display_name": "CVC / US Dollar",
+    "description": "CVC to US Dollar spot trading pair",
+    "tags": [
+      "cvc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CVC-USDT": {
+    "normalized_id": "CVC/USD",
+    "base": "CVC",
+    "quote": "USD",
+    "display_name": "CVC / US Dollar",
+    "description": "CVC to US Dollar spot trading pair",
+    "tags": [
+      "cvc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CVX-USD": {
+    "normalized_id": "CVX/USD",
+    "base": "CVX",
+    "quote": "USD",
+    "display_name": "CVX / US Dollar",
+    "description": "CVX to US Dollar spot trading pair",
+    "tags": [
+      "cvx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CVX-USDT": {
+    "normalized_id": "CVX/USD",
+    "base": "CVX",
+    "quote": "USD",
+    "display_name": "CVX / US Dollar",
+    "description": "CVX to US Dollar spot trading pair",
+    "tags": [
+      "cvx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CXT-USD": {
+    "normalized_id": "CXT/USD",
+    "base": "CXT",
+    "quote": "USD",
+    "display_name": "CXT / US Dollar",
+    "description": "CXT to US Dollar spot trading pair",
+    "tags": [
+      "cxt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "CXT-USDT": {
+    "normalized_id": "CXT/USD",
+    "base": "CXT",
+    "quote": "USD",
+    "display_name": "CXT / US Dollar",
+    "description": "CXT to US Dollar spot trading pair",
+    "tags": [
+      "cxt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DAI-USD": {
+    "normalized_id": "DAI/USD",
+    "base": "DAI",
+    "quote": "USD",
+    "display_name": "Dai / US Dollar",
+    "description": "Dai to US Dollar spot trading pair",
+    "tags": [
+      "dai",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DAI-USDC": {
+    "normalized_id": "DAI/USD",
+    "base": "DAI",
+    "quote": "USD",
+    "display_name": "Dai / US Dollar",
+    "description": "Dai to US Dollar spot trading pair",
+    "tags": [
+      "dai",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DAI-USDT": {
+    "normalized_id": "DAI/USD",
+    "base": "DAI",
+    "quote": "USD",
+    "display_name": "Dai / US Dollar",
+    "description": "Dai to US Dollar spot trading pair",
+    "tags": [
+      "dai",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DAO-USDT": {
+    "normalized_id": "DAO/USD",
+    "base": "DAO",
+    "quote": "USD",
+    "display_name": "DAO / US Dollar",
+    "description": "DAO to US Dollar spot trading pair",
+    "tags": [
+      "dao",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DEGEN-USD": {
+    "normalized_id": "DEGEN/USD",
+    "base": "DEGEN",
+    "quote": "USD",
+    "display_name": "DEGEN / US Dollar",
+    "description": "DEGEN to US Dollar spot trading pair",
+    "tags": [
+      "degen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DEGEN-USDT": {
+    "normalized_id": "DEGEN/USD",
+    "base": "DEGEN",
+    "quote": "USD",
+    "display_name": "DEGEN / US Dollar",
+    "description": "DEGEN to US Dollar spot trading pair",
+    "tags": [
+      "degen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DEP-USD": {
+    "normalized_id": "DEP/USD",
+    "base": "DEP",
+    "quote": "USD",
+    "display_name": "DEP / US Dollar",
+    "description": "DEP to US Dollar spot trading pair",
+    "tags": [
+      "dep",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DEP-USDT": {
+    "normalized_id": "DEP/USD",
+    "base": "DEP",
+    "quote": "USD",
+    "display_name": "DEP / US Dollar",
+    "description": "DEP to US Dollar spot trading pair",
+    "tags": [
+      "dep",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DGB-USDT": {
+    "normalized_id": "DGB/USD",
+    "base": "DGB",
+    "quote": "USD",
+    "display_name": "DGB / US Dollar",
+    "description": "DGB to US Dollar spot trading pair",
+    "tags": [
+      "dgb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGE-EUR": {
+    "normalized_id": "DOGE/EUR",
+    "base": "DOGE",
+    "quote": "EUR",
+    "display_name": "Dogecoin / Euro",
+    "description": "Dogecoin to Euro spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DOGE-USD": {
+    "normalized_id": "DOGE/USD",
+    "base": "DOGE",
+    "quote": "USD",
+    "display_name": "Dogecoin / US Dollar",
+    "description": "Dogecoin to US Dollar spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGE-USDC": {
+    "normalized_id": "DOGE/USD",
+    "base": "DOGE",
+    "quote": "USD",
+    "display_name": "Dogecoin / US Dollar",
+    "description": "Dogecoin to US Dollar spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGE-USDT": {
+    "normalized_id": "DOGE/USD",
+    "base": "DOGE",
+    "quote": "USD",
+    "display_name": "Dogecoin / US Dollar",
+    "description": "Dogecoin to US Dollar spot trading pair",
+    "tags": [
+      "doge",
+      "dogecoin",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGS-USD": {
+    "normalized_id": "DOGS/USD",
+    "base": "DOGS",
+    "quote": "USD",
+    "display_name": "DOGS / US Dollar",
+    "description": "DOGS to US Dollar spot trading pair",
+    "tags": [
+      "dogs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGS-USDC": {
+    "normalized_id": "DOGS/USD",
+    "base": "DOGS",
+    "quote": "USD",
+    "display_name": "DOGS / US Dollar",
+    "description": "DOGS to US Dollar spot trading pair",
+    "tags": [
+      "dogs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOGS-USDT": {
+    "normalized_id": "DOGS/USD",
+    "base": "DOGS",
+    "quote": "USD",
+    "display_name": "DOGS / US Dollar",
+    "description": "DOGS to US Dollar spot trading pair",
+    "tags": [
+      "dogs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DORA-USDT": {
+    "normalized_id": "DORA/USD",
+    "base": "DORA",
+    "quote": "USD",
+    "display_name": "DORA / US Dollar",
+    "description": "DORA to US Dollar spot trading pair",
+    "tags": [
+      "dora",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOT-EUR": {
+    "normalized_id": "DOT/EUR",
+    "base": "DOT",
+    "quote": "EUR",
+    "display_name": "Polkadot / Euro",
+    "description": "Polkadot to Euro spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DOT-USD": {
+    "normalized_id": "DOT/USD",
+    "base": "DOT",
+    "quote": "USD",
+    "display_name": "Polkadot / US Dollar",
+    "description": "Polkadot to US Dollar spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOT-USDC": {
+    "normalized_id": "DOT/USD",
+    "base": "DOT",
+    "quote": "USD",
+    "display_name": "Polkadot / US Dollar",
+    "description": "Polkadot to US Dollar spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DOT-USDT": {
+    "normalized_id": "DOT/USD",
+    "base": "DOT",
+    "quote": "USD",
+    "display_name": "Polkadot / US Dollar",
+    "description": "Polkadot to US Dollar spot trading pair",
+    "tags": [
+      "dot",
+      "polkadot",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DUCK-USD": {
+    "normalized_id": "DUCK/USD",
+    "base": "DUCK",
+    "quote": "USD",
+    "display_name": "DUCK / US Dollar",
+    "description": "DUCK to US Dollar spot trading pair",
+    "tags": [
+      "duck",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DUCK-USDT": {
+    "normalized_id": "DUCK/USD",
+    "base": "DUCK",
+    "quote": "USD",
+    "display_name": "DUCK / US Dollar",
+    "description": "DUCK to US Dollar spot trading pair",
+    "tags": [
+      "duck",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DYDX-EUR": {
+    "normalized_id": "DYDX/EUR",
+    "base": "DYDX",
+    "quote": "EUR",
+    "display_name": "DYDX / Euro",
+    "description": "DYDX to Euro spot trading pair",
+    "tags": [
+      "dydx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "DYDX-USD": {
+    "normalized_id": "DYDX/USD",
+    "base": "DYDX",
+    "quote": "USD",
+    "display_name": "DYDX / US Dollar",
+    "description": "DYDX to US Dollar spot trading pair",
+    "tags": [
+      "dydx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DYDX-USDC": {
+    "normalized_id": "DYDX/USD",
+    "base": "DYDX",
+    "quote": "USD",
+    "display_name": "DYDX / US Dollar",
+    "description": "DYDX to US Dollar spot trading pair",
+    "tags": [
+      "dydx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "DYDX-USDT": {
+    "normalized_id": "DYDX/USD",
+    "base": "DYDX",
+    "quote": "USD",
+    "display_name": "DYDX / US Dollar",
+    "description": "DYDX to US Dollar spot trading pair",
+    "tags": [
+      "dydx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EGLD-EUR": {
+    "normalized_id": "EGLD/EUR",
+    "base": "EGLD",
+    "quote": "EUR",
+    "display_name": "MultiversX / Euro",
+    "description": "MultiversX to Euro spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "EGLD-USD": {
+    "normalized_id": "EGLD/USD",
+    "base": "EGLD",
+    "quote": "USD",
+    "display_name": "MultiversX / US Dollar",
+    "description": "MultiversX to US Dollar spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EGLD-USDT": {
+    "normalized_id": "EGLD/USD",
+    "base": "EGLD",
+    "quote": "USD",
+    "display_name": "MultiversX / US Dollar",
+    "description": "MultiversX to US Dollar spot trading pair",
+    "tags": [
+      "egld",
+      "multiversx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EIGEN-USD": {
+    "normalized_id": "EIGEN/USD",
+    "base": "EIGEN",
+    "quote": "USD",
+    "display_name": "EIGEN / US Dollar",
+    "description": "EIGEN to US Dollar spot trading pair",
+    "tags": [
+      "eigen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EIGEN-USDC": {
+    "normalized_id": "EIGEN/USD",
+    "base": "EIGEN",
+    "quote": "USD",
+    "display_name": "EIGEN / US Dollar",
+    "description": "EIGEN to US Dollar spot trading pair",
+    "tags": [
+      "eigen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EIGEN-USDT": {
+    "normalized_id": "EIGEN/USD",
+    "base": "EIGEN",
+    "quote": "USD",
+    "display_name": "EIGEN / US Dollar",
+    "description": "EIGEN to US Dollar spot trading pair",
+    "tags": [
+      "eigen",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ELF-USD": {
+    "normalized_id": "ELF/USD",
+    "base": "ELF",
+    "quote": "USD",
+    "display_name": "ELF / US Dollar",
+    "description": "ELF to US Dollar spot trading pair",
+    "tags": [
+      "elf",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ELF-USDT": {
+    "normalized_id": "ELF/USD",
+    "base": "ELF",
+    "quote": "USD",
+    "display_name": "ELF / US Dollar",
+    "description": "ELF to US Dollar spot trading pair",
+    "tags": [
+      "elf",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ELON-USD": {
+    "normalized_id": "ELON/USD",
+    "base": "ELON",
+    "quote": "USD",
+    "display_name": "ELON / US Dollar",
+    "description": "ELON to US Dollar spot trading pair",
+    "tags": [
+      "elon",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ELON-USDT": {
+    "normalized_id": "ELON/USD",
+    "base": "ELON",
+    "quote": "USD",
+    "display_name": "ELON / US Dollar",
+    "description": "ELON to US Dollar spot trading pair",
+    "tags": [
+      "elon",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENJ-USD": {
+    "normalized_id": "ENJ/USD",
+    "base": "ENJ",
+    "quote": "USD",
+    "display_name": "Enjin / US Dollar",
+    "description": "Enjin to US Dollar spot trading pair",
+    "tags": [
+      "enj",
+      "enjin",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENJ-USDT": {
+    "normalized_id": "ENJ/USD",
+    "base": "ENJ",
+    "quote": "USD",
+    "display_name": "Enjin / US Dollar",
+    "description": "Enjin to US Dollar spot trading pair",
+    "tags": [
+      "enj",
+      "enjin",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENS-USD": {
+    "normalized_id": "ENS/USD",
+    "base": "ENS",
+    "quote": "USD",
+    "display_name": "ENS / US Dollar",
+    "description": "ENS to US Dollar spot trading pair",
+    "tags": [
+      "ens",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENS-USDC": {
+    "normalized_id": "ENS/USD",
+    "base": "ENS",
+    "quote": "USD",
+    "display_name": "ENS / US Dollar",
+    "description": "ENS to US Dollar spot trading pair",
+    "tags": [
+      "ens",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ENS-USDT": {
+    "normalized_id": "ENS/USD",
+    "base": "ENS",
+    "quote": "USD",
+    "display_name": "ENS / US Dollar",
+    "description": "ENS to US Dollar spot trading pair",
+    "tags": [
+      "ens",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ERN-USD": {
+    "normalized_id": "ERN/USD",
+    "base": "ERN",
+    "quote": "USD",
+    "display_name": "ERN / US Dollar",
+    "description": "ERN to US Dollar spot trading pair",
+    "tags": [
+      "ern",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ERN-USDT": {
+    "normalized_id": "ERN/USD",
+    "base": "ERN",
+    "quote": "USD",
+    "display_name": "ERN / US Dollar",
+    "description": "ERN to US Dollar spot trading pair",
+    "tags": [
+      "ern",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETC-USD": {
+    "normalized_id": "ETC/USD",
+    "base": "ETC",
+    "quote": "USD",
+    "display_name": "ETC / US Dollar",
+    "description": "ETC to US Dollar spot trading pair",
+    "tags": [
+      "etc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETC-USDC": {
+    "normalized_id": "ETC/USD",
+    "base": "ETC",
+    "quote": "USD",
+    "display_name": "ETC / US Dollar",
+    "description": "ETC to US Dollar spot trading pair",
+    "tags": [
+      "etc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETC-USDT": {
+    "normalized_id": "ETC/USD",
+    "base": "ETC",
+    "quote": "USD",
+    "display_name": "ETC / US Dollar",
+    "description": "ETC to US Dollar spot trading pair",
+    "tags": [
+      "etc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETH-AED": {
+    "normalized_id": "ETH/AED",
+    "base": "ETH",
+    "quote": "AED",
+    "display_name": "Ethereum / AED",
+    "description": "Ethereum to AED spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "aed"
+    ],
+    "category": "crypto"
+  },
+  "ETH-AUD": {
+    "normalized_id": "ETH/AUD",
+    "base": "ETH",
+    "quote": "AUD",
+    "display_name": "Ethereum / Australian Dollar",
+    "description": "Ethereum to Australian Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "ETH-BRL": {
+    "normalized_id": "ETH/BRL",
+    "base": "ETH",
+    "quote": "BRL",
+    "display_name": "Ethereum / Brazilian Real",
+    "description": "Ethereum to Brazilian Real spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "ETH-BTC": {
+    "normalized_id": "ETH/BTC",
+    "base": "ETH",
+    "quote": "BTC",
+    "display_name": "Ethereum / Bitcoin",
+    "description": "Ethereum to Bitcoin spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "ETH-EUR": {
+    "normalized_id": "ETH/EUR",
+    "base": "ETH",
+    "quote": "EUR",
+    "display_name": "Ethereum / Euro",
+    "description": "Ethereum to Euro spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ETH-TRY": {
+    "normalized_id": "ETH/TRY",
+    "base": "ETH",
+    "quote": "TRY",
+    "display_name": "Ethereum / Turkish Lira",
+    "description": "Ethereum to Turkish Lira spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "ETH-USD": {
+    "normalized_id": "ETH/USD",
+    "base": "ETH",
+    "quote": "USD",
+    "display_name": "Ethereum / US Dollar",
+    "description": "Ethereum to US Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETH-USDC": {
+    "normalized_id": "ETH/USD",
+    "base": "ETH",
+    "quote": "USD",
+    "display_name": "Ethereum / US Dollar",
+    "description": "Ethereum to US Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETH-USDT": {
+    "normalized_id": "ETH/USD",
+    "base": "ETH",
+    "quote": "USD",
+    "display_name": "Ethereum / US Dollar",
+    "description": "Ethereum to US Dollar spot trading pair",
+    "tags": [
+      "eth",
+      "ethereum",
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETHFI-USD": {
+    "normalized_id": "ETHFI/USD",
+    "base": "ETHFI",
+    "quote": "USD",
+    "display_name": "ETHFI / US Dollar",
+    "description": "ETHFI to US Dollar spot trading pair",
+    "tags": [
+      "ethfi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETHFI-USDC": {
+    "normalized_id": "ETHFI/USD",
+    "base": "ETHFI",
+    "quote": "USD",
+    "display_name": "ETHFI / US Dollar",
+    "description": "ETHFI to US Dollar spot trading pair",
+    "tags": [
+      "ethfi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETHFI-USDT": {
+    "normalized_id": "ETHFI/USD",
+    "base": "ETHFI",
+    "quote": "USD",
+    "display_name": "ETHFI / US Dollar",
+    "description": "ETHFI to US Dollar spot trading pair",
+    "tags": [
+      "ethfi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETHW-USD": {
+    "normalized_id": "ETHW/USD",
+    "base": "ETHW",
+    "quote": "USD",
+    "display_name": "ETHW / US Dollar",
+    "description": "ETHW to US Dollar spot trading pair",
+    "tags": [
+      "ethw",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETHW-USDC": {
+    "normalized_id": "ETHW/USD",
+    "base": "ETHW",
+    "quote": "USD",
+    "display_name": "ETHW / US Dollar",
+    "description": "ETHW to US Dollar spot trading pair",
+    "tags": [
+      "ethw",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ETHW-USDT": {
+    "normalized_id": "ETHW/USD",
+    "base": "ETHW",
+    "quote": "USD",
+    "display_name": "ETHW / US Dollar",
+    "description": "ETHW to US Dollar spot trading pair",
+    "tags": [
+      "ethw",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "EURC-USD": {
+    "normalized_id": "EURC/USD",
+    "base": "EURC",
+    "quote": "USD",
+    "display_name": "EURC / US Dollar",
+    "description": "EURC to US Dollar spot trading pair",
+    "tags": [
+      "eurc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FET-EUR": {
+    "normalized_id": "FET/EUR",
+    "base": "FET",
+    "quote": "EUR",
+    "display_name": "FET / Euro",
+    "description": "FET to Euro spot trading pair",
+    "tags": [
+      "fet",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FET-USDT": {
+    "normalized_id": "FET/USD",
+    "base": "FET",
+    "quote": "USD",
+    "display_name": "FET / US Dollar",
+    "description": "FET to US Dollar spot trading pair",
+    "tags": [
+      "fet",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FIL-USD": {
+    "normalized_id": "FIL/USD",
+    "base": "FIL",
+    "quote": "USD",
+    "display_name": "Filecoin / US Dollar",
+    "description": "Filecoin to US Dollar spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FIL-USDC": {
+    "normalized_id": "FIL/USD",
+    "base": "FIL",
+    "quote": "USD",
+    "display_name": "Filecoin / US Dollar",
+    "description": "Filecoin to US Dollar spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FIL-USDT": {
+    "normalized_id": "FIL/USD",
+    "base": "FIL",
+    "quote": "USD",
+    "display_name": "Filecoin / US Dollar",
+    "description": "Filecoin to US Dollar spot trading pair",
+    "tags": [
+      "fil",
+      "filecoin",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLM-USD": {
+    "normalized_id": "FLM/USD",
+    "base": "FLM",
+    "quote": "USD",
+    "display_name": "FLM / US Dollar",
+    "description": "FLM to US Dollar spot trading pair",
+    "tags": [
+      "flm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLM-USDT": {
+    "normalized_id": "FLM/USD",
+    "base": "FLM",
+    "quote": "USD",
+    "display_name": "FLM / US Dollar",
+    "description": "FLM to US Dollar spot trading pair",
+    "tags": [
+      "flm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLOKI-USD": {
+    "normalized_id": "FLOKI/USD",
+    "base": "FLOKI",
+    "quote": "USD",
+    "display_name": "Floki / US Dollar",
+    "description": "Floki to US Dollar spot trading pair",
+    "tags": [
+      "floki",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLOKI-USDT": {
+    "normalized_id": "FLOKI/USD",
+    "base": "FLOKI",
+    "quote": "USD",
+    "display_name": "Floki / US Dollar",
+    "description": "Floki to US Dollar spot trading pair",
+    "tags": [
+      "floki",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLOW-EUR": {
+    "normalized_id": "FLOW/EUR",
+    "base": "FLOW",
+    "quote": "EUR",
+    "display_name": "Flow / Euro",
+    "description": "Flow to Euro spot trading pair",
+    "tags": [
+      "flow",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FLOW-USD": {
+    "normalized_id": "FLOW/USD",
+    "base": "FLOW",
+    "quote": "USD",
+    "display_name": "Flow / US Dollar",
+    "description": "Flow to US Dollar spot trading pair",
+    "tags": [
+      "flow",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLOW-USDT": {
+    "normalized_id": "FLOW/USD",
+    "base": "FLOW",
+    "quote": "USD",
+    "display_name": "Flow / US Dollar",
+    "description": "Flow to US Dollar spot trading pair",
+    "tags": [
+      "flow",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLR-EUR": {
+    "normalized_id": "FLR/EUR",
+    "base": "FLR",
+    "quote": "EUR",
+    "display_name": "FLR / Euro",
+    "description": "FLR to Euro spot trading pair",
+    "tags": [
+      "flr",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FLR-USD": {
+    "normalized_id": "FLR/USD",
+    "base": "FLR",
+    "quote": "USD",
+    "display_name": "FLR / US Dollar",
+    "description": "FLR to US Dollar spot trading pair",
+    "tags": [
+      "flr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLR-USDC": {
+    "normalized_id": "FLR/USD",
+    "base": "FLR",
+    "quote": "USD",
+    "display_name": "FLR / US Dollar",
+    "description": "FLR to US Dollar spot trading pair",
+    "tags": [
+      "flr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLR-USDT": {
+    "normalized_id": "FLR/USD",
+    "base": "FLR",
+    "quote": "USD",
+    "display_name": "FLR / US Dollar",
+    "description": "FLR to US Dollar spot trading pair",
+    "tags": [
+      "flr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLUID-USD": {
+    "normalized_id": "FLUID/USD",
+    "base": "FLUID",
+    "quote": "USD",
+    "display_name": "FLUID / US Dollar",
+    "description": "FLUID to US Dollar spot trading pair",
+    "tags": [
+      "fluid",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FLUID-USDT": {
+    "normalized_id": "FLUID/USD",
+    "base": "FLUID",
+    "quote": "USD",
+    "display_name": "FLUID / US Dollar",
+    "description": "FLUID to US Dollar spot trading pair",
+    "tags": [
+      "fluid",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FORTH-USD": {
+    "normalized_id": "FORTH/USD",
+    "base": "FORTH",
+    "quote": "USD",
+    "display_name": "FORTH / US Dollar",
+    "description": "FORTH to US Dollar spot trading pair",
+    "tags": [
+      "forth",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FORTH-USDT": {
+    "normalized_id": "FORTH/USD",
+    "base": "FORTH",
+    "quote": "USD",
+    "display_name": "FORTH / US Dollar",
+    "description": "FORTH to US Dollar spot trading pair",
+    "tags": [
+      "forth",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FOXY-USDT": {
+    "normalized_id": "FOXY/USD",
+    "base": "FOXY",
+    "quote": "USD",
+    "display_name": "FOXY / US Dollar",
+    "description": "FOXY to US Dollar spot trading pair",
+    "tags": [
+      "foxy",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "FXS-EUR": {
+    "normalized_id": "FXS/EUR",
+    "base": "FXS",
+    "quote": "EUR",
+    "display_name": "FXS / Euro",
+    "description": "FXS to Euro spot trading pair",
+    "tags": [
+      "fxs",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "FXS-USDT": {
+    "normalized_id": "FXS/USD",
+    "base": "FXS",
+    "quote": "USD",
+    "display_name": "FXS / US Dollar",
+    "description": "FXS to US Dollar spot trading pair",
+    "tags": [
+      "fxs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "G-USD": {
+    "normalized_id": "G/USD",
+    "base": "G",
+    "quote": "USD",
+    "display_name": "G / US Dollar",
+    "description": "G to US Dollar spot trading pair",
+    "tags": [
+      "g",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "G-USDT": {
+    "normalized_id": "G/USD",
+    "base": "G",
+    "quote": "USD",
+    "display_name": "G / US Dollar",
+    "description": "G to US Dollar spot trading pair",
+    "tags": [
+      "g",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GALA-USD": {
+    "normalized_id": "GALA/USD",
+    "base": "GALA",
+    "quote": "USD",
+    "display_name": "Gala / US Dollar",
+    "description": "Gala to US Dollar spot trading pair",
+    "tags": [
+      "gala",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GALA-USDC": {
+    "normalized_id": "GALA/USD",
+    "base": "GALA",
+    "quote": "USD",
+    "display_name": "Gala / US Dollar",
+    "description": "Gala to US Dollar spot trading pair",
+    "tags": [
+      "gala",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GALA-USDT": {
+    "normalized_id": "GALA/USD",
+    "base": "GALA",
+    "quote": "USD",
+    "display_name": "Gala / US Dollar",
+    "description": "Gala to US Dollar spot trading pair",
+    "tags": [
+      "gala",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GALFT-USDT": {
+    "normalized_id": "GALFT/USD",
+    "base": "GALFT",
+    "quote": "USD",
+    "display_name": "GALFT / US Dollar",
+    "description": "GALFT to US Dollar spot trading pair",
+    "tags": [
+      "galft",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GAS-USD": {
+    "normalized_id": "GAS/USD",
+    "base": "GAS",
+    "quote": "USD",
+    "display_name": "GAS / US Dollar",
+    "description": "GAS to US Dollar spot trading pair",
+    "tags": [
+      "gas",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GAS-USDT": {
+    "normalized_id": "GAS/USD",
+    "base": "GAS",
+    "quote": "USD",
+    "display_name": "GAS / US Dollar",
+    "description": "GAS to US Dollar spot trading pair",
+    "tags": [
+      "gas",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GEAR-USD": {
+    "normalized_id": "GEAR/USD",
+    "base": "GEAR",
+    "quote": "USD",
+    "display_name": "GEAR / US Dollar",
+    "description": "GEAR to US Dollar spot trading pair",
+    "tags": [
+      "gear",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GEAR-USDT": {
+    "normalized_id": "GEAR/USD",
+    "base": "GEAR",
+    "quote": "USD",
+    "display_name": "GEAR / US Dollar",
+    "description": "GEAR to US Dollar spot trading pair",
+    "tags": [
+      "gear",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GHST-USD": {
+    "normalized_id": "GHST/USD",
+    "base": "GHST",
+    "quote": "USD",
+    "display_name": "GHST / US Dollar",
+    "description": "GHST to US Dollar spot trading pair",
+    "tags": [
+      "ghst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GHST-USDT": {
+    "normalized_id": "GHST/USD",
+    "base": "GHST",
+    "quote": "USD",
+    "display_name": "GHST / US Dollar",
+    "description": "GHST to US Dollar spot trading pair",
+    "tags": [
+      "ghst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GLM-USD": {
+    "normalized_id": "GLM/USD",
+    "base": "GLM",
+    "quote": "USD",
+    "display_name": "GLM / US Dollar",
+    "description": "GLM to US Dollar spot trading pair",
+    "tags": [
+      "glm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GLM-USDT": {
+    "normalized_id": "GLM/USD",
+    "base": "GLM",
+    "quote": "USD",
+    "display_name": "GLM / US Dollar",
+    "description": "GLM to US Dollar spot trading pair",
+    "tags": [
+      "glm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GLMR-USDT": {
+    "normalized_id": "GLMR/USD",
+    "base": "GLMR",
+    "quote": "USD",
+    "display_name": "GLMR / US Dollar",
+    "description": "GLMR to US Dollar spot trading pair",
+    "tags": [
+      "glmr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GMT-USD": {
+    "normalized_id": "GMT/USD",
+    "base": "GMT",
+    "quote": "USD",
+    "display_name": "GMT / US Dollar",
+    "description": "GMT to US Dollar spot trading pair",
+    "tags": [
+      "gmt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GMT-USDT": {
+    "normalized_id": "GMT/USD",
+    "base": "GMT",
+    "quote": "USD",
+    "display_name": "GMT / US Dollar",
+    "description": "GMT to US Dollar spot trading pair",
+    "tags": [
+      "gmt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GMX-USDT": {
+    "normalized_id": "GMX/USD",
+    "base": "GMX",
+    "quote": "USD",
+    "display_name": "GMX / US Dollar",
+    "description": "GMX to US Dollar spot trading pair",
+    "tags": [
+      "gmx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GOAT-USD": {
+    "normalized_id": "GOAT/USD",
+    "base": "GOAT",
+    "quote": "USD",
+    "display_name": "GOAT / US Dollar",
+    "description": "GOAT to US Dollar spot trading pair",
+    "tags": [
+      "goat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GOAT-USDT": {
+    "normalized_id": "GOAT/USD",
+    "base": "GOAT",
+    "quote": "USD",
+    "display_name": "GOAT / US Dollar",
+    "description": "GOAT to US Dollar spot trading pair",
+    "tags": [
+      "goat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GODS-USD": {
+    "normalized_id": "GODS/USD",
+    "base": "GODS",
+    "quote": "USD",
+    "display_name": "GODS / US Dollar",
+    "description": "GODS to US Dollar spot trading pair",
+    "tags": [
+      "gods",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GODS-USDT": {
+    "normalized_id": "GODS/USD",
+    "base": "GODS",
+    "quote": "USD",
+    "display_name": "GODS / US Dollar",
+    "description": "GODS to US Dollar spot trading pair",
+    "tags": [
+      "gods",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GRT-EUR": {
+    "normalized_id": "GRT/EUR",
+    "base": "GRT",
+    "quote": "EUR",
+    "display_name": "GRT / Euro",
+    "description": "GRT to Euro spot trading pair",
+    "tags": [
+      "grt",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "GRT-USD": {
+    "normalized_id": "GRT/USD",
+    "base": "GRT",
+    "quote": "USD",
+    "display_name": "GRT / US Dollar",
+    "description": "GRT to US Dollar spot trading pair",
+    "tags": [
+      "grt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GRT-USDC": {
+    "normalized_id": "GRT/USD",
+    "base": "GRT",
+    "quote": "USD",
+    "display_name": "GRT / US Dollar",
+    "description": "GRT to US Dollar spot trading pair",
+    "tags": [
+      "grt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "GRT-USDT": {
+    "normalized_id": "GRT/USD",
+    "base": "GRT",
+    "quote": "USD",
+    "display_name": "GRT / US Dollar",
+    "description": "GRT to US Dollar spot trading pair",
+    "tags": [
+      "grt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HBAR-EUR": {
+    "normalized_id": "HBAR/EUR",
+    "base": "HBAR",
+    "quote": "EUR",
+    "display_name": "Hedera / Euro",
+    "description": "Hedera to Euro spot trading pair",
+    "tags": [
+      "hbar",
+      "hedera",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "HBAR-USD": {
+    "normalized_id": "HBAR/USD",
+    "base": "HBAR",
+    "quote": "USD",
+    "display_name": "Hedera / US Dollar",
+    "description": "Hedera to US Dollar spot trading pair",
+    "tags": [
+      "hbar",
+      "hedera",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HBAR-USDC": {
+    "normalized_id": "HBAR/USD",
+    "base": "HBAR",
+    "quote": "USD",
+    "display_name": "Hedera / US Dollar",
+    "description": "Hedera to US Dollar spot trading pair",
+    "tags": [
+      "hbar",
+      "hedera",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HBAR-USDT": {
+    "normalized_id": "HBAR/USD",
+    "base": "HBAR",
+    "quote": "USD",
+    "display_name": "Hedera / US Dollar",
+    "description": "Hedera to US Dollar spot trading pair",
+    "tags": [
+      "hbar",
+      "hedera",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HMSTR-USD": {
+    "normalized_id": "HMSTR/USD",
+    "base": "HMSTR",
+    "quote": "USD",
+    "display_name": "HMSTR / US Dollar",
+    "description": "HMSTR to US Dollar spot trading pair",
+    "tags": [
+      "hmstr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HMSTR-USDT": {
+    "normalized_id": "HMSTR/USD",
+    "base": "HMSTR",
+    "quote": "USD",
+    "display_name": "HMSTR / US Dollar",
+    "description": "HMSTR to US Dollar spot trading pair",
+    "tags": [
+      "hmstr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "HUMA-USDT": {
+    "normalized_id": "HUMA/USD",
+    "base": "HUMA",
+    "quote": "USD",
+    "display_name": "HUMA / US Dollar",
+    "description": "HUMA to US Dollar spot trading pair",
+    "tags": [
+      "huma",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICE-USD": {
+    "normalized_id": "ICE/USD",
+    "base": "ICE",
+    "quote": "USD",
+    "display_name": "ICE / US Dollar",
+    "description": "ICE to US Dollar spot trading pair",
+    "tags": [
+      "ice",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICE-USDT": {
+    "normalized_id": "ICE/USD",
+    "base": "ICE",
+    "quote": "USD",
+    "display_name": "ICE / US Dollar",
+    "description": "ICE to US Dollar spot trading pair",
+    "tags": [
+      "ice",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICP-EUR": {
+    "normalized_id": "ICP/EUR",
+    "base": "ICP",
+    "quote": "EUR",
+    "display_name": "Internet Computer / Euro",
+    "description": "Internet Computer to Euro spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "ICP-USD": {
+    "normalized_id": "ICP/USD",
+    "base": "ICP",
+    "quote": "USD",
+    "display_name": "Internet Computer / US Dollar",
+    "description": "Internet Computer to US Dollar spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICP-USDC": {
+    "normalized_id": "ICP/USD",
+    "base": "ICP",
+    "quote": "USD",
+    "display_name": "Internet Computer / US Dollar",
+    "description": "Internet Computer to US Dollar spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICP-USDT": {
+    "normalized_id": "ICP/USD",
+    "base": "ICP",
+    "quote": "USD",
+    "display_name": "Internet Computer / US Dollar",
+    "description": "Internet Computer to US Dollar spot trading pair",
+    "tags": [
+      "icp",
+      "internet computer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICX-USD": {
+    "normalized_id": "ICX/USD",
+    "base": "ICX",
+    "quote": "USD",
+    "display_name": "ICX / US Dollar",
+    "description": "ICX to US Dollar spot trading pair",
+    "tags": [
+      "icx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ICX-USDT": {
+    "normalized_id": "ICX/USD",
+    "base": "ICX",
+    "quote": "USD",
+    "display_name": "ICX / US Dollar",
+    "description": "ICX to US Dollar spot trading pair",
+    "tags": [
+      "icx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ID-USD": {
+    "normalized_id": "ID/USD",
+    "base": "ID",
+    "quote": "USD",
+    "display_name": "ID / US Dollar",
+    "description": "ID to US Dollar spot trading pair",
+    "tags": [
+      "id",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ID-USDT": {
+    "normalized_id": "ID/USD",
+    "base": "ID",
+    "quote": "USD",
+    "display_name": "ID / US Dollar",
+    "description": "ID to US Dollar spot trading pair",
+    "tags": [
+      "id",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ILV-USD": {
+    "normalized_id": "ILV/USD",
+    "base": "ILV",
+    "quote": "USD",
+    "display_name": "ILV / US Dollar",
+    "description": "ILV to US Dollar spot trading pair",
+    "tags": [
+      "ilv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ILV-USDT": {
+    "normalized_id": "ILV/USD",
+    "base": "ILV",
+    "quote": "USD",
+    "display_name": "ILV / US Dollar",
+    "description": "ILV to US Dollar spot trading pair",
+    "tags": [
+      "ilv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IMX-EUR": {
+    "normalized_id": "IMX/EUR",
+    "base": "IMX",
+    "quote": "EUR",
+    "display_name": "IMX / Euro",
+    "description": "IMX to Euro spot trading pair",
+    "tags": [
+      "imx",
+      "layer2",
+      "gaming",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "IMX-USD": {
+    "normalized_id": "IMX/USD",
+    "base": "IMX",
+    "quote": "USD",
+    "display_name": "IMX / US Dollar",
+    "description": "IMX to US Dollar spot trading pair",
+    "tags": [
+      "imx",
+      "layer2",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IMX-USDT": {
+    "normalized_id": "IMX/USD",
+    "base": "IMX",
+    "quote": "USD",
+    "display_name": "IMX / US Dollar",
+    "description": "IMX to US Dollar spot trading pair",
+    "tags": [
+      "imx",
+      "layer2",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "INJ-EUR": {
+    "normalized_id": "INJ/EUR",
+    "base": "INJ",
+    "quote": "EUR",
+    "display_name": "Injective / Euro",
+    "description": "Injective to Euro spot trading pair",
+    "tags": [
+      "inj",
+      "injective",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "INJ-USDT": {
+    "normalized_id": "INJ/USD",
+    "base": "INJ",
+    "quote": "USD",
+    "display_name": "Injective / US Dollar",
+    "description": "Injective to US Dollar spot trading pair",
+    "tags": [
+      "inj",
+      "injective",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IOST-USD": {
+    "normalized_id": "IOST/USD",
+    "base": "IOST",
+    "quote": "USD",
+    "display_name": "IOST / US Dollar",
+    "description": "IOST to US Dollar spot trading pair",
+    "tags": [
+      "iost",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IOST-USDT": {
+    "normalized_id": "IOST/USD",
+    "base": "IOST",
+    "quote": "USD",
+    "display_name": "IOST / US Dollar",
+    "description": "IOST to US Dollar spot trading pair",
+    "tags": [
+      "iost",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IOTA-USD": {
+    "normalized_id": "IOTA/USD",
+    "base": "IOTA",
+    "quote": "USD",
+    "display_name": "IOTA / US Dollar",
+    "description": "IOTA to US Dollar spot trading pair",
+    "tags": [
+      "iota",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IOTA-USDT": {
+    "normalized_id": "IOTA/USD",
+    "base": "IOTA",
+    "quote": "USD",
+    "display_name": "IOTA / US Dollar",
+    "description": "IOTA to US Dollar spot trading pair",
+    "tags": [
+      "iota",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IP-USD": {
+    "normalized_id": "IP/USD",
+    "base": "IP",
+    "quote": "USD",
+    "display_name": "IP / US Dollar",
+    "description": "IP to US Dollar spot trading pair",
+    "tags": [
+      "ip",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "IP-USDT": {
+    "normalized_id": "IP/USD",
+    "base": "IP",
+    "quote": "USD",
+    "display_name": "IP / US Dollar",
+    "description": "IP to US Dollar spot trading pair",
+    "tags": [
+      "ip",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "J-USDT": {
+    "normalized_id": "J/USD",
+    "base": "J",
+    "quote": "USD",
+    "display_name": "J / US Dollar",
+    "description": "J to US Dollar spot trading pair",
+    "tags": [
+      "j",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JITOSOL-USDT": {
+    "normalized_id": "JITOSOL/USD",
+    "base": "JITOSOL",
+    "quote": "USD",
+    "display_name": "JITOSOL / US Dollar",
+    "description": "JITOSOL to US Dollar spot trading pair",
+    "tags": [
+      "jitosol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JOE-USD": {
+    "normalized_id": "JOE/USD",
+    "base": "JOE",
+    "quote": "USD",
+    "display_name": "JOE / US Dollar",
+    "description": "JOE to US Dollar spot trading pair",
+    "tags": [
+      "joe",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JOE-USDT": {
+    "normalized_id": "JOE/USD",
+    "base": "JOE",
+    "quote": "USD",
+    "display_name": "JOE / US Dollar",
+    "description": "JOE to US Dollar spot trading pair",
+    "tags": [
+      "joe",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JST-USD": {
+    "normalized_id": "JST/USD",
+    "base": "JST",
+    "quote": "USD",
+    "display_name": "JST / US Dollar",
+    "description": "JST to US Dollar spot trading pair",
+    "tags": [
+      "jst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JST-USDT": {
+    "normalized_id": "JST/USD",
+    "base": "JST",
+    "quote": "USD",
+    "display_name": "JST / US Dollar",
+    "description": "JST to US Dollar spot trading pair",
+    "tags": [
+      "jst",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JTO-EUR": {
+    "normalized_id": "JTO/EUR",
+    "base": "JTO",
+    "quote": "EUR",
+    "display_name": "JTO / Euro",
+    "description": "JTO to Euro spot trading pair",
+    "tags": [
+      "jto",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "JTO-USD": {
+    "normalized_id": "JTO/USD",
+    "base": "JTO",
+    "quote": "USD",
+    "display_name": "JTO / US Dollar",
+    "description": "JTO to US Dollar spot trading pair",
+    "tags": [
+      "jto",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JTO-USDC": {
+    "normalized_id": "JTO/USD",
+    "base": "JTO",
+    "quote": "USD",
+    "display_name": "JTO / US Dollar",
+    "description": "JTO to US Dollar spot trading pair",
+    "tags": [
+      "jto",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JTO-USDT": {
+    "normalized_id": "JTO/USD",
+    "base": "JTO",
+    "quote": "USD",
+    "display_name": "JTO / US Dollar",
+    "description": "JTO to US Dollar spot trading pair",
+    "tags": [
+      "jto",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JUP-USD": {
+    "normalized_id": "JUP/USD",
+    "base": "JUP",
+    "quote": "USD",
+    "display_name": "Jupiter / US Dollar",
+    "description": "Jupiter to US Dollar spot trading pair",
+    "tags": [
+      "jup",
+      "jupiter",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JUP-USDC": {
+    "normalized_id": "JUP/USD",
+    "base": "JUP",
+    "quote": "USD",
+    "display_name": "Jupiter / US Dollar",
+    "description": "Jupiter to US Dollar spot trading pair",
+    "tags": [
+      "jup",
+      "jupiter",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "JUP-USDT": {
+    "normalized_id": "JUP/USD",
+    "base": "JUP",
+    "quote": "USD",
+    "display_name": "Jupiter / US Dollar",
+    "description": "Jupiter to US Dollar spot trading pair",
+    "tags": [
+      "jup",
+      "jupiter",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAIA-USD": {
+    "normalized_id": "KAIA/USD",
+    "base": "KAIA",
+    "quote": "USD",
+    "display_name": "KAIA / US Dollar",
+    "description": "KAIA to US Dollar spot trading pair",
+    "tags": [
+      "kaia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAIA-USDT": {
+    "normalized_id": "KAIA/USD",
+    "base": "KAIA",
+    "quote": "USD",
+    "display_name": "KAIA / US Dollar",
+    "description": "KAIA to US Dollar spot trading pair",
+    "tags": [
+      "kaia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAITO-USD": {
+    "normalized_id": "KAITO/USD",
+    "base": "KAITO",
+    "quote": "USD",
+    "display_name": "KAITO / US Dollar",
+    "description": "KAITO to US Dollar spot trading pair",
+    "tags": [
+      "kaito",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KAITO-USDT": {
+    "normalized_id": "KAITO/USD",
+    "base": "KAITO",
+    "quote": "USD",
+    "display_name": "KAITO / US Dollar",
+    "description": "KAITO to US Dollar spot trading pair",
+    "tags": [
+      "kaito",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KDA-USD": {
+    "normalized_id": "KDA/USD",
+    "base": "KDA",
+    "quote": "USD",
+    "display_name": "KDA / US Dollar",
+    "description": "KDA to US Dollar spot trading pair",
+    "tags": [
+      "kda",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KDA-USDT": {
+    "normalized_id": "KDA/USD",
+    "base": "KDA",
+    "quote": "USD",
+    "display_name": "KDA / US Dollar",
+    "description": "KDA to US Dollar spot trading pair",
+    "tags": [
+      "kda",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KMNO-USD": {
+    "normalized_id": "KMNO/USD",
+    "base": "KMNO",
+    "quote": "USD",
+    "display_name": "KMNO / US Dollar",
+    "description": "KMNO to US Dollar spot trading pair",
+    "tags": [
+      "kmno",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KMNO-USDT": {
+    "normalized_id": "KMNO/USD",
+    "base": "KMNO",
+    "quote": "USD",
+    "display_name": "KMNO / US Dollar",
+    "description": "KMNO to US Dollar spot trading pair",
+    "tags": [
+      "kmno",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KNC-USD": {
+    "normalized_id": "KNC/USD",
+    "base": "KNC",
+    "quote": "USD",
+    "display_name": "KNC / US Dollar",
+    "description": "KNC to US Dollar spot trading pair",
+    "tags": [
+      "knc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KNC-USDT": {
+    "normalized_id": "KNC/USD",
+    "base": "KNC",
+    "quote": "USD",
+    "display_name": "KNC / US Dollar",
+    "description": "KNC to US Dollar spot trading pair",
+    "tags": [
+      "knc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KSM-USD": {
+    "normalized_id": "KSM/USD",
+    "base": "KSM",
+    "quote": "USD",
+    "display_name": "KSM / US Dollar",
+    "description": "KSM to US Dollar spot trading pair",
+    "tags": [
+      "ksm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "KSM-USDT": {
+    "normalized_id": "KSM/USD",
+    "base": "KSM",
+    "quote": "USD",
+    "display_name": "KSM / US Dollar",
+    "description": "KSM to US Dollar spot trading pair",
+    "tags": [
+      "ksm",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LAT-USD": {
+    "normalized_id": "LAT/USD",
+    "base": "LAT",
+    "quote": "USD",
+    "display_name": "LAT / US Dollar",
+    "description": "LAT to US Dollar spot trading pair",
+    "tags": [
+      "lat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LAT-USDT": {
+    "normalized_id": "LAT/USD",
+    "base": "LAT",
+    "quote": "USD",
+    "display_name": "LAT / US Dollar",
+    "description": "LAT to US Dollar spot trading pair",
+    "tags": [
+      "lat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LAYER-USD": {
+    "normalized_id": "LAYER/USD",
+    "base": "LAYER",
+    "quote": "USD",
+    "display_name": "LAYER / US Dollar",
+    "description": "LAYER to US Dollar spot trading pair",
+    "tags": [
+      "layer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LAYER-USDT": {
+    "normalized_id": "LAYER/USD",
+    "base": "LAYER",
+    "quote": "USD",
+    "display_name": "LAYER / US Dollar",
+    "description": "LAYER to US Dollar spot trading pair",
+    "tags": [
+      "layer",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LDO-EUR": {
+    "normalized_id": "LDO/EUR",
+    "base": "LDO",
+    "quote": "EUR",
+    "display_name": "LDO / Euro",
+    "description": "LDO to Euro spot trading pair",
+    "tags": [
+      "ldo",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LDO-USD": {
+    "normalized_id": "LDO/USD",
+    "base": "LDO",
+    "quote": "USD",
+    "display_name": "LDO / US Dollar",
+    "description": "LDO to US Dollar spot trading pair",
+    "tags": [
+      "ldo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LDO-USDC": {
+    "normalized_id": "LDO/USD",
+    "base": "LDO",
+    "quote": "USD",
+    "display_name": "LDO / US Dollar",
+    "description": "LDO to US Dollar spot trading pair",
+    "tags": [
+      "ldo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LDO-USDT": {
+    "normalized_id": "LDO/USD",
+    "base": "LDO",
+    "quote": "USD",
+    "display_name": "LDO / US Dollar",
+    "description": "LDO to US Dollar spot trading pair",
+    "tags": [
+      "ldo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LEO-USD": {
+    "normalized_id": "LEO/USD",
+    "base": "LEO",
+    "quote": "USD",
+    "display_name": "LEO / US Dollar",
+    "description": "LEO to US Dollar spot trading pair",
+    "tags": [
+      "leo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LEO-USDT": {
+    "normalized_id": "LEO/USD",
+    "base": "LEO",
+    "quote": "USD",
+    "display_name": "LEO / US Dollar",
+    "description": "LEO to US Dollar spot trading pair",
+    "tags": [
+      "leo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LINK-EUR": {
+    "normalized_id": "LINK/EUR",
+    "base": "LINK",
+    "quote": "EUR",
+    "display_name": "Chainlink / Euro",
+    "description": "Chainlink to Euro spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LINK-USD": {
+    "normalized_id": "LINK/USD",
+    "base": "LINK",
+    "quote": "USD",
+    "display_name": "Chainlink / US Dollar",
+    "description": "Chainlink to US Dollar spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LINK-USDC": {
+    "normalized_id": "LINK/USD",
+    "base": "LINK",
+    "quote": "USD",
+    "display_name": "Chainlink / US Dollar",
+    "description": "Chainlink to US Dollar spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LINK-USDT": {
+    "normalized_id": "LINK/USD",
+    "base": "LINK",
+    "quote": "USD",
+    "display_name": "Chainlink / US Dollar",
+    "description": "Chainlink to US Dollar spot trading pair",
+    "tags": [
+      "link",
+      "chainlink",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LOOKS-USD": {
+    "normalized_id": "LOOKS/USD",
+    "base": "LOOKS",
+    "quote": "USD",
+    "display_name": "LOOKS / US Dollar",
+    "description": "LOOKS to US Dollar spot trading pair",
+    "tags": [
+      "looks",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LOOKS-USDT": {
+    "normalized_id": "LOOKS/USD",
+    "base": "LOOKS",
+    "quote": "USD",
+    "display_name": "LOOKS / US Dollar",
+    "description": "LOOKS to US Dollar spot trading pair",
+    "tags": [
+      "looks",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LPT-USD": {
+    "normalized_id": "LPT/USD",
+    "base": "LPT",
+    "quote": "USD",
+    "display_name": "LPT / US Dollar",
+    "description": "LPT to US Dollar spot trading pair",
+    "tags": [
+      "lpt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LPT-USDT": {
+    "normalized_id": "LPT/USD",
+    "base": "LPT",
+    "quote": "USD",
+    "display_name": "LPT / US Dollar",
+    "description": "LPT to US Dollar spot trading pair",
+    "tags": [
+      "lpt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LQTY-USD": {
+    "normalized_id": "LQTY/USD",
+    "base": "LQTY",
+    "quote": "USD",
+    "display_name": "LQTY / US Dollar",
+    "description": "LQTY to US Dollar spot trading pair",
+    "tags": [
+      "lqty",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LQTY-USDT": {
+    "normalized_id": "LQTY/USD",
+    "base": "LQTY",
+    "quote": "USD",
+    "display_name": "LQTY / US Dollar",
+    "description": "LQTY to US Dollar spot trading pair",
+    "tags": [
+      "lqty",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LRC-USD": {
+    "normalized_id": "LRC/USD",
+    "base": "LRC",
+    "quote": "USD",
+    "display_name": "LRC / US Dollar",
+    "description": "LRC to US Dollar spot trading pair",
+    "tags": [
+      "lrc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LRC-USDC": {
+    "normalized_id": "LRC/USD",
+    "base": "LRC",
+    "quote": "USD",
+    "display_name": "LRC / US Dollar",
+    "description": "LRC to US Dollar spot trading pair",
+    "tags": [
+      "lrc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LRC-USDT": {
+    "normalized_id": "LRC/USD",
+    "base": "LRC",
+    "quote": "USD",
+    "display_name": "LRC / US Dollar",
+    "description": "LRC to US Dollar spot trading pair",
+    "tags": [
+      "lrc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LSK-USD": {
+    "normalized_id": "LSK/USD",
+    "base": "LSK",
+    "quote": "USD",
+    "display_name": "LSK / US Dollar",
+    "description": "LSK to US Dollar spot trading pair",
+    "tags": [
+      "lsk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LSK-USDT": {
+    "normalized_id": "LSK/USD",
+    "base": "LSK",
+    "quote": "USD",
+    "display_name": "LSK / US Dollar",
+    "description": "LSK to US Dollar spot trading pair",
+    "tags": [
+      "lsk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LTC-BTC": {
+    "normalized_id": "LTC/BTC",
+    "base": "LTC",
+    "quote": "BTC",
+    "display_name": "Litecoin / Bitcoin",
+    "description": "Litecoin to Bitcoin spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "LTC-EUR": {
+    "normalized_id": "LTC/EUR",
+    "base": "LTC",
+    "quote": "EUR",
+    "display_name": "Litecoin / Euro",
+    "description": "Litecoin to Euro spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LTC-USD": {
+    "normalized_id": "LTC/USD",
+    "base": "LTC",
+    "quote": "USD",
+    "display_name": "Litecoin / US Dollar",
+    "description": "Litecoin to US Dollar spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LTC-USDC": {
+    "normalized_id": "LTC/USD",
+    "base": "LTC",
+    "quote": "USD",
+    "display_name": "Litecoin / US Dollar",
+    "description": "Litecoin to US Dollar spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LTC-USDT": {
+    "normalized_id": "LTC/USD",
+    "base": "LTC",
+    "quote": "USD",
+    "display_name": "Litecoin / US Dollar",
+    "description": "Litecoin to US Dollar spot trading pair",
+    "tags": [
+      "ltc",
+      "litecoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LUNA-USD": {
+    "normalized_id": "LUNA/USD",
+    "base": "LUNA",
+    "quote": "USD",
+    "display_name": "LUNA / US Dollar",
+    "description": "LUNA to US Dollar spot trading pair",
+    "tags": [
+      "luna",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LUNA-USDC": {
+    "normalized_id": "LUNA/USD",
+    "base": "LUNA",
+    "quote": "USD",
+    "display_name": "LUNA / US Dollar",
+    "description": "LUNA to US Dollar spot trading pair",
+    "tags": [
+      "luna",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LUNA-USDT": {
+    "normalized_id": "LUNA/USD",
+    "base": "LUNA",
+    "quote": "USD",
+    "display_name": "LUNA / US Dollar",
+    "description": "LUNA to US Dollar spot trading pair",
+    "tags": [
+      "luna",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LUNC-EUR": {
+    "normalized_id": "LUNC/EUR",
+    "base": "LUNC",
+    "quote": "EUR",
+    "display_name": "LUNC / Euro",
+    "description": "LUNC to Euro spot trading pair",
+    "tags": [
+      "lunc",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "LUNC-USD": {
+    "normalized_id": "LUNC/USD",
+    "base": "LUNC",
+    "quote": "USD",
+    "display_name": "LUNC / US Dollar",
+    "description": "LUNC to US Dollar spot trading pair",
+    "tags": [
+      "lunc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LUNC-USDC": {
+    "normalized_id": "LUNC/USD",
+    "base": "LUNC",
+    "quote": "USD",
+    "display_name": "LUNC / US Dollar",
+    "description": "LUNC to US Dollar spot trading pair",
+    "tags": [
+      "lunc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "LUNC-USDT": {
+    "normalized_id": "LUNC/USD",
+    "base": "LUNC",
+    "quote": "USD",
+    "display_name": "LUNC / US Dollar",
+    "description": "LUNC to US Dollar spot trading pair",
+    "tags": [
+      "lunc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MAGIC-USD": {
+    "normalized_id": "MAGIC/USD",
+    "base": "MAGIC",
+    "quote": "USD",
+    "display_name": "MAGIC / US Dollar",
+    "description": "MAGIC to US Dollar spot trading pair",
+    "tags": [
+      "magic",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MAGIC-USDT": {
+    "normalized_id": "MAGIC/USD",
+    "base": "MAGIC",
+    "quote": "USD",
+    "display_name": "MAGIC / US Dollar",
+    "description": "MAGIC to US Dollar spot trading pair",
+    "tags": [
+      "magic",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MAJOR-USD": {
+    "normalized_id": "MAJOR/USD",
+    "base": "MAJOR",
+    "quote": "USD",
+    "display_name": "MAJOR / US Dollar",
+    "description": "MAJOR to US Dollar spot trading pair",
+    "tags": [
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MAJOR-USDT": {
+    "normalized_id": "MAJOR/USD",
+    "base": "MAJOR",
+    "quote": "USD",
+    "display_name": "MAJOR / US Dollar",
+    "description": "MAJOR to US Dollar spot trading pair",
+    "tags": [
+      "major",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MANA-EUR": {
+    "normalized_id": "MANA/EUR",
+    "base": "MANA",
+    "quote": "EUR",
+    "display_name": "Decentraland / Euro",
+    "description": "Decentraland to Euro spot trading pair",
+    "tags": [
+      "mana",
+      "decentraland",
+      "gaming",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MANA-USD": {
+    "normalized_id": "MANA/USD",
+    "base": "MANA",
+    "quote": "USD",
+    "display_name": "Decentraland / US Dollar",
+    "description": "Decentraland to US Dollar spot trading pair",
+    "tags": [
+      "mana",
+      "decentraland",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MANA-USDT": {
+    "normalized_id": "MANA/USD",
+    "base": "MANA",
+    "quote": "USD",
+    "display_name": "Decentraland / US Dollar",
+    "description": "Decentraland to US Dollar spot trading pair",
+    "tags": [
+      "mana",
+      "decentraland",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MASK-USD": {
+    "normalized_id": "MASK/USD",
+    "base": "MASK",
+    "quote": "USD",
+    "display_name": "MASK / US Dollar",
+    "description": "MASK to US Dollar spot trading pair",
+    "tags": [
+      "mask",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MASK-USDT": {
+    "normalized_id": "MASK/USD",
+    "base": "MASK",
+    "quote": "USD",
+    "display_name": "MASK / US Dollar",
+    "description": "MASK to US Dollar spot trading pair",
+    "tags": [
+      "mask",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ME-USD": {
+    "normalized_id": "ME/USD",
+    "base": "ME",
+    "quote": "USD",
+    "display_name": "ME / US Dollar",
+    "description": "ME to US Dollar spot trading pair",
+    "tags": [
+      "me",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ME-USDT": {
+    "normalized_id": "ME/USD",
+    "base": "ME",
+    "quote": "USD",
+    "display_name": "ME / US Dollar",
+    "description": "ME to US Dollar spot trading pair",
+    "tags": [
+      "me",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MEME-USD": {
+    "normalized_id": "MEME/USD",
+    "base": "MEME",
+    "quote": "USD",
+    "display_name": "MEME / US Dollar",
+    "description": "MEME to US Dollar spot trading pair",
+    "tags": [
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MEME-USDT": {
+    "normalized_id": "MEME/USD",
+    "base": "MEME",
+    "quote": "USD",
+    "display_name": "MEME / US Dollar",
+    "description": "MEME to US Dollar spot trading pair",
+    "tags": [
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MEMEFI-USD": {
+    "normalized_id": "MEMEFI/USD",
+    "base": "MEMEFI",
+    "quote": "USD",
+    "display_name": "MEMEFI / US Dollar",
+    "description": "MEMEFI to US Dollar spot trading pair",
+    "tags": [
+      "memefi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MEMEFI-USDT": {
+    "normalized_id": "MEMEFI/USD",
+    "base": "MEMEFI",
+    "quote": "USD",
+    "display_name": "MEMEFI / US Dollar",
+    "description": "MEMEFI to US Dollar spot trading pair",
+    "tags": [
+      "memefi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MENGO-USD": {
+    "normalized_id": "MENGO/USD",
+    "base": "MENGO",
+    "quote": "USD",
+    "display_name": "MENGO / US Dollar",
+    "description": "MENGO to US Dollar spot trading pair",
+    "tags": [
+      "mengo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MENGO-USDT": {
+    "normalized_id": "MENGO/USD",
+    "base": "MENGO",
+    "quote": "USD",
+    "display_name": "MENGO / US Dollar",
+    "description": "MENGO to US Dollar spot trading pair",
+    "tags": [
+      "mengo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MERL-USD": {
+    "normalized_id": "MERL/USD",
+    "base": "MERL",
+    "quote": "USD",
+    "display_name": "MERL / US Dollar",
+    "description": "MERL to US Dollar spot trading pair",
+    "tags": [
+      "merl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MERL-USDC": {
+    "normalized_id": "MERL/USD",
+    "base": "MERL",
+    "quote": "USD",
+    "display_name": "MERL / US Dollar",
+    "description": "MERL to US Dollar spot trading pair",
+    "tags": [
+      "merl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MERL-USDT": {
+    "normalized_id": "MERL/USD",
+    "base": "MERL",
+    "quote": "USD",
+    "display_name": "MERL / US Dollar",
+    "description": "MERL to US Dollar spot trading pair",
+    "tags": [
+      "merl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "METIS-USD": {
+    "normalized_id": "METIS/USD",
+    "base": "METIS",
+    "quote": "USD",
+    "display_name": "METIS / US Dollar",
+    "description": "METIS to US Dollar spot trading pair",
+    "tags": [
+      "metis",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "METIS-USDT": {
+    "normalized_id": "METIS/USD",
+    "base": "METIS",
+    "quote": "USD",
+    "display_name": "METIS / US Dollar",
+    "description": "METIS to US Dollar spot trading pair",
+    "tags": [
+      "metis",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MEW-USD": {
+    "normalized_id": "MEW/USD",
+    "base": "MEW",
+    "quote": "USD",
+    "display_name": "MEW / US Dollar",
+    "description": "MEW to US Dollar spot trading pair",
+    "tags": [
+      "mew",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MEW-USDT": {
+    "normalized_id": "MEW/USD",
+    "base": "MEW",
+    "quote": "USD",
+    "display_name": "MEW / US Dollar",
+    "description": "MEW to US Dollar spot trading pair",
+    "tags": [
+      "mew",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MINA-EUR": {
+    "normalized_id": "MINA/EUR",
+    "base": "MINA",
+    "quote": "EUR",
+    "display_name": "MINA / Euro",
+    "description": "MINA to Euro spot trading pair",
+    "tags": [
+      "mina",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MINA-USD": {
+    "normalized_id": "MINA/USD",
+    "base": "MINA",
+    "quote": "USD",
+    "display_name": "MINA / US Dollar",
+    "description": "MINA to US Dollar spot trading pair",
+    "tags": [
+      "mina",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MINA-USDT": {
+    "normalized_id": "MINA/USD",
+    "base": "MINA",
+    "quote": "USD",
+    "display_name": "MINA / US Dollar",
+    "description": "MINA to US Dollar spot trading pair",
+    "tags": [
+      "mina",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MKR-EUR": {
+    "normalized_id": "MKR/EUR",
+    "base": "MKR",
+    "quote": "EUR",
+    "display_name": "Maker / Euro",
+    "description": "Maker to Euro spot trading pair",
+    "tags": [
+      "mkr",
+      "maker",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "MKR-USD": {
+    "normalized_id": "MKR/USD",
+    "base": "MKR",
+    "quote": "USD",
+    "display_name": "Maker / US Dollar",
+    "description": "Maker to US Dollar spot trading pair",
+    "tags": [
+      "mkr",
+      "maker",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MKR-USDC": {
+    "normalized_id": "MKR/USD",
+    "base": "MKR",
+    "quote": "USD",
+    "display_name": "Maker / US Dollar",
+    "description": "Maker to US Dollar spot trading pair",
+    "tags": [
+      "mkr",
+      "maker",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MKR-USDT": {
+    "normalized_id": "MKR/USD",
+    "base": "MKR",
+    "quote": "USD",
+    "display_name": "Maker / US Dollar",
+    "description": "Maker to US Dollar spot trading pair",
+    "tags": [
+      "mkr",
+      "maker",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MLN-USD": {
+    "normalized_id": "MLN/USD",
+    "base": "MLN",
+    "quote": "USD",
+    "display_name": "MLN / US Dollar",
+    "description": "MLN to US Dollar spot trading pair",
+    "tags": [
+      "mln",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MLN-USDT": {
+    "normalized_id": "MLN/USD",
+    "base": "MLN",
+    "quote": "USD",
+    "display_name": "MLN / US Dollar",
+    "description": "MLN to US Dollar spot trading pair",
+    "tags": [
+      "mln",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOODENG-USD": {
+    "normalized_id": "MOODENG/USD",
+    "base": "MOODENG",
+    "quote": "USD",
+    "display_name": "MOODENG / US Dollar",
+    "description": "MOODENG to US Dollar spot trading pair",
+    "tags": [
+      "moodeng",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOODENG-USDC": {
+    "normalized_id": "MOODENG/USD",
+    "base": "MOODENG",
+    "quote": "USD",
+    "display_name": "MOODENG / US Dollar",
+    "description": "MOODENG to US Dollar spot trading pair",
+    "tags": [
+      "moodeng",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOODENG-USDT": {
+    "normalized_id": "MOODENG/USD",
+    "base": "MOODENG",
+    "quote": "USD",
+    "display_name": "MOODENG / US Dollar",
+    "description": "MOODENG to US Dollar spot trading pair",
+    "tags": [
+      "moodeng",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MORPHO-USD": {
+    "normalized_id": "MORPHO/USD",
+    "base": "MORPHO",
+    "quote": "USD",
+    "display_name": "MORPHO / US Dollar",
+    "description": "MORPHO to US Dollar spot trading pair",
+    "tags": [
+      "morpho",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MORPHO-USDC": {
+    "normalized_id": "MORPHO/USD",
+    "base": "MORPHO",
+    "quote": "USD",
+    "display_name": "MORPHO / US Dollar",
+    "description": "MORPHO to US Dollar spot trading pair",
+    "tags": [
+      "morpho",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MORPHO-USDT": {
+    "normalized_id": "MORPHO/USD",
+    "base": "MORPHO",
+    "quote": "USD",
+    "display_name": "MORPHO / US Dollar",
+    "description": "MORPHO to US Dollar spot trading pair",
+    "tags": [
+      "morpho",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOVE-USD": {
+    "normalized_id": "MOVE/USD",
+    "base": "MOVE",
+    "quote": "USD",
+    "display_name": "MOVE / US Dollar",
+    "description": "MOVE to US Dollar spot trading pair",
+    "tags": [
+      "move",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOVE-USDC": {
+    "normalized_id": "MOVE/USD",
+    "base": "MOVE",
+    "quote": "USD",
+    "display_name": "MOVE / US Dollar",
+    "description": "MOVE to US Dollar spot trading pair",
+    "tags": [
+      "move",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOVE-USDT": {
+    "normalized_id": "MOVE/USD",
+    "base": "MOVE",
+    "quote": "USD",
+    "display_name": "MOVE / US Dollar",
+    "description": "MOVE to US Dollar spot trading pair",
+    "tags": [
+      "move",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOVR-USD": {
+    "normalized_id": "MOVR/USD",
+    "base": "MOVR",
+    "quote": "USD",
+    "display_name": "MOVR / US Dollar",
+    "description": "MOVR to US Dollar spot trading pair",
+    "tags": [
+      "movr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "MOVR-USDT": {
+    "normalized_id": "MOVR/USD",
+    "base": "MOVR",
+    "quote": "USD",
+    "display_name": "MOVR / US Dollar",
+    "description": "MOVR to US Dollar spot trading pair",
+    "tags": [
+      "movr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NAVX-USD": {
+    "normalized_id": "NAVX/USD",
+    "base": "NAVX",
+    "quote": "USD",
+    "display_name": "NAVX / US Dollar",
+    "description": "NAVX to US Dollar spot trading pair",
+    "tags": [
+      "navx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NAVX-USDT": {
+    "normalized_id": "NAVX/USD",
+    "base": "NAVX",
+    "quote": "USD",
+    "display_name": "NAVX / US Dollar",
+    "description": "NAVX to US Dollar spot trading pair",
+    "tags": [
+      "navx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NC-USD": {
+    "normalized_id": "NC/USD",
+    "base": "NC",
+    "quote": "USD",
+    "display_name": "NC / US Dollar",
+    "description": "NC to US Dollar spot trading pair",
+    "tags": [
+      "nc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NC-USDT": {
+    "normalized_id": "NC/USD",
+    "base": "NC",
+    "quote": "USD",
+    "display_name": "NC / US Dollar",
+    "description": "NC to US Dollar spot trading pair",
+    "tags": [
+      "nc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEAR-USD": {
+    "normalized_id": "NEAR/USD",
+    "base": "NEAR",
+    "quote": "USD",
+    "display_name": "NEAR Protocol / US Dollar",
+    "description": "NEAR Protocol to US Dollar spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEAR-USDC": {
+    "normalized_id": "NEAR/USD",
+    "base": "NEAR",
+    "quote": "USD",
+    "display_name": "NEAR Protocol / US Dollar",
+    "description": "NEAR Protocol to US Dollar spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEAR-USDT": {
+    "normalized_id": "NEAR/USD",
+    "base": "NEAR",
+    "quote": "USD",
+    "display_name": "NEAR Protocol / US Dollar",
+    "description": "NEAR Protocol to US Dollar spot trading pair",
+    "tags": [
+      "near",
+      "near protocol",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEIRO-USD": {
+    "normalized_id": "NEIRO/USD",
+    "base": "NEIRO",
+    "quote": "USD",
+    "display_name": "NEIRO / US Dollar",
+    "description": "NEIRO to US Dollar spot trading pair",
+    "tags": [
+      "neiro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEIRO-USDC": {
+    "normalized_id": "NEIRO/USD",
+    "base": "NEIRO",
+    "quote": "USD",
+    "display_name": "NEIRO / US Dollar",
+    "description": "NEIRO to US Dollar spot trading pair",
+    "tags": [
+      "neiro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEIRO-USDT": {
+    "normalized_id": "NEIRO/USD",
+    "base": "NEIRO",
+    "quote": "USD",
+    "display_name": "NEIRO / US Dollar",
+    "description": "NEIRO to US Dollar spot trading pair",
+    "tags": [
+      "neiro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEO-USD": {
+    "normalized_id": "NEO/USD",
+    "base": "NEO",
+    "quote": "USD",
+    "display_name": "NEO / US Dollar",
+    "description": "NEO to US Dollar spot trading pair",
+    "tags": [
+      "neo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NEO-USDT": {
+    "normalized_id": "NEO/USD",
+    "base": "NEO",
+    "quote": "USD",
+    "display_name": "NEO / US Dollar",
+    "description": "NEO to US Dollar spot trading pair",
+    "tags": [
+      "neo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NFT-USDT": {
+    "normalized_id": "NFT/USD",
+    "base": "NFT",
+    "quote": "USD",
+    "display_name": "NFT / US Dollar",
+    "description": "NFT to US Dollar spot trading pair",
+    "tags": [
+      "nft",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NMR-USD": {
+    "normalized_id": "NMR/USD",
+    "base": "NMR",
+    "quote": "USD",
+    "display_name": "NMR / US Dollar",
+    "description": "NMR to US Dollar spot trading pair",
+    "tags": [
+      "nmr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NMR-USDT": {
+    "normalized_id": "NMR/USD",
+    "base": "NMR",
+    "quote": "USD",
+    "display_name": "NMR / US Dollar",
+    "description": "NMR to US Dollar spot trading pair",
+    "tags": [
+      "nmr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NOT-USD": {
+    "normalized_id": "NOT/USD",
+    "base": "NOT",
+    "quote": "USD",
+    "display_name": "NOT / US Dollar",
+    "description": "NOT to US Dollar spot trading pair",
+    "tags": [
+      "not",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NOT-USDC": {
+    "normalized_id": "NOT/USD",
+    "base": "NOT",
+    "quote": "USD",
+    "display_name": "NOT / US Dollar",
+    "description": "NOT to US Dollar spot trading pair",
+    "tags": [
+      "not",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "NOT-USDT": {
+    "normalized_id": "NOT/USD",
+    "base": "NOT",
+    "quote": "USD",
+    "display_name": "NOT / US Dollar",
+    "description": "NOT to US Dollar spot trading pair",
+    "tags": [
+      "not",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OAS-USD": {
+    "normalized_id": "OAS/USD",
+    "base": "OAS",
+    "quote": "USD",
+    "display_name": "OAS / US Dollar",
+    "description": "OAS to US Dollar spot trading pair",
+    "tags": [
+      "oas",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OAS-USDT": {
+    "normalized_id": "OAS/USD",
+    "base": "OAS",
+    "quote": "USD",
+    "display_name": "OAS / US Dollar",
+    "description": "OAS to US Dollar spot trading pair",
+    "tags": [
+      "oas",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OKB-BTC": {
+    "normalized_id": "OKB/BTC",
+    "base": "OKB",
+    "quote": "BTC",
+    "display_name": "OKB / Bitcoin",
+    "description": "OKB to Bitcoin spot trading pair",
+    "tags": [
+      "okb",
+      "exchange",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "OKB-USDC": {
+    "normalized_id": "OKB/USD",
+    "base": "OKB",
+    "quote": "USD",
+    "display_name": "OKB / US Dollar",
+    "description": "OKB to US Dollar spot trading pair",
+    "tags": [
+      "okb",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OKB-USDT": {
+    "normalized_id": "OKB/USD",
+    "base": "OKB",
+    "quote": "USD",
+    "display_name": "OKB / US Dollar",
+    "description": "OKB to US Dollar spot trading pair",
+    "tags": [
+      "okb",
+      "exchange",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OKSOL-SOL": {
+    "normalized_id": "OKSOL/SOL",
+    "base": "OKSOL",
+    "quote": "SOL",
+    "display_name": "OKSOL / Solana",
+    "description": "OKSOL to Solana spot trading pair",
+    "tags": [
+      "oksol",
+      "sol"
+    ],
+    "category": "crypto"
+  },
+  "OKSOL-USDT": {
+    "normalized_id": "OKSOL/USD",
+    "base": "OKSOL",
+    "quote": "USD",
+    "display_name": "OKSOL / US Dollar",
+    "description": "OKSOL to US Dollar spot trading pair",
+    "tags": [
+      "oksol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OL-USD": {
+    "normalized_id": "OL/USD",
+    "base": "OL",
+    "quote": "USD",
+    "display_name": "OL / US Dollar",
+    "description": "OL to US Dollar spot trading pair",
+    "tags": [
+      "ol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OL-USDT": {
+    "normalized_id": "OL/USD",
+    "base": "OL",
+    "quote": "USD",
+    "display_name": "OL / US Dollar",
+    "description": "OL to US Dollar spot trading pair",
+    "tags": [
+      "ol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OM-USD": {
+    "normalized_id": "OM/USD",
+    "base": "OM",
+    "quote": "USD",
+    "display_name": "OM / US Dollar",
+    "description": "OM to US Dollar spot trading pair",
+    "tags": [
+      "om",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OM-USDT": {
+    "normalized_id": "OM/USD",
+    "base": "OM",
+    "quote": "USD",
+    "display_name": "OM / US Dollar",
+    "description": "OM to US Dollar spot trading pair",
+    "tags": [
+      "om",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OMI-USD": {
+    "normalized_id": "OMI/USD",
+    "base": "OMI",
+    "quote": "USD",
+    "display_name": "OMI / US Dollar",
+    "description": "OMI to US Dollar spot trading pair",
+    "tags": [
+      "omi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OMI-USDT": {
+    "normalized_id": "OMI/USD",
+    "base": "OMI",
+    "quote": "USD",
+    "display_name": "OMI / US Dollar",
+    "description": "OMI to US Dollar spot trading pair",
+    "tags": [
+      "omi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ONDO-USD": {
+    "normalized_id": "ONDO/USD",
+    "base": "ONDO",
+    "quote": "USD",
+    "display_name": "ONDO / US Dollar",
+    "description": "ONDO to US Dollar spot trading pair",
+    "tags": [
+      "ondo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ONDO-USDC": {
+    "normalized_id": "ONDO/USD",
+    "base": "ONDO",
+    "quote": "USD",
+    "display_name": "ONDO / US Dollar",
+    "description": "ONDO to US Dollar spot trading pair",
+    "tags": [
+      "ondo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ONDO-USDT": {
+    "normalized_id": "ONDO/USD",
+    "base": "ONDO",
+    "quote": "USD",
+    "display_name": "ONDO / US Dollar",
+    "description": "ONDO to US Dollar spot trading pair",
+    "tags": [
+      "ondo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ONE-USD": {
+    "normalized_id": "ONE/USD",
+    "base": "ONE",
+    "quote": "USD",
+    "display_name": "ONE / US Dollar",
+    "description": "ONE to US Dollar spot trading pair",
+    "tags": [
+      "one",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ONE-USDT": {
+    "normalized_id": "ONE/USD",
+    "base": "ONE",
+    "quote": "USD",
+    "display_name": "ONE / US Dollar",
+    "description": "ONE to US Dollar spot trading pair",
+    "tags": [
+      "one",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ONT-USD": {
+    "normalized_id": "ONT/USD",
+    "base": "ONT",
+    "quote": "USD",
+    "display_name": "ONT / US Dollar",
+    "description": "ONT to US Dollar spot trading pair",
+    "tags": [
+      "ont",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ONT-USDT": {
+    "normalized_id": "ONT/USD",
+    "base": "ONT",
+    "quote": "USD",
+    "display_name": "ONT / US Dollar",
+    "description": "ONT to US Dollar spot trading pair",
+    "tags": [
+      "ont",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OP-EUR": {
+    "normalized_id": "OP/EUR",
+    "base": "OP",
+    "quote": "EUR",
+    "display_name": "Optimism / Euro",
+    "description": "Optimism to Euro spot trading pair",
+    "tags": [
+      "op",
+      "optimism",
+      "layer2",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "OP-USD": {
+    "normalized_id": "OP/USD",
+    "base": "OP",
+    "quote": "USD",
+    "display_name": "Optimism / US Dollar",
+    "description": "Optimism to US Dollar spot trading pair",
+    "tags": [
+      "op",
+      "optimism",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OP-USDC": {
+    "normalized_id": "OP/USD",
+    "base": "OP",
+    "quote": "USD",
+    "display_name": "Optimism / US Dollar",
+    "description": "Optimism to US Dollar spot trading pair",
+    "tags": [
+      "op",
+      "optimism",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "OP-USDT": {
+    "normalized_id": "OP/USD",
+    "base": "OP",
+    "quote": "USD",
+    "display_name": "Optimism / US Dollar",
+    "description": "Optimism to US Dollar spot trading pair",
+    "tags": [
+      "op",
+      "optimism",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ORBS-USD": {
+    "normalized_id": "ORBS/USD",
+    "base": "ORBS",
+    "quote": "USD",
+    "display_name": "ORBS / US Dollar",
+    "description": "ORBS to US Dollar spot trading pair",
+    "tags": [
+      "orbs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ORBS-USDT": {
+    "normalized_id": "ORBS/USD",
+    "base": "ORBS",
+    "quote": "USD",
+    "display_name": "ORBS / US Dollar",
+    "description": "ORBS to US Dollar spot trading pair",
+    "tags": [
+      "orbs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ORDI-USD": {
+    "normalized_id": "ORDI/USD",
+    "base": "ORDI",
+    "quote": "USD",
+    "display_name": "ORDI / US Dollar",
+    "description": "ORDI to US Dollar spot trading pair",
+    "tags": [
+      "ordi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ORDI-USDT": {
+    "normalized_id": "ORDI/USD",
+    "base": "ORDI",
+    "quote": "USD",
+    "display_name": "ORDI / US Dollar",
+    "description": "ORDI to US Dollar spot trading pair",
+    "tags": [
+      "ordi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PARTI-USD": {
+    "normalized_id": "PARTI/USD",
+    "base": "PARTI",
+    "quote": "USD",
+    "display_name": "PARTI / US Dollar",
+    "description": "PARTI to US Dollar spot trading pair",
+    "tags": [
+      "parti",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PARTI-USDT": {
+    "normalized_id": "PARTI/USD",
+    "base": "PARTI",
+    "quote": "USD",
+    "display_name": "PARTI / US Dollar",
+    "description": "PARTI to US Dollar spot trading pair",
+    "tags": [
+      "parti",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENDLE-USD": {
+    "normalized_id": "PENDLE/USD",
+    "base": "PENDLE",
+    "quote": "USD",
+    "display_name": "PENDLE / US Dollar",
+    "description": "PENDLE to US Dollar spot trading pair",
+    "tags": [
+      "pendle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENDLE-USDT": {
+    "normalized_id": "PENDLE/USD",
+    "base": "PENDLE",
+    "quote": "USD",
+    "display_name": "PENDLE / US Dollar",
+    "description": "PENDLE to US Dollar spot trading pair",
+    "tags": [
+      "pendle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENGU-USD": {
+    "normalized_id": "PENGU/USD",
+    "base": "PENGU",
+    "quote": "USD",
+    "display_name": "PENGU / US Dollar",
+    "description": "PENGU to US Dollar spot trading pair",
+    "tags": [
+      "pengu",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PENGU-USDT": {
+    "normalized_id": "PENGU/USD",
+    "base": "PENGU",
+    "quote": "USD",
+    "display_name": "PENGU / US Dollar",
+    "description": "PENGU to US Dollar spot trading pair",
+    "tags": [
+      "pengu",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PEOPLE-USD": {
+    "normalized_id": "PEOPLE/USD",
+    "base": "PEOPLE",
+    "quote": "USD",
+    "display_name": "PEOPLE / US Dollar",
+    "description": "PEOPLE to US Dollar spot trading pair",
+    "tags": [
+      "people",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PEOPLE-USDT": {
+    "normalized_id": "PEOPLE/USD",
+    "base": "PEOPLE",
+    "quote": "USD",
+    "display_name": "PEOPLE / US Dollar",
+    "description": "PEOPLE to US Dollar spot trading pair",
+    "tags": [
+      "people",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PEPE-BRL": {
+    "normalized_id": "PEPE/BRL",
+    "base": "PEPE",
+    "quote": "BRL",
+    "display_name": "Pepe / Brazilian Real",
+    "description": "Pepe to Brazilian Real spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "PEPE-USD": {
+    "normalized_id": "PEPE/USD",
+    "base": "PEPE",
+    "quote": "USD",
+    "display_name": "Pepe / US Dollar",
+    "description": "Pepe to US Dollar spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PEPE-USDC": {
+    "normalized_id": "PEPE/USD",
+    "base": "PEPE",
+    "quote": "USD",
+    "display_name": "Pepe / US Dollar",
+    "description": "Pepe to US Dollar spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PEPE-USDT": {
+    "normalized_id": "PEPE/USD",
+    "base": "PEPE",
+    "quote": "USD",
+    "display_name": "Pepe / US Dollar",
+    "description": "Pepe to US Dollar spot trading pair",
+    "tags": [
+      "pepe",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PERP-USD": {
+    "normalized_id": "PERP/USD",
+    "base": "PERP",
+    "quote": "USD",
+    "display_name": "PERP / US Dollar",
+    "description": "PERP to US Dollar spot trading pair",
+    "tags": [
+      "perp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PERP-USDT": {
+    "normalized_id": "PERP/USD",
+    "base": "PERP",
+    "quote": "USD",
+    "display_name": "PERP / US Dollar",
+    "description": "PERP to US Dollar spot trading pair",
+    "tags": [
+      "perp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PHA-USD": {
+    "normalized_id": "PHA/USD",
+    "base": "PHA",
+    "quote": "USD",
+    "display_name": "PHA / US Dollar",
+    "description": "PHA to US Dollar spot trading pair",
+    "tags": [
+      "pha",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PHA-USDT": {
+    "normalized_id": "PHA/USD",
+    "base": "PHA",
+    "quote": "USD",
+    "display_name": "PHA / US Dollar",
+    "description": "PHA to US Dollar spot trading pair",
+    "tags": [
+      "pha",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PI-BRL": {
+    "normalized_id": "PI/BRL",
+    "base": "PI",
+    "quote": "BRL",
+    "display_name": "PI / Brazilian Real",
+    "description": "PI to Brazilian Real spot trading pair",
+    "tags": [
+      "pi",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "PI-EUR": {
+    "normalized_id": "PI/EUR",
+    "base": "PI",
+    "quote": "EUR",
+    "display_name": "PI / Euro",
+    "description": "PI to Euro spot trading pair",
+    "tags": [
+      "pi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "PI-TRY": {
+    "normalized_id": "PI/TRY",
+    "base": "PI",
+    "quote": "TRY",
+    "display_name": "PI / Turkish Lira",
+    "description": "PI to Turkish Lira spot trading pair",
+    "tags": [
+      "pi",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "PI-USD": {
+    "normalized_id": "PI/USD",
+    "base": "PI",
+    "quote": "USD",
+    "display_name": "PI / US Dollar",
+    "description": "PI to US Dollar spot trading pair",
+    "tags": [
+      "pi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PI-USDT": {
+    "normalized_id": "PI/USD",
+    "base": "PI",
+    "quote": "USD",
+    "display_name": "PI / US Dollar",
+    "description": "PI to US Dollar spot trading pair",
+    "tags": [
+      "pi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PIXEL-USD": {
+    "normalized_id": "PIXEL/USD",
+    "base": "PIXEL",
+    "quote": "USD",
+    "display_name": "PIXEL / US Dollar",
+    "description": "PIXEL to US Dollar spot trading pair",
+    "tags": [
+      "pixel",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PIXEL-USDT": {
+    "normalized_id": "PIXEL/USD",
+    "base": "PIXEL",
+    "quote": "USD",
+    "display_name": "PIXEL / US Dollar",
+    "description": "PIXEL to US Dollar spot trading pair",
+    "tags": [
+      "pixel",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PNUT-USD": {
+    "normalized_id": "PNUT/USD",
+    "base": "PNUT",
+    "quote": "USD",
+    "display_name": "PNUT / US Dollar",
+    "description": "PNUT to US Dollar spot trading pair",
+    "tags": [
+      "pnut",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PNUT-USDC": {
+    "normalized_id": "PNUT/USD",
+    "base": "PNUT",
+    "quote": "USD",
+    "display_name": "PNUT / US Dollar",
+    "description": "PNUT to US Dollar spot trading pair",
+    "tags": [
+      "pnut",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PNUT-USDT": {
+    "normalized_id": "PNUT/USD",
+    "base": "PNUT",
+    "quote": "USD",
+    "display_name": "PNUT / US Dollar",
+    "description": "PNUT to US Dollar spot trading pair",
+    "tags": [
+      "pnut",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POL-USD": {
+    "normalized_id": "POL/USD",
+    "base": "POL",
+    "quote": "USD",
+    "display_name": "POL / US Dollar",
+    "description": "POL to US Dollar spot trading pair",
+    "tags": [
+      "pol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POL-USDT": {
+    "normalized_id": "POL/USD",
+    "base": "POL",
+    "quote": "USD",
+    "display_name": "POL / US Dollar",
+    "description": "POL to US Dollar spot trading pair",
+    "tags": [
+      "pol",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POLYDOGE-USD": {
+    "normalized_id": "POLYDOGE/USD",
+    "base": "POLYDOGE",
+    "quote": "USD",
+    "display_name": "POLYDOGE / US Dollar",
+    "description": "POLYDOGE to US Dollar spot trading pair",
+    "tags": [
+      "polydoge",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POLYDOGE-USDT": {
+    "normalized_id": "POLYDOGE/USD",
+    "base": "POLYDOGE",
+    "quote": "USD",
+    "display_name": "POLYDOGE / US Dollar",
+    "description": "POLYDOGE to US Dollar spot trading pair",
+    "tags": [
+      "polydoge",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POR-USD": {
+    "normalized_id": "POR/USD",
+    "base": "POR",
+    "quote": "USD",
+    "display_name": "POR / US Dollar",
+    "description": "POR to US Dollar spot trading pair",
+    "tags": [
+      "por",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "POR-USDT": {
+    "normalized_id": "POR/USD",
+    "base": "POR",
+    "quote": "USD",
+    "display_name": "POR / US Dollar",
+    "description": "POR to US Dollar spot trading pair",
+    "tags": [
+      "por",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PRCL-USD": {
+    "normalized_id": "PRCL/USD",
+    "base": "PRCL",
+    "quote": "USD",
+    "display_name": "PRCL / US Dollar",
+    "description": "PRCL to US Dollar spot trading pair",
+    "tags": [
+      "prcl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PRCL-USDT": {
+    "normalized_id": "PRCL/USD",
+    "base": "PRCL",
+    "quote": "USD",
+    "display_name": "PRCL / US Dollar",
+    "description": "PRCL to US Dollar spot trading pair",
+    "tags": [
+      "prcl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PROMPT-USDT": {
+    "normalized_id": "PROMPT/USD",
+    "base": "PROMPT",
+    "quote": "USD",
+    "display_name": "PROMPT / US Dollar",
+    "description": "PROMPT to US Dollar spot trading pair",
+    "tags": [
+      "prompt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PSTAKE-USD": {
+    "normalized_id": "PSTAKE/USD",
+    "base": "PSTAKE",
+    "quote": "USD",
+    "display_name": "PSTAKE / US Dollar",
+    "description": "PSTAKE to US Dollar spot trading pair",
+    "tags": [
+      "pstake",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PSTAKE-USDT": {
+    "normalized_id": "PSTAKE/USD",
+    "base": "PSTAKE",
+    "quote": "USD",
+    "display_name": "PSTAKE / US Dollar",
+    "description": "PSTAKE to US Dollar spot trading pair",
+    "tags": [
+      "pstake",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PUMP-USD": {
+    "normalized_id": "PUMP/USD",
+    "base": "PUMP",
+    "quote": "USD",
+    "display_name": "PUMP / US Dollar",
+    "description": "PUMP to US Dollar spot trading pair",
+    "tags": [
+      "pump",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PUMP-USDT": {
+    "normalized_id": "PUMP/USD",
+    "base": "PUMP",
+    "quote": "USD",
+    "display_name": "PUMP / US Dollar",
+    "description": "PUMP to US Dollar spot trading pair",
+    "tags": [
+      "pump",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PYTH-USD": {
+    "normalized_id": "PYTH/USD",
+    "base": "PYTH",
+    "quote": "USD",
+    "display_name": "Pyth Network / US Dollar",
+    "description": "Pyth Network to US Dollar spot trading pair",
+    "tags": [
+      "pyth",
+      "pyth network",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PYTH-USDC": {
+    "normalized_id": "PYTH/USD",
+    "base": "PYTH",
+    "quote": "USD",
+    "display_name": "Pyth Network / US Dollar",
+    "description": "Pyth Network to US Dollar spot trading pair",
+    "tags": [
+      "pyth",
+      "pyth network",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PYTH-USDT": {
+    "normalized_id": "PYTH/USD",
+    "base": "PYTH",
+    "quote": "USD",
+    "display_name": "Pyth Network / US Dollar",
+    "description": "Pyth Network to US Dollar spot trading pair",
+    "tags": [
+      "pyth",
+      "pyth network",
+      "oracle",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "PYUSD-USDT": {
+    "normalized_id": "PYUSD/USD",
+    "base": "PYUSD",
+    "quote": "USD",
+    "display_name": "PYUSD / US Dollar",
+    "description": "PYUSD to US Dollar spot trading pair",
+    "tags": [
+      "pyusd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "QTUM-USD": {
+    "normalized_id": "QTUM/USD",
+    "base": "QTUM",
+    "quote": "USD",
+    "display_name": "QTUM / US Dollar",
+    "description": "QTUM to US Dollar spot trading pair",
+    "tags": [
+      "qtum",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "QTUM-USDT": {
+    "normalized_id": "QTUM/USD",
+    "base": "QTUM",
+    "quote": "USD",
+    "display_name": "QTUM / US Dollar",
+    "description": "QTUM to US Dollar spot trading pair",
+    "tags": [
+      "qtum",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RACA-USD": {
+    "normalized_id": "RACA/USD",
+    "base": "RACA",
+    "quote": "USD",
+    "display_name": "RACA / US Dollar",
+    "description": "RACA to US Dollar spot trading pair",
+    "tags": [
+      "raca",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RACA-USDT": {
+    "normalized_id": "RACA/USD",
+    "base": "RACA",
+    "quote": "USD",
+    "display_name": "RACA / US Dollar",
+    "description": "RACA to US Dollar spot trading pair",
+    "tags": [
+      "raca",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RAY-USD": {
+    "normalized_id": "RAY/USD",
+    "base": "RAY",
+    "quote": "USD",
+    "display_name": "RAY / US Dollar",
+    "description": "RAY to US Dollar spot trading pair",
+    "tags": [
+      "ray",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RAY-USDT": {
+    "normalized_id": "RAY/USD",
+    "base": "RAY",
+    "quote": "USD",
+    "display_name": "RAY / US Dollar",
+    "description": "RAY to US Dollar spot trading pair",
+    "tags": [
+      "ray",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RDNT-USD": {
+    "normalized_id": "RDNT/USD",
+    "base": "RDNT",
+    "quote": "USD",
+    "display_name": "RDNT / US Dollar",
+    "description": "RDNT to US Dollar spot trading pair",
+    "tags": [
+      "rdnt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RDNT-USDC": {
+    "normalized_id": "RDNT/USD",
+    "base": "RDNT",
+    "quote": "USD",
+    "display_name": "RDNT / US Dollar",
+    "description": "RDNT to US Dollar spot trading pair",
+    "tags": [
+      "rdnt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RDNT-USDT": {
+    "normalized_id": "RDNT/USD",
+    "base": "RDNT",
+    "quote": "USD",
+    "display_name": "RDNT / US Dollar",
+    "description": "RDNT to US Dollar spot trading pair",
+    "tags": [
+      "rdnt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RENDER-USD": {
+    "normalized_id": "RENDER/USD",
+    "base": "RENDER",
+    "quote": "USD",
+    "display_name": "RENDER / US Dollar",
+    "description": "RENDER to US Dollar spot trading pair",
+    "tags": [
+      "render",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RENDER-USDT": {
+    "normalized_id": "RENDER/USD",
+    "base": "RENDER",
+    "quote": "USD",
+    "display_name": "RENDER / US Dollar",
+    "description": "RENDER to US Dollar spot trading pair",
+    "tags": [
+      "render",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RESOLV-USD": {
+    "normalized_id": "RESOLV/USD",
+    "base": "RESOLV",
+    "quote": "USD",
+    "display_name": "RESOLV / US Dollar",
+    "description": "RESOLV to US Dollar spot trading pair",
+    "tags": [
+      "resolv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RESOLV-USDT": {
+    "normalized_id": "RESOLV/USD",
+    "base": "RESOLV",
+    "quote": "USD",
+    "display_name": "RESOLV / US Dollar",
+    "description": "RESOLV to US Dollar spot trading pair",
+    "tags": [
+      "resolv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RIO-USD": {
+    "normalized_id": "RIO/USD",
+    "base": "RIO",
+    "quote": "USD",
+    "display_name": "RIO / US Dollar",
+    "description": "RIO to US Dollar spot trading pair",
+    "tags": [
+      "rio",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RIO-USDT": {
+    "normalized_id": "RIO/USD",
+    "base": "RIO",
+    "quote": "USD",
+    "display_name": "RIO / US Dollar",
+    "description": "RIO to US Dollar spot trading pair",
+    "tags": [
+      "rio",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RON-USD": {
+    "normalized_id": "RON/USD",
+    "base": "RON",
+    "quote": "USD",
+    "display_name": "RON / US Dollar",
+    "description": "RON to US Dollar spot trading pair",
+    "tags": [
+      "ron",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RON-USDT": {
+    "normalized_id": "RON/USD",
+    "base": "RON",
+    "quote": "USD",
+    "display_name": "RON / US Dollar",
+    "description": "RON to US Dollar spot trading pair",
+    "tags": [
+      "ron",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RPL-USD": {
+    "normalized_id": "RPL/USD",
+    "base": "RPL",
+    "quote": "USD",
+    "display_name": "RPL / US Dollar",
+    "description": "RPL to US Dollar spot trading pair",
+    "tags": [
+      "rpl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RPL-USDT": {
+    "normalized_id": "RPL/USD",
+    "base": "RPL",
+    "quote": "USD",
+    "display_name": "RPL / US Dollar",
+    "description": "RPL to US Dollar spot trading pair",
+    "tags": [
+      "rpl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RSR-USD": {
+    "normalized_id": "RSR/USD",
+    "base": "RSR",
+    "quote": "USD",
+    "display_name": "RSR / US Dollar",
+    "description": "RSR to US Dollar spot trading pair",
+    "tags": [
+      "rsr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RSR-USDT": {
+    "normalized_id": "RSR/USD",
+    "base": "RSR",
+    "quote": "USD",
+    "display_name": "RSR / US Dollar",
+    "description": "RSR to US Dollar spot trading pair",
+    "tags": [
+      "rsr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RSS3-USD": {
+    "normalized_id": "RSS3/USD",
+    "base": "RSS3",
+    "quote": "USD",
+    "display_name": "RSS3 / US Dollar",
+    "description": "RSS3 to US Dollar spot trading pair",
+    "tags": [
+      "rss3",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RSS3-USDT": {
+    "normalized_id": "RSS3/USD",
+    "base": "RSS3",
+    "quote": "USD",
+    "display_name": "RSS3 / US Dollar",
+    "description": "RSS3 to US Dollar spot trading pair",
+    "tags": [
+      "rss3",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RUNECOIN-USDT": {
+    "normalized_id": "RUNECOIN/USD",
+    "base": "RUNECOIN",
+    "quote": "USD",
+    "display_name": "RUNECOIN / US Dollar",
+    "description": "RUNECOIN to US Dollar spot trading pair",
+    "tags": [
+      "runecoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RVN-USD": {
+    "normalized_id": "RVN/USD",
+    "base": "RVN",
+    "quote": "USD",
+    "display_name": "RVN / US Dollar",
+    "description": "RVN to US Dollar spot trading pair",
+    "tags": [
+      "rvn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "RVN-USDT": {
+    "normalized_id": "RVN/USD",
+    "base": "RVN",
+    "quote": "USD",
+    "display_name": "RVN / US Dollar",
+    "description": "RVN to US Dollar spot trading pair",
+    "tags": [
+      "rvn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "S-USD": {
+    "normalized_id": "S/USD",
+    "base": "S",
+    "quote": "USD",
+    "display_name": "S / US Dollar",
+    "description": "S to US Dollar spot trading pair",
+    "tags": [
+      "s",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "S-USDT": {
+    "normalized_id": "S/USD",
+    "base": "S",
+    "quote": "USD",
+    "display_name": "S / US Dollar",
+    "description": "S to US Dollar spot trading pair",
+    "tags": [
+      "s",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAFE-USD": {
+    "normalized_id": "SAFE/USD",
+    "base": "SAFE",
+    "quote": "USD",
+    "display_name": "SAFE / US Dollar",
+    "description": "SAFE to US Dollar spot trading pair",
+    "tags": [
+      "safe",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAFE-USDT": {
+    "normalized_id": "SAFE/USD",
+    "base": "SAFE",
+    "quote": "USD",
+    "display_name": "SAFE / US Dollar",
+    "description": "SAFE to US Dollar spot trading pair",
+    "tags": [
+      "safe",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAHARA-USD": {
+    "normalized_id": "SAHARA/USD",
+    "base": "SAHARA",
+    "quote": "USD",
+    "display_name": "SAHARA / US Dollar",
+    "description": "SAHARA to US Dollar spot trading pair",
+    "tags": [
+      "sahara",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAHARA-USDT": {
+    "normalized_id": "SAHARA/USD",
+    "base": "SAHARA",
+    "quote": "USD",
+    "display_name": "SAHARA / US Dollar",
+    "description": "SAHARA to US Dollar spot trading pair",
+    "tags": [
+      "sahara",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAND-EUR": {
+    "normalized_id": "SAND/EUR",
+    "base": "SAND",
+    "quote": "EUR",
+    "display_name": "The Sandbox / Euro",
+    "description": "The Sandbox to Euro spot trading pair",
+    "tags": [
+      "sand",
+      "the sandbox",
+      "gaming",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SAND-USD": {
+    "normalized_id": "SAND/USD",
+    "base": "SAND",
+    "quote": "USD",
+    "display_name": "The Sandbox / US Dollar",
+    "description": "The Sandbox to US Dollar spot trading pair",
+    "tags": [
+      "sand",
+      "the sandbox",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAND-USDC": {
+    "normalized_id": "SAND/USD",
+    "base": "SAND",
+    "quote": "USD",
+    "display_name": "The Sandbox / US Dollar",
+    "description": "The Sandbox to US Dollar spot trading pair",
+    "tags": [
+      "sand",
+      "the sandbox",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SAND-USDT": {
+    "normalized_id": "SAND/USD",
+    "base": "SAND",
+    "quote": "USD",
+    "display_name": "The Sandbox / US Dollar",
+    "description": "The Sandbox to US Dollar spot trading pair",
+    "tags": [
+      "sand",
+      "the sandbox",
+      "gaming",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SATS-USD": {
+    "normalized_id": "SATS/USD",
+    "base": "SATS",
+    "quote": "USD",
+    "display_name": "SATS / US Dollar",
+    "description": "SATS to US Dollar spot trading pair",
+    "tags": [
+      "sats",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SATS-USDT": {
+    "normalized_id": "SATS/USD",
+    "base": "SATS",
+    "quote": "USD",
+    "display_name": "SATS / US Dollar",
+    "description": "SATS to US Dollar spot trading pair",
+    "tags": [
+      "sats",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SC-USDT": {
+    "normalized_id": "SC/USD",
+    "base": "SC",
+    "quote": "USD",
+    "display_name": "SC / US Dollar",
+    "description": "SC to US Dollar spot trading pair",
+    "tags": [
+      "sc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SCR-USD": {
+    "normalized_id": "SCR/USD",
+    "base": "SCR",
+    "quote": "USD",
+    "display_name": "SCR / US Dollar",
+    "description": "SCR to US Dollar spot trading pair",
+    "tags": [
+      "scr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SCR-USDT": {
+    "normalized_id": "SCR/USD",
+    "base": "SCR",
+    "quote": "USD",
+    "display_name": "SCR / US Dollar",
+    "description": "SCR to US Dollar spot trading pair",
+    "tags": [
+      "scr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SD-USD": {
+    "normalized_id": "SD/USD",
+    "base": "SD",
+    "quote": "USD",
+    "display_name": "SD / US Dollar",
+    "description": "SD to US Dollar spot trading pair",
+    "tags": [
+      "sd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SD-USDT": {
+    "normalized_id": "SD/USD",
+    "base": "SD",
+    "quote": "USD",
+    "display_name": "SD / US Dollar",
+    "description": "SD to US Dollar spot trading pair",
+    "tags": [
+      "sd",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHIB-EUR": {
+    "normalized_id": "SHIB/EUR",
+    "base": "SHIB",
+    "quote": "EUR",
+    "display_name": "Shiba Inu / Euro",
+    "description": "Shiba Inu to Euro spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SHIB-USD": {
+    "normalized_id": "SHIB/USD",
+    "base": "SHIB",
+    "quote": "USD",
+    "display_name": "Shiba Inu / US Dollar",
+    "description": "Shiba Inu to US Dollar spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHIB-USDC": {
+    "normalized_id": "SHIB/USD",
+    "base": "SHIB",
+    "quote": "USD",
+    "display_name": "Shiba Inu / US Dollar",
+    "description": "Shiba Inu to US Dollar spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SHIB-USDT": {
+    "normalized_id": "SHIB/USD",
+    "base": "SHIB",
+    "quote": "USD",
+    "display_name": "Shiba Inu / US Dollar",
+    "description": "Shiba Inu to US Dollar spot trading pair",
+    "tags": [
+      "shib",
+      "shiba inu",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SKL-USD": {
+    "normalized_id": "SKL/USD",
+    "base": "SKL",
+    "quote": "USD",
+    "display_name": "SKL / US Dollar",
+    "description": "SKL to US Dollar spot trading pair",
+    "tags": [
+      "skl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SKL-USDT": {
+    "normalized_id": "SKL/USD",
+    "base": "SKL",
+    "quote": "USD",
+    "display_name": "SKL / US Dollar",
+    "description": "SKL to US Dollar spot trading pair",
+    "tags": [
+      "skl",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SLERF-USDT": {
+    "normalized_id": "SLERF/USD",
+    "base": "SLERF",
+    "quote": "USD",
+    "display_name": "SLERF / US Dollar",
+    "description": "SLERF to US Dollar spot trading pair",
+    "tags": [
+      "slerf",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SLP-USD": {
+    "normalized_id": "SLP/USD",
+    "base": "SLP",
+    "quote": "USD",
+    "display_name": "SLP / US Dollar",
+    "description": "SLP to US Dollar spot trading pair",
+    "tags": [
+      "slp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SLP-USDT": {
+    "normalized_id": "SLP/USD",
+    "base": "SLP",
+    "quote": "USD",
+    "display_name": "SLP / US Dollar",
+    "description": "SLP to US Dollar spot trading pair",
+    "tags": [
+      "slp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SNT-USD": {
+    "normalized_id": "SNT/USD",
+    "base": "SNT",
+    "quote": "USD",
+    "display_name": "SNT / US Dollar",
+    "description": "SNT to US Dollar spot trading pair",
+    "tags": [
+      "snt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SNT-USDT": {
+    "normalized_id": "SNT/USD",
+    "base": "SNT",
+    "quote": "USD",
+    "display_name": "SNT / US Dollar",
+    "description": "SNT to US Dollar spot trading pair",
+    "tags": [
+      "snt",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SNX-EUR": {
+    "normalized_id": "SNX/EUR",
+    "base": "SNX",
+    "quote": "EUR",
+    "display_name": "Synthetix / Euro",
+    "description": "Synthetix to Euro spot trading pair",
+    "tags": [
+      "snx",
+      "synthetix",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SNX-USD": {
+    "normalized_id": "SNX/USD",
+    "base": "SNX",
+    "quote": "USD",
+    "display_name": "Synthetix / US Dollar",
+    "description": "Synthetix to US Dollar spot trading pair",
+    "tags": [
+      "snx",
+      "synthetix",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SNX-USDT": {
+    "normalized_id": "SNX/USD",
+    "base": "SNX",
+    "quote": "USD",
+    "display_name": "Synthetix / US Dollar",
+    "description": "Synthetix to US Dollar spot trading pair",
+    "tags": [
+      "snx",
+      "synthetix",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOL-AED": {
+    "normalized_id": "SOL/AED",
+    "base": "SOL",
+    "quote": "AED",
+    "display_name": "Solana / AED",
+    "description": "Solana to AED spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "aed"
+    ],
+    "category": "crypto"
+  },
+  "SOL-AUD": {
+    "normalized_id": "SOL/AUD",
+    "base": "SOL",
+    "quote": "AUD",
+    "display_name": "Solana / Australian Dollar",
+    "description": "Solana to Australian Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "SOL-BRL": {
+    "normalized_id": "SOL/BRL",
+    "base": "SOL",
+    "quote": "BRL",
+    "display_name": "Solana / Brazilian Real",
+    "description": "Solana to Brazilian Real spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "SOL-BTC": {
+    "normalized_id": "SOL/BTC",
+    "base": "SOL",
+    "quote": "BTC",
+    "display_name": "Solana / Bitcoin",
+    "description": "Solana to Bitcoin spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "SOL-ETH": {
+    "normalized_id": "SOL/ETH",
+    "base": "SOL",
+    "quote": "ETH",
+    "display_name": "Solana / Ethereum",
+    "description": "Solana to Ethereum spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "SOL-EUR": {
+    "normalized_id": "SOL/EUR",
+    "base": "SOL",
+    "quote": "EUR",
+    "display_name": "Solana / Euro",
+    "description": "Solana to Euro spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SOL-TRY": {
+    "normalized_id": "SOL/TRY",
+    "base": "SOL",
+    "quote": "TRY",
+    "display_name": "Solana / Turkish Lira",
+    "description": "Solana to Turkish Lira spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "SOL-USD": {
+    "normalized_id": "SOL/USD",
+    "base": "SOL",
+    "quote": "USD",
+    "display_name": "Solana / US Dollar",
+    "description": "Solana to US Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOL-USDC": {
+    "normalized_id": "SOL/USD",
+    "base": "SOL",
+    "quote": "USD",
+    "display_name": "Solana / US Dollar",
+    "description": "Solana to US Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOL-USDT": {
+    "normalized_id": "SOL/USD",
+    "base": "SOL",
+    "quote": "USD",
+    "display_name": "Solana / US Dollar",
+    "description": "Solana to US Dollar spot trading pair",
+    "tags": [
+      "sol",
+      "solana",
+      "layer1",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SONIC-USD": {
+    "normalized_id": "SONIC/USD",
+    "base": "SONIC",
+    "quote": "USD",
+    "display_name": "SONIC / US Dollar",
+    "description": "SONIC to US Dollar spot trading pair",
+    "tags": [
+      "sonic",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SONIC-USDT": {
+    "normalized_id": "SONIC/USD",
+    "base": "SONIC",
+    "quote": "USD",
+    "display_name": "SONIC / US Dollar",
+    "description": "SONIC to US Dollar spot trading pair",
+    "tags": [
+      "sonic",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOPH-USD": {
+    "normalized_id": "SOPH/USD",
+    "base": "SOPH",
+    "quote": "USD",
+    "display_name": "SOPH / US Dollar",
+    "description": "SOPH to US Dollar spot trading pair",
+    "tags": [
+      "soph",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SOPH-USDT": {
+    "normalized_id": "SOPH/USD",
+    "base": "SOPH",
+    "quote": "USD",
+    "display_name": "SOPH / US Dollar",
+    "description": "SOPH to US Dollar spot trading pair",
+    "tags": [
+      "soph",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SPK-USD": {
+    "normalized_id": "SPK/USD",
+    "base": "SPK",
+    "quote": "USD",
+    "display_name": "SPK / US Dollar",
+    "description": "SPK to US Dollar spot trading pair",
+    "tags": [
+      "spk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SPK-USDT": {
+    "normalized_id": "SPK/USD",
+    "base": "SPK",
+    "quote": "USD",
+    "display_name": "SPK / US Dollar",
+    "description": "SPK to US Dollar spot trading pair",
+    "tags": [
+      "spk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SPURS-USD": {
+    "normalized_id": "SPURS/USD",
+    "base": "SPURS",
+    "quote": "USD",
+    "display_name": "SPURS / US Dollar",
+    "description": "SPURS to US Dollar spot trading pair",
+    "tags": [
+      "spurs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SPURS-USDT": {
+    "normalized_id": "SPURS/USD",
+    "base": "SPURS",
+    "quote": "USD",
+    "display_name": "SPURS / US Dollar",
+    "description": "SPURS to US Dollar spot trading pair",
+    "tags": [
+      "spurs",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SSV-USD": {
+    "normalized_id": "SSV/USD",
+    "base": "SSV",
+    "quote": "USD",
+    "display_name": "SSV / US Dollar",
+    "description": "SSV to US Dollar spot trading pair",
+    "tags": [
+      "ssv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SSV-USDT": {
+    "normalized_id": "SSV/USD",
+    "base": "SSV",
+    "quote": "USD",
+    "display_name": "SSV / US Dollar",
+    "description": "SSV to US Dollar spot trading pair",
+    "tags": [
+      "ssv",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STETH-ETH": {
+    "normalized_id": "STETH/ETH",
+    "base": "STETH",
+    "quote": "ETH",
+    "display_name": "STETH / Ethereum",
+    "description": "STETH to Ethereum spot trading pair",
+    "tags": [
+      "steth",
+      "eth"
+    ],
+    "category": "crypto"
+  },
+  "STETH-USD": {
+    "normalized_id": "STETH/USD",
+    "base": "STETH",
+    "quote": "USD",
+    "display_name": "STETH / US Dollar",
+    "description": "STETH to US Dollar spot trading pair",
+    "tags": [
+      "steth",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STETH-USDT": {
+    "normalized_id": "STETH/USD",
+    "base": "STETH",
+    "quote": "USD",
+    "display_name": "STETH / US Dollar",
+    "description": "STETH to US Dollar spot trading pair",
+    "tags": [
+      "steth",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STORJ-USD": {
+    "normalized_id": "STORJ/USD",
+    "base": "STORJ",
+    "quote": "USD",
+    "display_name": "STORJ / US Dollar",
+    "description": "STORJ to US Dollar spot trading pair",
+    "tags": [
+      "storj",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STORJ-USDT": {
+    "normalized_id": "STORJ/USD",
+    "base": "STORJ",
+    "quote": "USD",
+    "display_name": "STORJ / US Dollar",
+    "description": "STORJ to US Dollar spot trading pair",
+    "tags": [
+      "storj",
+      "storage",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STRK-USD": {
+    "normalized_id": "STRK/USD",
+    "base": "STRK",
+    "quote": "USD",
+    "display_name": "STRK / US Dollar",
+    "description": "STRK to US Dollar spot trading pair",
+    "tags": [
+      "strk",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STRK-USDC": {
+    "normalized_id": "STRK/USD",
+    "base": "STRK",
+    "quote": "USD",
+    "display_name": "STRK / US Dollar",
+    "description": "STRK to US Dollar spot trading pair",
+    "tags": [
+      "strk",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STRK-USDT": {
+    "normalized_id": "STRK/USD",
+    "base": "STRK",
+    "quote": "USD",
+    "display_name": "STRK / US Dollar",
+    "description": "STRK to US Dollar spot trading pair",
+    "tags": [
+      "strk",
+      "layer2",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STX-BTC": {
+    "normalized_id": "STX/BTC",
+    "base": "STX",
+    "quote": "BTC",
+    "display_name": "STX / Bitcoin",
+    "description": "STX to Bitcoin spot trading pair",
+    "tags": [
+      "stx",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "STX-EUR": {
+    "normalized_id": "STX/EUR",
+    "base": "STX",
+    "quote": "EUR",
+    "display_name": "STX / Euro",
+    "description": "STX to Euro spot trading pair",
+    "tags": [
+      "stx",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "STX-USD": {
+    "normalized_id": "STX/USD",
+    "base": "STX",
+    "quote": "USD",
+    "display_name": "STX / US Dollar",
+    "description": "STX to US Dollar spot trading pair",
+    "tags": [
+      "stx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STX-USDC": {
+    "normalized_id": "STX/USD",
+    "base": "STX",
+    "quote": "USD",
+    "display_name": "STX / US Dollar",
+    "description": "STX to US Dollar spot trading pair",
+    "tags": [
+      "stx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "STX-USDT": {
+    "normalized_id": "STX/USD",
+    "base": "STX",
+    "quote": "USD",
+    "display_name": "STX / US Dollar",
+    "description": "STX to US Dollar spot trading pair",
+    "tags": [
+      "stx",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUI-EUR": {
+    "normalized_id": "SUI/EUR",
+    "base": "SUI",
+    "quote": "EUR",
+    "display_name": "Sui / Euro",
+    "description": "Sui to Euro spot trading pair",
+    "tags": [
+      "sui",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SUI-USD": {
+    "normalized_id": "SUI/USD",
+    "base": "SUI",
+    "quote": "USD",
+    "display_name": "Sui / US Dollar",
+    "description": "Sui to US Dollar spot trading pair",
+    "tags": [
+      "sui",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUI-USDC": {
+    "normalized_id": "SUI/USD",
+    "base": "SUI",
+    "quote": "USD",
+    "display_name": "Sui / US Dollar",
+    "description": "Sui to US Dollar spot trading pair",
+    "tags": [
+      "sui",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUI-USDT": {
+    "normalized_id": "SUI/USD",
+    "base": "SUI",
+    "quote": "USD",
+    "display_name": "Sui / US Dollar",
+    "description": "Sui to US Dollar spot trading pair",
+    "tags": [
+      "sui",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUSHI-EUR": {
+    "normalized_id": "SUSHI/EUR",
+    "base": "SUSHI",
+    "quote": "EUR",
+    "display_name": "SUSHI / Euro",
+    "description": "SUSHI to Euro spot trading pair",
+    "tags": [
+      "sushi",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "SUSHI-USD": {
+    "normalized_id": "SUSHI/USD",
+    "base": "SUSHI",
+    "quote": "USD",
+    "display_name": "SUSHI / US Dollar",
+    "description": "SUSHI to US Dollar spot trading pair",
+    "tags": [
+      "sushi",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SUSHI-USDT": {
+    "normalized_id": "SUSHI/USD",
+    "base": "SUSHI",
+    "quote": "USD",
+    "display_name": "SUSHI / US Dollar",
+    "description": "SUSHI to US Dollar spot trading pair",
+    "tags": [
+      "sushi",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SWEAT-USDT": {
+    "normalized_id": "SWEAT/USD",
+    "base": "SWEAT",
+    "quote": "USD",
+    "display_name": "SWEAT / US Dollar",
+    "description": "SWEAT to US Dollar spot trading pair",
+    "tags": [
+      "sweat",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SWFTC-USD": {
+    "normalized_id": "SWFTC/USD",
+    "base": "SWFTC",
+    "quote": "USD",
+    "display_name": "SWFTC / US Dollar",
+    "description": "SWFTC to US Dollar spot trading pair",
+    "tags": [
+      "swftc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "SWFTC-USDT": {
+    "normalized_id": "SWFTC/USD",
+    "base": "SWFTC",
+    "quote": "USD",
+    "display_name": "SWFTC / US Dollar",
+    "description": "SWFTC to US Dollar spot trading pair",
+    "tags": [
+      "swftc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "T-USD": {
+    "normalized_id": "T/USD",
+    "base": "T",
+    "quote": "USD",
+    "display_name": "T / US Dollar",
+    "description": "T to US Dollar spot trading pair",
+    "tags": [
+      "t",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "T-USDT": {
+    "normalized_id": "T/USD",
+    "base": "T",
+    "quote": "USD",
+    "display_name": "T / US Dollar",
+    "description": "T to US Dollar spot trading pair",
+    "tags": [
+      "t",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "THETA-USD": {
+    "normalized_id": "THETA/USD",
+    "base": "THETA",
+    "quote": "USD",
+    "display_name": "Theta / US Dollar",
+    "description": "Theta to US Dollar spot trading pair",
+    "tags": [
+      "theta",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "THETA-USDT": {
+    "normalized_id": "THETA/USD",
+    "base": "THETA",
+    "quote": "USD",
+    "display_name": "Theta / US Dollar",
+    "description": "Theta to US Dollar spot trading pair",
+    "tags": [
+      "theta",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TIA-USD": {
+    "normalized_id": "TIA/USD",
+    "base": "TIA",
+    "quote": "USD",
+    "display_name": "Celestia / US Dollar",
+    "description": "Celestia to US Dollar spot trading pair",
+    "tags": [
+      "tia",
+      "celestia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TIA-USDC": {
+    "normalized_id": "TIA/USD",
+    "base": "TIA",
+    "quote": "USD",
+    "display_name": "Celestia / US Dollar",
+    "description": "Celestia to US Dollar spot trading pair",
+    "tags": [
+      "tia",
+      "celestia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TIA-USDT": {
+    "normalized_id": "TIA/USD",
+    "base": "TIA",
+    "quote": "USD",
+    "display_name": "Celestia / US Dollar",
+    "description": "Celestia to US Dollar spot trading pair",
+    "tags": [
+      "tia",
+      "celestia",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TNSR-USD": {
+    "normalized_id": "TNSR/USD",
+    "base": "TNSR",
+    "quote": "USD",
+    "display_name": "TNSR / US Dollar",
+    "description": "TNSR to US Dollar spot trading pair",
+    "tags": [
+      "tnsr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TNSR-USDT": {
+    "normalized_id": "TNSR/USD",
+    "base": "TNSR",
+    "quote": "USD",
+    "display_name": "TNSR / US Dollar",
+    "description": "TNSR to US Dollar spot trading pair",
+    "tags": [
+      "tnsr",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TON-EUR": {
+    "normalized_id": "TON/EUR",
+    "base": "TON",
+    "quote": "EUR",
+    "display_name": "Toncoin / Euro",
+    "description": "Toncoin to Euro spot trading pair",
+    "tags": [
+      "ton",
+      "toncoin",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TON-USD": {
+    "normalized_id": "TON/USD",
+    "base": "TON",
+    "quote": "USD",
+    "display_name": "Toncoin / US Dollar",
+    "description": "Toncoin to US Dollar spot trading pair",
+    "tags": [
+      "ton",
+      "toncoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TON-USDC": {
+    "normalized_id": "TON/USD",
+    "base": "TON",
+    "quote": "USD",
+    "display_name": "Toncoin / US Dollar",
+    "description": "Toncoin to US Dollar spot trading pair",
+    "tags": [
+      "ton",
+      "toncoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TON-USDT": {
+    "normalized_id": "TON/USD",
+    "base": "TON",
+    "quote": "USD",
+    "display_name": "Toncoin / US Dollar",
+    "description": "Toncoin to US Dollar spot trading pair",
+    "tags": [
+      "ton",
+      "toncoin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRA-USD": {
+    "normalized_id": "TRA/USD",
+    "base": "TRA",
+    "quote": "USD",
+    "display_name": "TRA / US Dollar",
+    "description": "TRA to US Dollar spot trading pair",
+    "tags": [
+      "tra",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRA-USDT": {
+    "normalized_id": "TRA/USD",
+    "base": "TRA",
+    "quote": "USD",
+    "display_name": "TRA / US Dollar",
+    "description": "TRA to US Dollar spot trading pair",
+    "tags": [
+      "tra",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRB-USD": {
+    "normalized_id": "TRB/USD",
+    "base": "TRB",
+    "quote": "USD",
+    "display_name": "TRB / US Dollar",
+    "description": "TRB to US Dollar spot trading pair",
+    "tags": [
+      "trb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRB-USDT": {
+    "normalized_id": "TRB/USD",
+    "base": "TRB",
+    "quote": "USD",
+    "display_name": "TRB / US Dollar",
+    "description": "TRB to US Dollar spot trading pair",
+    "tags": [
+      "trb",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRUMP-AED": {
+    "normalized_id": "TRUMP/AED",
+    "base": "TRUMP",
+    "quote": "AED",
+    "display_name": "TRUMP / AED",
+    "description": "TRUMP to AED spot trading pair",
+    "tags": [
+      "trump",
+      "aed"
+    ],
+    "category": "crypto"
+  },
+  "TRUMP-AUD": {
+    "normalized_id": "TRUMP/AUD",
+    "base": "TRUMP",
+    "quote": "AUD",
+    "display_name": "TRUMP / Australian Dollar",
+    "description": "TRUMP to Australian Dollar spot trading pair",
+    "tags": [
+      "trump",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "TRUMP-BRL": {
+    "normalized_id": "TRUMP/BRL",
+    "base": "TRUMP",
+    "quote": "BRL",
+    "display_name": "TRUMP / Brazilian Real",
+    "description": "TRUMP to Brazilian Real spot trading pair",
+    "tags": [
+      "trump",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "TRUMP-EUR": {
+    "normalized_id": "TRUMP/EUR",
+    "base": "TRUMP",
+    "quote": "EUR",
+    "display_name": "TRUMP / Euro",
+    "description": "TRUMP to Euro spot trading pair",
+    "tags": [
+      "trump",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TRUMP-TRY": {
+    "normalized_id": "TRUMP/TRY",
+    "base": "TRUMP",
+    "quote": "TRY",
+    "display_name": "TRUMP / Turkish Lira",
+    "description": "TRUMP to Turkish Lira spot trading pair",
+    "tags": [
+      "trump",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "TRUMP-USD": {
+    "normalized_id": "TRUMP/USD",
+    "base": "TRUMP",
+    "quote": "USD",
+    "display_name": "TRUMP / US Dollar",
+    "description": "TRUMP to US Dollar spot trading pair",
+    "tags": [
+      "trump",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRUMP-USDT": {
+    "normalized_id": "TRUMP/USD",
+    "base": "TRUMP",
+    "quote": "USD",
+    "display_name": "TRUMP / US Dollar",
+    "description": "TRUMP to US Dollar spot trading pair",
+    "tags": [
+      "trump",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRX-EUR": {
+    "normalized_id": "TRX/EUR",
+    "base": "TRX",
+    "quote": "EUR",
+    "display_name": "TRON / Euro",
+    "description": "TRON to Euro spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "TRX-USD": {
+    "normalized_id": "TRX/USD",
+    "base": "TRX",
+    "quote": "USD",
+    "display_name": "TRON / US Dollar",
+    "description": "TRON to US Dollar spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRX-USDC": {
+    "normalized_id": "TRX/USD",
+    "base": "TRX",
+    "quote": "USD",
+    "display_name": "TRON / US Dollar",
+    "description": "TRON to US Dollar spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TRX-USDT": {
+    "normalized_id": "TRX/USD",
+    "base": "TRX",
+    "quote": "USD",
+    "display_name": "TRON / US Dollar",
+    "description": "TRON to US Dollar spot trading pair",
+    "tags": [
+      "trx",
+      "tron",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TURBO-USD": {
+    "normalized_id": "TURBO/USD",
+    "base": "TURBO",
+    "quote": "USD",
+    "display_name": "TURBO / US Dollar",
+    "description": "TURBO to US Dollar spot trading pair",
+    "tags": [
+      "turbo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TURBO-USDC": {
+    "normalized_id": "TURBO/USD",
+    "base": "TURBO",
+    "quote": "USD",
+    "display_name": "TURBO / US Dollar",
+    "description": "TURBO to US Dollar spot trading pair",
+    "tags": [
+      "turbo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "TURBO-USDT": {
+    "normalized_id": "TURBO/USD",
+    "base": "TURBO",
+    "quote": "USD",
+    "display_name": "TURBO / US Dollar",
+    "description": "TURBO to US Dollar spot trading pair",
+    "tags": [
+      "turbo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ULTI-USD": {
+    "normalized_id": "ULTI/USD",
+    "base": "ULTI",
+    "quote": "USD",
+    "display_name": "ULTI / US Dollar",
+    "description": "ULTI to US Dollar spot trading pair",
+    "tags": [
+      "ulti",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ULTI-USDT": {
+    "normalized_id": "ULTI/USD",
+    "base": "ULTI",
+    "quote": "USD",
+    "display_name": "ULTI / US Dollar",
+    "description": "ULTI to US Dollar spot trading pair",
+    "tags": [
+      "ulti",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UMA-USD": {
+    "normalized_id": "UMA/USD",
+    "base": "UMA",
+    "quote": "USD",
+    "display_name": "UMA / US Dollar",
+    "description": "UMA to US Dollar spot trading pair",
+    "tags": [
+      "uma",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UMA-USDT": {
+    "normalized_id": "UMA/USD",
+    "base": "UMA",
+    "quote": "USD",
+    "display_name": "UMA / US Dollar",
+    "description": "UMA to US Dollar spot trading pair",
+    "tags": [
+      "uma",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UNI-EUR": {
+    "normalized_id": "UNI/EUR",
+    "base": "UNI",
+    "quote": "EUR",
+    "display_name": "Uniswap / Euro",
+    "description": "Uniswap to Euro spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "UNI-USD": {
+    "normalized_id": "UNI/USD",
+    "base": "UNI",
+    "quote": "USD",
+    "display_name": "Uniswap / US Dollar",
+    "description": "Uniswap to US Dollar spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UNI-USDC": {
+    "normalized_id": "UNI/USD",
+    "base": "UNI",
+    "quote": "USD",
+    "display_name": "Uniswap / US Dollar",
+    "description": "Uniswap to US Dollar spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UNI-USDT": {
+    "normalized_id": "UNI/USD",
+    "base": "UNI",
+    "quote": "USD",
+    "display_name": "Uniswap / US Dollar",
+    "description": "Uniswap to US Dollar spot trading pair",
+    "tags": [
+      "uni",
+      "uniswap",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDC-AUD": {
+    "normalized_id": "USDC/AUD",
+    "base": "USDC",
+    "quote": "AUD",
+    "display_name": "USD Coin / Australian Dollar",
+    "description": "USD Coin to Australian Dollar spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "USDC-BRL": {
+    "normalized_id": "USDC/BRL",
+    "base": "USDC",
+    "quote": "BRL",
+    "display_name": "USD Coin / Brazilian Real",
+    "description": "USD Coin to Brazilian Real spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "USDC-EUR": {
+    "normalized_id": "USDC/EUR",
+    "base": "USDC",
+    "quote": "EUR",
+    "display_name": "USD Coin / Euro",
+    "description": "USD Coin to Euro spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "USDC-SGD": {
+    "normalized_id": "USDC/SGD",
+    "base": "USDC",
+    "quote": "SGD",
+    "display_name": "USD Coin / SGD",
+    "description": "USD Coin to SGD spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "sgd"
+    ],
+    "category": "crypto"
+  },
+  "USDC-USDT": {
+    "normalized_id": "USDC/USD",
+    "base": "USDC",
+    "quote": "USD",
+    "display_name": "USD Coin / US Dollar",
+    "description": "USD Coin to US Dollar spot trading pair",
+    "tags": [
+      "usdc",
+      "usd coin",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDG-USDT": {
+    "normalized_id": "USDG/USD",
+    "base": "USDG",
+    "quote": "USD",
+    "display_name": "USDG / US Dollar",
+    "description": "USDG to US Dollar spot trading pair",
+    "tags": [
+      "usdg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USDT-AED": {
+    "normalized_id": "USDT/AED",
+    "base": "USDT",
+    "quote": "AED",
+    "display_name": "Tether / AED",
+    "description": "Tether to AED spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "aed"
+    ],
+    "category": "crypto"
+  },
+  "USDT-AUD": {
+    "normalized_id": "USDT/AUD",
+    "base": "USDT",
+    "quote": "AUD",
+    "display_name": "Tether / Australian Dollar",
+    "description": "Tether to Australian Dollar spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "USDT-BRL": {
+    "normalized_id": "USDT/BRL",
+    "base": "USDT",
+    "quote": "BRL",
+    "display_name": "Tether / Brazilian Real",
+    "description": "Tether to Brazilian Real spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "USDT-EUR": {
+    "normalized_id": "USDT/EUR",
+    "base": "USDT",
+    "quote": "EUR",
+    "display_name": "Tether / Euro",
+    "description": "Tether to Euro spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "USDT-SGD": {
+    "normalized_id": "USDT/SGD",
+    "base": "USDT",
+    "quote": "SGD",
+    "display_name": "Tether / SGD",
+    "description": "Tether to SGD spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "sgd"
+    ],
+    "category": "crypto"
+  },
+  "USDT-TRY": {
+    "normalized_id": "USDT/TRY",
+    "base": "USDT",
+    "quote": "TRY",
+    "display_name": "Tether / Turkish Lira",
+    "description": "Tether to Turkish Lira spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "USDT-USD": {
+    "normalized_id": "USDT/USD",
+    "base": "USDT",
+    "quote": "USD",
+    "display_name": "Tether / US Dollar",
+    "description": "Tether to US Dollar spot trading pair",
+    "tags": [
+      "usdt",
+      "tether",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "USTC-USDT": {
+    "normalized_id": "USTC/USD",
+    "base": "USTC",
+    "quote": "USD",
+    "display_name": "USTC / US Dollar",
+    "description": "USTC to US Dollar spot trading pair",
+    "tags": [
+      "ustc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UXLINK-USD": {
+    "normalized_id": "UXLINK/USD",
+    "base": "UXLINK",
+    "quote": "USD",
+    "display_name": "UXLINK / US Dollar",
+    "description": "UXLINK to US Dollar spot trading pair",
+    "tags": [
+      "uxlink",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "UXLINK-USDT": {
+    "normalized_id": "UXLINK/USD",
+    "base": "UXLINK",
+    "quote": "USD",
+    "display_name": "UXLINK / US Dollar",
+    "description": "UXLINK to US Dollar spot trading pair",
+    "tags": [
+      "uxlink",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VELO-USD": {
+    "normalized_id": "VELO/USD",
+    "base": "VELO",
+    "quote": "USD",
+    "display_name": "VELO / US Dollar",
+    "description": "VELO to US Dollar spot trading pair",
+    "tags": [
+      "velo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VELO-USDT": {
+    "normalized_id": "VELO/USD",
+    "base": "VELO",
+    "quote": "USD",
+    "display_name": "VELO / US Dollar",
+    "description": "VELO to US Dollar spot trading pair",
+    "tags": [
+      "velo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VELODROME-USD": {
+    "normalized_id": "VELODROME/USD",
+    "base": "VELODROME",
+    "quote": "USD",
+    "display_name": "VELODROME / US Dollar",
+    "description": "VELODROME to US Dollar spot trading pair",
+    "tags": [
+      "velodrome",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VELODROME-USDT": {
+    "normalized_id": "VELODROME/USD",
+    "base": "VELODROME",
+    "quote": "USD",
+    "display_name": "VELODROME / US Dollar",
+    "description": "VELODROME to US Dollar spot trading pair",
+    "tags": [
+      "velodrome",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VINE-USDT": {
+    "normalized_id": "VINE/USD",
+    "base": "VINE",
+    "quote": "USD",
+    "display_name": "VINE / US Dollar",
+    "description": "VINE to US Dollar spot trading pair",
+    "tags": [
+      "vine",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VRA-USD": {
+    "normalized_id": "VRA/USD",
+    "base": "VRA",
+    "quote": "USD",
+    "display_name": "VRA / US Dollar",
+    "description": "VRA to US Dollar spot trading pair",
+    "tags": [
+      "vra",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "VRA-USDT": {
+    "normalized_id": "VRA/USD",
+    "base": "VRA",
+    "quote": "USD",
+    "display_name": "VRA / US Dollar",
+    "description": "VRA to US Dollar spot trading pair",
+    "tags": [
+      "vra",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "W-USD": {
+    "normalized_id": "W/USD",
+    "base": "W",
+    "quote": "USD",
+    "display_name": "W / US Dollar",
+    "description": "W to US Dollar spot trading pair",
+    "tags": [
+      "w",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "W-USDT": {
+    "normalized_id": "W/USD",
+    "base": "W",
+    "quote": "USD",
+    "display_name": "W / US Dollar",
+    "description": "W to US Dollar spot trading pair",
+    "tags": [
+      "w",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WAXP-USD": {
+    "normalized_id": "WAXP/USD",
+    "base": "WAXP",
+    "quote": "USD",
+    "display_name": "WAXP / US Dollar",
+    "description": "WAXP to US Dollar spot trading pair",
+    "tags": [
+      "waxp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WAXP-USDT": {
+    "normalized_id": "WAXP/USD",
+    "base": "WAXP",
+    "quote": "USD",
+    "display_name": "WAXP / US Dollar",
+    "description": "WAXP to US Dollar spot trading pair",
+    "tags": [
+      "waxp",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WBTC-BTC": {
+    "normalized_id": "WBTC/BTC",
+    "base": "WBTC",
+    "quote": "BTC",
+    "display_name": "WBTC / Bitcoin",
+    "description": "WBTC to Bitcoin spot trading pair",
+    "tags": [
+      "wbtc",
+      "btc"
+    ],
+    "category": "crypto"
+  },
+  "WBTC-USD": {
+    "normalized_id": "WBTC/USD",
+    "base": "WBTC",
+    "quote": "USD",
+    "display_name": "WBTC / US Dollar",
+    "description": "WBTC to US Dollar spot trading pair",
+    "tags": [
+      "wbtc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WBTC-USDC": {
+    "normalized_id": "WBTC/USD",
+    "base": "WBTC",
+    "quote": "USD",
+    "display_name": "WBTC / US Dollar",
+    "description": "WBTC to US Dollar spot trading pair",
+    "tags": [
+      "wbtc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WBTC-USDT": {
+    "normalized_id": "WBTC/USD",
+    "base": "WBTC",
+    "quote": "USD",
+    "display_name": "WBTC / US Dollar",
+    "description": "WBTC to US Dollar spot trading pair",
+    "tags": [
+      "wbtc",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WCT-USD": {
+    "normalized_id": "WCT/USD",
+    "base": "WCT",
+    "quote": "USD",
+    "display_name": "WCT / US Dollar",
+    "description": "WCT to US Dollar spot trading pair",
+    "tags": [
+      "wct",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WCT-USDT": {
+    "normalized_id": "WCT/USD",
+    "base": "WCT",
+    "quote": "USD",
+    "display_name": "WCT / US Dollar",
+    "description": "WCT to US Dollar spot trading pair",
+    "tags": [
+      "wct",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WIF-EUR": {
+    "normalized_id": "WIF/EUR",
+    "base": "WIF",
+    "quote": "EUR",
+    "display_name": "dogwifhat / Euro",
+    "description": "dogwifhat to Euro spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "WIF-USD": {
+    "normalized_id": "WIF/USD",
+    "base": "WIF",
+    "quote": "USD",
+    "display_name": "dogwifhat / US Dollar",
+    "description": "dogwifhat to US Dollar spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WIF-USDC": {
+    "normalized_id": "WIF/USD",
+    "base": "WIF",
+    "quote": "USD",
+    "display_name": "dogwifhat / US Dollar",
+    "description": "dogwifhat to US Dollar spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WIF-USDT": {
+    "normalized_id": "WIF/USD",
+    "base": "WIF",
+    "quote": "USD",
+    "display_name": "dogwifhat / US Dollar",
+    "description": "dogwifhat to US Dollar spot trading pair",
+    "tags": [
+      "wif",
+      "dogwifhat",
+      "meme",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WIN-USD": {
+    "normalized_id": "WIN/USD",
+    "base": "WIN",
+    "quote": "USD",
+    "display_name": "WIN / US Dollar",
+    "description": "WIN to US Dollar spot trading pair",
+    "tags": [
+      "win",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WIN-USDT": {
+    "normalized_id": "WIN/USD",
+    "base": "WIN",
+    "quote": "USD",
+    "display_name": "WIN / US Dollar",
+    "description": "WIN to US Dollar spot trading pair",
+    "tags": [
+      "win",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WLD-USD": {
+    "normalized_id": "WLD/USD",
+    "base": "WLD",
+    "quote": "USD",
+    "display_name": "WLD / US Dollar",
+    "description": "WLD to US Dollar spot trading pair",
+    "tags": [
+      "wld",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WLD-USDC": {
+    "normalized_id": "WLD/USD",
+    "base": "WLD",
+    "quote": "USD",
+    "display_name": "WLD / US Dollar",
+    "description": "WLD to US Dollar spot trading pair",
+    "tags": [
+      "wld",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WLD-USDT": {
+    "normalized_id": "WLD/USD",
+    "base": "WLD",
+    "quote": "USD",
+    "display_name": "WLD / US Dollar",
+    "description": "WLD to US Dollar spot trading pair",
+    "tags": [
+      "wld",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "WOO-EUR": {
+    "normalized_id": "WOO/EUR",
+    "base": "WOO",
+    "quote": "EUR",
+    "display_name": "WOO / Euro",
+    "description": "WOO to Euro spot trading pair",
+    "tags": [
+      "woo",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "WOO-USDT": {
+    "normalized_id": "WOO/USD",
+    "base": "WOO",
+    "quote": "USD",
+    "display_name": "WOO / US Dollar",
+    "description": "WOO to US Dollar spot trading pair",
+    "tags": [
+      "woo",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XAUT-USDT": {
+    "normalized_id": "XAUT/USD",
+    "base": "XAUT",
+    "quote": "USD",
+    "display_name": "XAUT / US Dollar",
+    "description": "XAUT to US Dollar spot trading pair",
+    "tags": [
+      "xaut",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XCH-USD": {
+    "normalized_id": "XCH/USD",
+    "base": "XCH",
+    "quote": "USD",
+    "display_name": "XCH / US Dollar",
+    "description": "XCH to US Dollar spot trading pair",
+    "tags": [
+      "xch",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XCH-USDT": {
+    "normalized_id": "XCH/USD",
+    "base": "XCH",
+    "quote": "USD",
+    "display_name": "XCH / US Dollar",
+    "description": "XCH to US Dollar spot trading pair",
+    "tags": [
+      "xch",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XLM-EUR": {
+    "normalized_id": "XLM/EUR",
+    "base": "XLM",
+    "quote": "EUR",
+    "display_name": "Stellar / Euro",
+    "description": "Stellar to Euro spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XLM-USD": {
+    "normalized_id": "XLM/USD",
+    "base": "XLM",
+    "quote": "USD",
+    "display_name": "Stellar / US Dollar",
+    "description": "Stellar to US Dollar spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XLM-USDC": {
+    "normalized_id": "XLM/USD",
+    "base": "XLM",
+    "quote": "USD",
+    "display_name": "Stellar / US Dollar",
+    "description": "Stellar to US Dollar spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XLM-USDT": {
+    "normalized_id": "XLM/USD",
+    "base": "XLM",
+    "quote": "USD",
+    "display_name": "Stellar / US Dollar",
+    "description": "Stellar to US Dollar spot trading pair",
+    "tags": [
+      "xlm",
+      "stellar",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XRP-AED": {
+    "normalized_id": "XRP/AED",
+    "base": "XRP",
+    "quote": "AED",
+    "display_name": "Ripple / AED",
+    "description": "Ripple to AED spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "aed"
+    ],
+    "category": "crypto"
+  },
+  "XRP-AUD": {
+    "normalized_id": "XRP/AUD",
+    "base": "XRP",
+    "quote": "AUD",
+    "display_name": "Ripple / Australian Dollar",
+    "description": "Ripple to Australian Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "aud",
+      "fiat",
+      "australian dollar"
+    ],
+    "category": "crypto"
+  },
+  "XRP-BRL": {
+    "normalized_id": "XRP/BRL",
+    "base": "XRP",
+    "quote": "BRL",
+    "display_name": "Ripple / Brazilian Real",
+    "description": "Ripple to Brazilian Real spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "brl"
+    ],
+    "category": "crypto"
+  },
+  "XRP-EUR": {
+    "normalized_id": "XRP/EUR",
+    "base": "XRP",
+    "quote": "EUR",
+    "display_name": "Ripple / Euro",
+    "description": "Ripple to Euro spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XRP-TRY": {
+    "normalized_id": "XRP/TRY",
+    "base": "XRP",
+    "quote": "TRY",
+    "display_name": "Ripple / Turkish Lira",
+    "description": "Ripple to Turkish Lira spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "try"
+    ],
+    "category": "crypto"
+  },
+  "XRP-USD": {
+    "normalized_id": "XRP/USD",
+    "base": "XRP",
+    "quote": "USD",
+    "display_name": "Ripple / US Dollar",
+    "description": "Ripple to US Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XRP-USDC": {
+    "normalized_id": "XRP/USD",
+    "base": "XRP",
+    "quote": "USD",
+    "display_name": "Ripple / US Dollar",
+    "description": "Ripple to US Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XRP-USDT": {
+    "normalized_id": "XRP/USD",
+    "base": "XRP",
+    "quote": "USD",
+    "display_name": "Ripple / US Dollar",
+    "description": "Ripple to US Dollar spot trading pair",
+    "tags": [
+      "xrp",
+      "ripple",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XTZ-EUR": {
+    "normalized_id": "XTZ/EUR",
+    "base": "XTZ",
+    "quote": "EUR",
+    "display_name": "Tezos / Euro",
+    "description": "Tezos to Euro spot trading pair",
+    "tags": [
+      "xtz",
+      "tezos",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "XTZ-USD": {
+    "normalized_id": "XTZ/USD",
+    "base": "XTZ",
+    "quote": "USD",
+    "display_name": "Tezos / US Dollar",
+    "description": "Tezos to US Dollar spot trading pair",
+    "tags": [
+      "xtz",
+      "tezos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "XTZ-USDT": {
+    "normalized_id": "XTZ/USD",
+    "base": "XTZ",
+    "quote": "USD",
+    "display_name": "Tezos / US Dollar",
+    "description": "Tezos to US Dollar spot trading pair",
+    "tags": [
+      "xtz",
+      "tezos",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "YFI-USD": {
+    "normalized_id": "YFI/USD",
+    "base": "YFI",
+    "quote": "USD",
+    "display_name": "YFI / US Dollar",
+    "description": "YFI to US Dollar spot trading pair",
+    "tags": [
+      "yfi",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "YFI-USDT": {
+    "normalized_id": "YFI/USD",
+    "base": "YFI",
+    "quote": "USD",
+    "display_name": "YFI / US Dollar",
+    "description": "YFI to US Dollar spot trading pair",
+    "tags": [
+      "yfi",
+      "defi",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "YGG-EUR": {
+    "normalized_id": "YGG/EUR",
+    "base": "YGG",
+    "quote": "EUR",
+    "display_name": "YGG / Euro",
+    "description": "YGG to Euro spot trading pair",
+    "tags": [
+      "ygg",
+      "eur",
+      "fiat",
+      "euro"
+    ],
+    "category": "crypto"
+  },
+  "YGG-USD": {
+    "normalized_id": "YGG/USD",
+    "base": "YGG",
+    "quote": "USD",
+    "display_name": "YGG / US Dollar",
+    "description": "YGG to US Dollar spot trading pair",
+    "tags": [
+      "ygg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "YGG-USDC": {
+    "normalized_id": "YGG/USD",
+    "base": "YGG",
+    "quote": "USD",
+    "display_name": "YGG / US Dollar",
+    "description": "YGG to US Dollar spot trading pair",
+    "tags": [
+      "ygg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "YGG-USDT": {
+    "normalized_id": "YGG/USD",
+    "base": "YGG",
+    "quote": "USD",
+    "display_name": "YGG / US Dollar",
+    "description": "YGG to US Dollar spot trading pair",
+    "tags": [
+      "ygg",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZBCN-USD": {
+    "normalized_id": "ZBCN/USD",
+    "base": "ZBCN",
+    "quote": "USD",
+    "display_name": "ZBCN / US Dollar",
+    "description": "ZBCN to US Dollar spot trading pair",
+    "tags": [
+      "zbcn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZBCN-USDT": {
+    "normalized_id": "ZBCN/USD",
+    "base": "ZBCN",
+    "quote": "USD",
+    "display_name": "ZBCN / US Dollar",
+    "description": "ZBCN to US Dollar spot trading pair",
+    "tags": [
+      "zbcn",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZENT-USD": {
+    "normalized_id": "ZENT/USD",
+    "base": "ZENT",
+    "quote": "USD",
+    "display_name": "ZENT / US Dollar",
+    "description": "ZENT to US Dollar spot trading pair",
+    "tags": [
+      "zent",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZENT-USDC": {
+    "normalized_id": "ZENT/USD",
+    "base": "ZENT",
+    "quote": "USD",
+    "display_name": "ZENT / US Dollar",
+    "description": "ZENT to US Dollar spot trading pair",
+    "tags": [
+      "zent",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZENT-USDT": {
+    "normalized_id": "ZENT/USD",
+    "base": "ZENT",
+    "quote": "USD",
+    "display_name": "ZENT / US Dollar",
+    "description": "ZENT to US Dollar spot trading pair",
+    "tags": [
+      "zent",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZETA-USD": {
+    "normalized_id": "ZETA/USD",
+    "base": "ZETA",
+    "quote": "USD",
+    "display_name": "ZETA / US Dollar",
+    "description": "ZETA to US Dollar spot trading pair",
+    "tags": [
+      "zeta",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZETA-USDC": {
+    "normalized_id": "ZETA/USD",
+    "base": "ZETA",
+    "quote": "USD",
+    "display_name": "ZETA / US Dollar",
+    "description": "ZETA to US Dollar spot trading pair",
+    "tags": [
+      "zeta",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZETA-USDT": {
+    "normalized_id": "ZETA/USD",
+    "base": "ZETA",
+    "quote": "USD",
+    "display_name": "ZETA / US Dollar",
+    "description": "ZETA to US Dollar spot trading pair",
+    "tags": [
+      "zeta",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZEUS-USD": {
+    "normalized_id": "ZEUS/USD",
+    "base": "ZEUS",
+    "quote": "USD",
+    "display_name": "ZEUS / US Dollar",
+    "description": "ZEUS to US Dollar spot trading pair",
+    "tags": [
+      "zeus",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZEUS-USDC": {
+    "normalized_id": "ZEUS/USD",
+    "base": "ZEUS",
+    "quote": "USD",
+    "display_name": "ZEUS / US Dollar",
+    "description": "ZEUS to US Dollar spot trading pair",
+    "tags": [
+      "zeus",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZEUS-USDT": {
+    "normalized_id": "ZEUS/USD",
+    "base": "ZEUS",
+    "quote": "USD",
+    "display_name": "ZEUS / US Dollar",
+    "description": "ZEUS to US Dollar spot trading pair",
+    "tags": [
+      "zeus",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZIL-USD": {
+    "normalized_id": "ZIL/USD",
+    "base": "ZIL",
+    "quote": "USD",
+    "display_name": "ZIL / US Dollar",
+    "description": "ZIL to US Dollar spot trading pair",
+    "tags": [
+      "zil",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZIL-USDT": {
+    "normalized_id": "ZIL/USD",
+    "base": "ZIL",
+    "quote": "USD",
+    "display_name": "ZIL / US Dollar",
+    "description": "ZIL to US Dollar spot trading pair",
+    "tags": [
+      "zil",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZK-USD": {
+    "normalized_id": "ZK/USD",
+    "base": "ZK",
+    "quote": "USD",
+    "display_name": "ZK / US Dollar",
+    "description": "ZK to US Dollar spot trading pair",
+    "tags": [
+      "zk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZK-USDC": {
+    "normalized_id": "ZK/USD",
+    "base": "ZK",
+    "quote": "USD",
+    "display_name": "ZK / US Dollar",
+    "description": "ZK to US Dollar spot trading pair",
+    "tags": [
+      "zk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZK-USDT": {
+    "normalized_id": "ZK/USD",
+    "base": "ZK",
+    "quote": "USD",
+    "display_name": "ZK / US Dollar",
+    "description": "ZK to US Dollar spot trading pair",
+    "tags": [
+      "zk",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZKJ-USD": {
+    "normalized_id": "ZKJ/USD",
+    "base": "ZKJ",
+    "quote": "USD",
+    "display_name": "ZKJ / US Dollar",
+    "description": "ZKJ to US Dollar spot trading pair",
+    "tags": [
+      "zkj",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZKJ-USDT": {
+    "normalized_id": "ZKJ/USD",
+    "base": "ZKJ",
+    "quote": "USD",
+    "display_name": "ZKJ / US Dollar",
+    "description": "ZKJ to US Dollar spot trading pair",
+    "tags": [
+      "zkj",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZRO-USD": {
+    "normalized_id": "ZRO/USD",
+    "base": "ZRO",
+    "quote": "USD",
+    "display_name": "ZRO / US Dollar",
+    "description": "ZRO to US Dollar spot trading pair",
+    "tags": [
+      "zro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZRO-USDC": {
+    "normalized_id": "ZRO/USD",
+    "base": "ZRO",
+    "quote": "USD",
+    "display_name": "ZRO / US Dollar",
+    "description": "ZRO to US Dollar spot trading pair",
+    "tags": [
+      "zro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZRO-USDT": {
+    "normalized_id": "ZRO/USD",
+    "base": "ZRO",
+    "quote": "USD",
+    "display_name": "ZRO / US Dollar",
+    "description": "ZRO to US Dollar spot trading pair",
+    "tags": [
+      "zro",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZRX-USD": {
+    "normalized_id": "ZRX/USD",
+    "base": "ZRX",
+    "quote": "USD",
+    "display_name": "0x / US Dollar",
+    "description": "0x to US Dollar spot trading pair",
+    "tags": [
+      "zrx",
+      "0x",
+      "usd"
+    ],
+    "category": "crypto"
+  },
+  "ZRX-USDT": {
+    "normalized_id": "ZRX/USD",
+    "base": "ZRX",
+    "quote": "USD",
+    "display_name": "0x / US Dollar",
+    "description": "0x to US Dollar spot trading pair",
+    "tags": [
+      "zrx",
+      "0x",
+      "usd"
+    ],
+    "category": "crypto"
+  }
+}

--- a/server/src/symbols/mod.rs
+++ b/server/src/symbols/mod.rs
@@ -1,6 +1,6 @@
-mod search;
+mod search_runtime;
 
-pub use search::{
+pub use search_runtime::{
     SymbolSearchService, 
     SearchResult, 
     ExchangeSymbol,
@@ -192,7 +192,8 @@ pub async fn handle_symbol_search_request(
     // If no query provided, return empty results
     if search_query.is_empty() {
         let response = json!({
-            "results": []
+            "results": [],
+            "message": "Please provide a search query"
         });
         
         return Ok(Response::builder()
@@ -212,9 +213,18 @@ pub async fn handle_symbol_search_request(
     let service = SEARCH_SERVICE.read().await;
     let results = service.search(&decoded_query);
     
-    let response = json!({
-        "results": results
-    });
+    // Add debug info if no results
+    let response = if results.is_empty() {
+        json!({
+            "results": results,
+            "query": decoded_query,
+            "message": "No matching symbols found"
+        })
+    } else {
+        json!({
+            "results": results
+        })
+    };
     
     Ok(Response::builder()
         .status(StatusCode::OK)

--- a/server/src/symbols/search.rs
+++ b/server/src/symbols/search.rs
@@ -1,0 +1,359 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+// Symbol metadata for normalized representation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SymbolMetadata {
+    pub normalized_id: String,     // e.g., "BTC/USD"
+    pub base: String,              // e.g., "BTC"
+    pub quote: String,             // e.g., "USD"
+    pub display_name: String,      // e.g., "Bitcoin / US Dollar"
+    pub description: String,       // e.g., "Bitcoin to US Dollar spot trading pair"
+    pub tags: Vec<String>,         // e.g., ["crypto", "major", "btc", "bitcoin", "usd"]
+    pub category: String,          // e.g., "crypto", "forex", "commodity"
+}
+
+// Exchange-specific symbol mapping
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExchangeSymbol {
+    pub exchange: String,          // e.g., "coinbase"
+    pub symbol: String,            // e.g., "BTC-USD"
+}
+
+// Search result item
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchResult {
+    pub normalized_id: String,
+    pub display_name: String,
+    pub description: String,
+    pub base: String,
+    pub quote: String,
+    pub category: String,
+    pub exchanges: Vec<ExchangeSymbol>,
+    pub relevance_score: f32,
+}
+
+// Configuration for an exchange's symbol mappings
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExchangeConfig {
+    pub exchange_name: String,
+    pub mappings: HashMap<String, SymbolMetadata>,
+}
+
+// Main search service
+pub struct SymbolSearchService {
+    // Normalized ID -> metadata
+    normalized_symbols: HashMap<String, SymbolMetadata>,
+    // Exchange -> Symbol -> Normalized ID
+    exchange_mappings: HashMap<String, HashMap<String, String>>,
+    // Search indices for fast lookup
+    search_indices: SearchIndices,
+}
+
+struct SearchIndices {
+    // Lowercase symbol parts for case-insensitive search
+    by_base: HashMap<String, Vec<String>>,      // "btc" -> ["BTC/USD", "BTC/EUR"]
+    by_quote: HashMap<String, Vec<String>>,     // "usd" -> ["BTC/USD", "ETH/USD"]
+    by_tag: HashMap<String, Vec<String>>,       // "bitcoin" -> ["BTC/USD"]
+    // Full text tokens from display names and descriptions
+    text_tokens: HashMap<String, Vec<String>>,   // "bitcoin" -> ["BTC/USD"]
+}
+
+impl SymbolSearchService {
+    pub fn new() -> Self {
+        Self {
+            normalized_symbols: HashMap::new(),
+            exchange_mappings: HashMap::new(),
+            search_indices: SearchIndices {
+                by_base: HashMap::new(),
+                by_quote: HashMap::new(),
+                by_tag: HashMap::new(),
+                text_tokens: HashMap::new(),
+            },
+        }
+    }
+
+    // Load configuration from embedded data
+    pub fn load_configs(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        // Load each exchange configuration
+        self.load_coinbase_config()?;
+        self.load_binance_config()?;
+        self.load_bitfinex_config()?;
+        self.load_okx_config()?;
+        self.load_kraken_config()?;
+        
+        // Build search indices
+        self.build_indices();
+        
+        Ok(())
+    }
+
+    fn load_coinbase_config(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let config = include_str!("configs/coinbase.json");
+        let mappings: HashMap<String, SymbolMetadata> = serde_json::from_str(config)?;
+        
+        let mut exchange_map = HashMap::new();
+        for (symbol, metadata) in mappings {
+            exchange_map.insert(symbol.clone(), metadata.normalized_id.clone());
+            self.normalized_symbols.entry(metadata.normalized_id.clone())
+                .or_insert(metadata);
+        }
+        
+        self.exchange_mappings.insert("coinbase".to_string(), exchange_map);
+        Ok(())
+    }
+
+    fn load_binance_config(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let config = include_str!("configs/binance.json");
+        let mappings: HashMap<String, SymbolMetadata> = serde_json::from_str(config)?;
+        
+        let mut exchange_map = HashMap::new();
+        for (symbol, metadata) in mappings {
+            exchange_map.insert(symbol.clone(), metadata.normalized_id.clone());
+            self.normalized_symbols.entry(metadata.normalized_id.clone())
+                .or_insert(metadata);
+        }
+        
+        self.exchange_mappings.insert("binance".to_string(), exchange_map);
+        Ok(())
+    }
+
+    fn load_bitfinex_config(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let config = include_str!("configs/bitfinex.json");
+        let mappings: HashMap<String, SymbolMetadata> = serde_json::from_str(config)?;
+        
+        let mut exchange_map = HashMap::new();
+        for (symbol, metadata) in mappings {
+            exchange_map.insert(symbol.clone(), metadata.normalized_id.clone());
+            self.normalized_symbols.entry(metadata.normalized_id.clone())
+                .or_insert(metadata);
+        }
+        
+        self.exchange_mappings.insert("bitfinex".to_string(), exchange_map);
+        Ok(())
+    }
+
+    fn load_okx_config(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let config = include_str!("configs/okx.json");
+        let mappings: HashMap<String, SymbolMetadata> = serde_json::from_str(config)?;
+        
+        let mut exchange_map = HashMap::new();
+        for (symbol, metadata) in mappings {
+            exchange_map.insert(symbol.clone(), metadata.normalized_id.clone());
+            self.normalized_symbols.entry(metadata.normalized_id.clone())
+                .or_insert(metadata);
+        }
+        
+        self.exchange_mappings.insert("okx".to_string(), exchange_map);
+        Ok(())
+    }
+
+    fn load_kraken_config(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let config = include_str!("configs/kraken.json");
+        let mappings: HashMap<String, SymbolMetadata> = serde_json::from_str(config)?;
+        
+        let mut exchange_map = HashMap::new();
+        for (symbol, metadata) in mappings {
+            exchange_map.insert(symbol.clone(), metadata.normalized_id.clone());
+            self.normalized_symbols.entry(metadata.normalized_id.clone())
+                .or_insert(metadata);
+        }
+        
+        self.exchange_mappings.insert("kraken".to_string(), exchange_map);
+        Ok(())
+    }
+
+    fn build_indices(&mut self) {
+        for (normalized_id, metadata) in &self.normalized_symbols {
+            // Index by base currency
+            let base_lower = metadata.base.to_lowercase();
+            self.search_indices.by_base
+                .entry(base_lower)
+                .or_insert_with(Vec::new)
+                .push(normalized_id.clone());
+            
+            // Index by quote currency
+            let quote_lower = metadata.quote.to_lowercase();
+            self.search_indices.by_quote
+                .entry(quote_lower)
+                .or_insert_with(Vec::new)
+                .push(normalized_id.clone());
+            
+            // Index by tags
+            for tag in &metadata.tags {
+                let tag_lower = tag.to_lowercase();
+                self.search_indices.by_tag
+                    .entry(tag_lower)
+                    .or_insert_with(Vec::new)
+                    .push(normalized_id.clone());
+            }
+            
+            // Index text tokens from display name and description
+            let text = format!("{} {}", metadata.display_name, metadata.description);
+            for word in text.split_whitespace() {
+                let word_lower = word.to_lowercase()
+                    .trim_matches(|c: char| !c.is_alphanumeric())
+                    .to_string();
+                if !word_lower.is_empty() {
+                    self.search_indices.text_tokens
+                        .entry(word_lower)
+                        .or_insert_with(Vec::new)
+                        .push(normalized_id.clone());
+                }
+            }
+        }
+    }
+
+    pub fn search(&self, query: &str) -> Vec<SearchResult> {
+        let query_lower = query.to_lowercase();
+        let mut results_map: HashMap<String, (SearchResult, f32)> = HashMap::new();
+        
+        // Search in different indices and accumulate scores
+        
+        // Exact normalized ID match (highest score)
+        for (id, metadata) in &self.normalized_symbols {
+            if id.to_lowercase().contains(&query_lower) {
+                let score = if id.to_lowercase() == query_lower { 150.0 } else { 120.0 };
+                self.add_or_update_result(&mut results_map, id, metadata, score);
+            }
+        }
+        
+        // Base currency match
+        if let Some(ids) = self.search_indices.by_base.get(&query_lower) {
+            for id in ids {
+                if let Some(metadata) = self.normalized_symbols.get(id) {
+                    self.add_or_update_result(&mut results_map, id, metadata, 100.0);
+                }
+            }
+        }
+        
+        // Quote currency match
+        if let Some(ids) = self.search_indices.by_quote.get(&query_lower) {
+            for id in ids {
+                if let Some(metadata) = self.normalized_symbols.get(id) {
+                    self.add_or_update_result(&mut results_map, id, metadata, 90.0);
+                }
+            }
+        }
+        
+        // Tag match
+        if let Some(ids) = self.search_indices.by_tag.get(&query_lower) {
+            for id in ids {
+                if let Some(metadata) = self.normalized_symbols.get(id) {
+                    self.add_or_update_result(&mut results_map, id, metadata, 80.0);
+                }
+            }
+        }
+        
+        // Partial matches in tags
+        for (tag, ids) in &self.search_indices.by_tag {
+            if tag.contains(&query_lower) {
+                for id in ids {
+                    if let Some(metadata) = self.normalized_symbols.get(id) {
+                        self.add_or_update_result(&mut results_map, id, metadata, 60.0);
+                    }
+                }
+            }
+        }
+        
+        // Text token matches
+        for (token, ids) in &self.search_indices.text_tokens {
+            if token.contains(&query_lower) {
+                for id in ids {
+                    if let Some(metadata) = self.normalized_symbols.get(id) {
+                        let score = if token == &query_lower { 50.0 } else { 40.0 };
+                        self.add_or_update_result(&mut results_map, id, metadata, score);
+                    }
+                }
+            }
+        }
+        
+        // Display name partial match
+        for (id, metadata) in &self.normalized_symbols {
+            if metadata.display_name.to_lowercase().contains(&query_lower) {
+                self.add_or_update_result(&mut results_map, id, metadata, 70.0);
+            }
+        }
+        
+        // Convert to vector and sort by score
+        let mut results: Vec<SearchResult> = results_map
+            .into_iter()
+            .map(|(_, (mut result, score))| {
+                result.relevance_score = score;
+                result
+            })
+            .collect();
+        
+        results.sort_by(|a, b| b.relevance_score.partial_cmp(&a.relevance_score).unwrap());
+        
+        // Limit to top 20 results
+        results.truncate(20);
+        
+        results
+    }
+
+    fn add_or_update_result(
+        &self,
+        results_map: &mut HashMap<String, (SearchResult, f32)>,
+        normalized_id: &str,
+        metadata: &SymbolMetadata,
+        score: f32
+    ) {
+        let exchanges = self.get_exchanges_for_symbol(normalized_id);
+        
+        if let Some((_, existing_score)) = results_map.get_mut(normalized_id) {
+            // Update score if higher
+            if score > *existing_score {
+                *existing_score = score;
+            }
+        } else {
+            let result = SearchResult {
+                normalized_id: normalized_id.to_string(),
+                display_name: metadata.display_name.clone(),
+                description: metadata.description.clone(),
+                base: metadata.base.clone(),
+                quote: metadata.quote.clone(),
+                category: metadata.category.clone(),
+                exchanges,
+                relevance_score: score,
+            };
+            results_map.insert(normalized_id.to_string(), (result, score));
+        }
+    }
+
+    fn get_exchanges_for_symbol(&self, normalized_id: &str) -> Vec<ExchangeSymbol> {
+        let mut exchanges = Vec::new();
+        
+        for (exchange_name, mappings) in &self.exchange_mappings {
+            for (symbol, norm_id) in mappings {
+                if norm_id == normalized_id {
+                    exchanges.push(ExchangeSymbol {
+                        exchange: exchange_name.clone(),
+                        symbol: symbol.clone(),
+                    });
+                }
+            }
+        }
+        
+        exchanges
+    }
+}
+
+// Global instance
+pub static SEARCH_SERVICE: once_cell::sync::Lazy<Arc<RwLock<SymbolSearchService>>> =
+    once_cell::sync::Lazy::new(|| {
+        let mut service = SymbolSearchService::new();
+        // Load configs will be called from main.rs
+        Arc::new(RwLock::new(service))
+    });
+
+// Initialize the search service
+pub async fn initialize_search_service() -> Result<(), Box<dyn std::error::Error>> {
+    let mut service = SEARCH_SERVICE.write().await;
+    service.load_configs()?;
+    println!("Symbol search service initialized with {} normalized symbols", 
+             service.normalized_symbols.len());
+    Ok(())
+}

--- a/server/src/symbols/search_runtime.rs
+++ b/server/src/symbols/search_runtime.rs
@@ -1,0 +1,461 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use std::path::Path;
+use tokio::fs;
+
+// Symbol metadata for normalized representation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SymbolMetadata {
+    pub normalized_id: String,     // e.g., "BTC/USD"
+    pub base: String,              // e.g., "BTC"
+    pub quote: String,             // e.g., "USD"
+    pub display_name: String,      // e.g., "Bitcoin / US Dollar"
+    pub description: String,       // e.g., "Bitcoin to US Dollar spot trading pair"
+    pub tags: Vec<String>,         // e.g., ["crypto", "major", "btc", "bitcoin", "usd"]
+    pub category: String,          // e.g., "crypto", "forex", "commodity"
+}
+
+// Exchange-specific symbol mapping
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExchangeSymbol {
+    pub exchange: String,          // e.g., "coinbase"
+    pub symbol: String,            // e.g., "BTC-USD"
+}
+
+// Search result item
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchResult {
+    pub normalized_id: String,
+    pub display_name: String,
+    pub description: String,
+    pub base: String,
+    pub quote: String,
+    pub category: String,
+    pub exchanges: Vec<ExchangeSymbol>,
+    pub relevance_score: f32,
+}
+
+// Main search service
+pub struct SymbolSearchService {
+    // Normalized ID -> metadata
+    normalized_symbols: HashMap<String, SymbolMetadata>,
+    // Exchange -> Symbol -> Normalized ID
+    exchange_mappings: HashMap<String, HashMap<String, String>>,
+    // Search indices for fast lookup
+    search_indices: SearchIndices,
+}
+
+struct SearchIndices {
+    // Lowercase symbol parts for case-insensitive search
+    by_base: HashMap<String, Vec<String>>,      // "btc" -> ["BTC/USD", "BTC/EUR"]
+    by_quote: HashMap<String, Vec<String>>,     // "usd" -> ["BTC/USD", "ETH/USD"]
+    by_tag: HashMap<String, Vec<String>>,       // "bitcoin" -> ["BTC/USD"]
+    // Full text tokens from display names and descriptions
+    text_tokens: HashMap<String, Vec<String>>,   // "bitcoin" -> ["BTC/USD"]
+}
+
+impl SymbolSearchService {
+    pub fn new() -> Self {
+        Self {
+            normalized_symbols: HashMap::new(),
+            exchange_mappings: HashMap::new(),
+            search_indices: SearchIndices {
+                by_base: HashMap::new(),
+                by_quote: HashMap::new(),
+                by_tag: HashMap::new(),
+                text_tokens: HashMap::new(),
+            },
+        }
+    }
+
+    // Load configuration from files at runtime
+    pub async fn load_configs(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        // Try multiple possible config locations
+        let config_paths = vec![
+            // Production paths
+            "/app/server/src/symbols/configs",
+            "/opt/gpu-charts/configs",
+            "./configs",
+            // Development paths
+            "server/src/symbols/configs",
+            "src/symbols/configs",
+        ];
+
+        let mut config_dir = None;
+        for path in &config_paths {
+            if Path::new(path).exists() {
+                config_dir = Some(path.to_string());
+                println!("Found symbol config directory at: {}", path);
+                break;
+            }
+        }
+
+        // If no config directory found, generate minimal runtime config
+        if config_dir.is_none() {
+            println!("Warning: No symbol config directory found, generating minimal runtime config");
+            self.generate_minimal_config().await?;
+            return Ok(());
+        }
+
+        let dir = config_dir.unwrap();
+        
+        // Load each exchange configuration
+        for exchange in &["coinbase", "binance", "bitfinex", "okx", "kraken"] {
+            let config_path = format!("{}/{}.json", dir, exchange);
+            if Path::new(&config_path).exists() {
+                self.load_exchange_config(exchange, &config_path).await?;
+            } else {
+                println!("Warning: Config file not found: {}", config_path);
+            }
+        }
+        
+        // Build search indices
+        self.build_indices();
+        
+        println!("Loaded {} normalized symbols from configs", self.normalized_symbols.len());
+        Ok(())
+    }
+
+    async fn load_exchange_config(&mut self, exchange: &str, path: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let config_content = fs::read_to_string(path).await?;
+        let mappings: HashMap<String, SymbolMetadata> = serde_json::from_str(&config_content)?;
+        
+        let mut exchange_map = HashMap::new();
+        for (symbol, metadata) in mappings {
+            exchange_map.insert(symbol.clone(), metadata.normalized_id.clone());
+            self.normalized_symbols.entry(metadata.normalized_id.clone())
+                .or_insert(metadata);
+        }
+        
+        self.exchange_mappings.insert(exchange.to_string(), exchange_map);
+        Ok(())
+    }
+
+    // Generate minimal config based on available data directories
+    async fn generate_minimal_config(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        let data_path = "/mnt/md/data";
+        
+        if !Path::new(data_path).exists() {
+            // If no data directory, create hardcoded minimal config
+            self.create_hardcoded_config();
+            return Ok(());
+        }
+
+        // Scan data directories to build config
+        let mut entries = fs::read_dir(data_path).await?;
+        
+        while let Some(entry) = entries.next_entry().await? {
+            if let Some(exchange_name) = entry.file_name().to_str() {
+                if !exchange_name.starts_with('.') && !exchange_name.contains('.') {
+                    let exchange_path = format!("{}/{}", data_path, exchange_name);
+                    let mut symbol_entries = fs::read_dir(&exchange_path).await?;
+                    
+                    let mut exchange_map = HashMap::new();
+                    
+                    while let Some(symbol_entry) = symbol_entries.next_entry().await? {
+                        if let Some(symbol_name) = symbol_entry.file_name().to_str() {
+                            if !symbol_name.starts_with('.') && !symbol_name.contains('.') {
+                                // Create basic metadata for this symbol
+                                let (base, quote) = self.parse_symbol(&symbol_name, exchange_name);
+                                let normalized_id = format!("{}/{}", base, quote);
+                                
+                                let metadata = SymbolMetadata {
+                                    normalized_id: normalized_id.clone(),
+                                    base: base.clone(),
+                                    quote: quote.clone(),
+                                    display_name: format!("{} / {}", base, quote),
+                                    description: format!("{} to {} trading pair", base, quote),
+                                    tags: vec![base.to_lowercase(), quote.to_lowercase()],
+                                    category: "crypto".to_string(),
+                                };
+                                
+                                exchange_map.insert(symbol_name.to_string(), normalized_id.clone());
+                                self.normalized_symbols.entry(normalized_id)
+                                    .or_insert(metadata);
+                            }
+                        }
+                    }
+                    
+                    if !exchange_map.is_empty() {
+                        self.exchange_mappings.insert(exchange_name.to_string(), exchange_map);
+                    }
+                }
+            }
+        }
+        
+        self.build_indices();
+        Ok(())
+    }
+
+    fn create_hardcoded_config(&mut self) {
+        // Create a minimal hardcoded config for common pairs
+        let pairs = vec![
+            ("BTC-USD", "BTC", "USD", "Bitcoin", "coinbase"),
+            ("ETH-USD", "ETH", "USD", "Ethereum", "coinbase"),
+            ("BTCUSDT", "BTC", "USD", "Bitcoin", "binance"),
+            ("ETHUSDT", "ETH", "USD", "Ethereum", "binance"),
+            ("tBTCUSD", "BTC", "USD", "Bitcoin", "bitfinex"),
+            ("tETHUSD", "ETH", "USD", "Ethereum", "bitfinex"),
+            ("XBT/USD", "BTC", "USD", "Bitcoin", "kraken"),
+            ("ETH/USD", "ETH", "USD", "Ethereum", "kraken"),
+            ("BTC-USDT", "BTC", "USD", "Bitcoin", "okx"),
+            ("ETH-USDT", "ETH", "USD", "Ethereum", "okx"),
+        ];
+
+        for (symbol, base, quote, base_name, exchange) in pairs {
+            let normalized_id = format!("{}/{}", base, quote);
+            let metadata = SymbolMetadata {
+                normalized_id: normalized_id.clone(),
+                base: base.to_string(),
+                quote: quote.to_string(),
+                display_name: format!("{} / US Dollar", base_name),
+                description: format!("{} to US Dollar trading pair", base_name),
+                tags: vec![base.to_lowercase(), base_name.to_lowercase(), quote.to_lowercase()],
+                category: "crypto".to_string(),
+            };
+
+            self.normalized_symbols.entry(normalized_id.clone())
+                .or_insert(metadata);
+
+            let exchange_map = self.exchange_mappings.entry(exchange.to_string())
+                .or_insert_with(HashMap::new);
+            exchange_map.insert(symbol.to_string(), normalized_id);
+        }
+
+        self.build_indices();
+    }
+
+    fn parse_symbol(&self, symbol: &str, exchange: &str) -> (String, String) {
+        // Simple parsing logic for common formats
+        match exchange {
+            "coinbase" | "okx" => {
+                if let Some(idx) = symbol.find('-') {
+                    let base = &symbol[..idx];
+                    let quote = &symbol[idx + 1..];
+                    let quote = if quote == "USDT" || quote == "USDC" { "USD" } else { quote };
+                    return (base.to_string(), quote.to_string());
+                }
+            }
+            "binance" => {
+                if symbol.ends_with("USDT") {
+                    let base = &symbol[..symbol.len() - 4];
+                    return (base.to_string(), "USD".to_string());
+                } else if symbol.ends_with("USDC") {
+                    let base = &symbol[..symbol.len() - 4];
+                    return (base.to_string(), "USD".to_string());
+                }
+            }
+            "bitfinex" => {
+                let sym = if symbol.starts_with('t') { &symbol[1..] } else { symbol };
+                if sym.ends_with("USD") {
+                    let base = &sym[..sym.len() - 3];
+                    return (base.to_string(), "USD".to_string());
+                }
+            }
+            "kraken" => {
+                if let Some(idx) = symbol.find('_') {
+                    let base = &symbol[..idx];
+                    let quote = &symbol[idx + 1..];
+                    let base = if base == "XBT" { "BTC" } else { base };
+                    let quote = if quote == "USDT" || quote == "USDC" { "USD" } else { quote };
+                    return (base.to_string(), quote.to_string());
+                }
+            }
+            _ => {}
+        }
+        
+        (symbol.to_string(), "UNKNOWN".to_string())
+    }
+
+    fn build_indices(&mut self) {
+        for (normalized_id, metadata) in &self.normalized_symbols {
+            // Index by base currency
+            let base_lower = metadata.base.to_lowercase();
+            self.search_indices.by_base
+                .entry(base_lower)
+                .or_insert_with(Vec::new)
+                .push(normalized_id.clone());
+            
+            // Index by quote currency
+            let quote_lower = metadata.quote.to_lowercase();
+            self.search_indices.by_quote
+                .entry(quote_lower)
+                .or_insert_with(Vec::new)
+                .push(normalized_id.clone());
+            
+            // Index by tags
+            for tag in &metadata.tags {
+                let tag_lower = tag.to_lowercase();
+                self.search_indices.by_tag
+                    .entry(tag_lower)
+                    .or_insert_with(Vec::new)
+                    .push(normalized_id.clone());
+            }
+            
+            // Index text tokens from display name and description
+            let text = format!("{} {}", metadata.display_name, metadata.description);
+            for word in text.split_whitespace() {
+                let word_lower = word.to_lowercase()
+                    .trim_matches(|c: char| !c.is_alphanumeric())
+                    .to_string();
+                if !word_lower.is_empty() {
+                    self.search_indices.text_tokens
+                        .entry(word_lower)
+                        .or_insert_with(Vec::new)
+                        .push(normalized_id.clone());
+                }
+            }
+        }
+    }
+
+    pub fn search(&self, query: &str) -> Vec<SearchResult> {
+        let query_lower = query.to_lowercase();
+        let mut results_map: HashMap<String, (SearchResult, f32)> = HashMap::new();
+        
+        // Search in different indices and accumulate scores
+        
+        // Exact normalized ID match (highest score)
+        for (id, metadata) in &self.normalized_symbols {
+            if id.to_lowercase().contains(&query_lower) {
+                let score = if id.to_lowercase() == query_lower { 150.0 } else { 120.0 };
+                self.add_or_update_result(&mut results_map, id, metadata, score);
+            }
+        }
+        
+        // Base currency match
+        if let Some(ids) = self.search_indices.by_base.get(&query_lower) {
+            for id in ids {
+                if let Some(metadata) = self.normalized_symbols.get(id) {
+                    self.add_or_update_result(&mut results_map, id, metadata, 100.0);
+                }
+            }
+        }
+        
+        // Quote currency match
+        if let Some(ids) = self.search_indices.by_quote.get(&query_lower) {
+            for id in ids {
+                if let Some(metadata) = self.normalized_symbols.get(id) {
+                    self.add_or_update_result(&mut results_map, id, metadata, 90.0);
+                }
+            }
+        }
+        
+        // Tag match
+        if let Some(ids) = self.search_indices.by_tag.get(&query_lower) {
+            for id in ids {
+                if let Some(metadata) = self.normalized_symbols.get(id) {
+                    self.add_or_update_result(&mut results_map, id, metadata, 80.0);
+                }
+            }
+        }
+        
+        // Partial matches in tags
+        for (tag, ids) in &self.search_indices.by_tag {
+            if tag.contains(&query_lower) {
+                for id in ids {
+                    if let Some(metadata) = self.normalized_symbols.get(id) {
+                        self.add_or_update_result(&mut results_map, id, metadata, 60.0);
+                    }
+                }
+            }
+        }
+        
+        // Text token matches
+        for (token, ids) in &self.search_indices.text_tokens {
+            if token.contains(&query_lower) {
+                for id in ids {
+                    if let Some(metadata) = self.normalized_symbols.get(id) {
+                        let score = if token == &query_lower { 50.0 } else { 40.0 };
+                        self.add_or_update_result(&mut results_map, id, metadata, score);
+                    }
+                }
+            }
+        }
+        
+        // Display name partial match
+        for (id, metadata) in &self.normalized_symbols {
+            if metadata.display_name.to_lowercase().contains(&query_lower) {
+                self.add_or_update_result(&mut results_map, id, metadata, 70.0);
+            }
+        }
+        
+        // Convert to vector and sort by score
+        let mut results: Vec<SearchResult> = results_map
+            .into_iter()
+            .map(|(_, (mut result, score))| {
+                result.relevance_score = score;
+                result
+            })
+            .collect();
+        
+        results.sort_by(|a, b| b.relevance_score.partial_cmp(&a.relevance_score).unwrap());
+        
+        // Limit to top 20 results
+        results.truncate(20);
+        
+        results
+    }
+
+    fn add_or_update_result(
+        &self,
+        results_map: &mut HashMap<String, (SearchResult, f32)>,
+        normalized_id: &str,
+        metadata: &SymbolMetadata,
+        score: f32
+    ) {
+        let exchanges = self.get_exchanges_for_symbol(normalized_id);
+        
+        if let Some((_, existing_score)) = results_map.get_mut(normalized_id) {
+            // Update score if higher
+            if score > *existing_score {
+                *existing_score = score;
+            }
+        } else {
+            let result = SearchResult {
+                normalized_id: normalized_id.to_string(),
+                display_name: metadata.display_name.clone(),
+                description: metadata.description.clone(),
+                base: metadata.base.clone(),
+                quote: metadata.quote.clone(),
+                category: metadata.category.clone(),
+                exchanges,
+                relevance_score: score,
+            };
+            results_map.insert(normalized_id.to_string(), (result, score));
+        }
+    }
+
+    fn get_exchanges_for_symbol(&self, normalized_id: &str) -> Vec<ExchangeSymbol> {
+        let mut exchanges = Vec::new();
+        
+        for (exchange_name, mappings) in &self.exchange_mappings {
+            for (symbol, norm_id) in mappings {
+                if norm_id == normalized_id {
+                    exchanges.push(ExchangeSymbol {
+                        exchange: exchange_name.clone(),
+                        symbol: symbol.clone(),
+                    });
+                }
+            }
+        }
+        
+        exchanges
+    }
+}
+
+// Global instance
+pub static SEARCH_SERVICE: once_cell::sync::Lazy<Arc<RwLock<SymbolSearchService>>> =
+    once_cell::sync::Lazy::new(|| {
+        let service = SymbolSearchService::new();
+        Arc::new(RwLock::new(service))
+    });
+
+// Initialize the search service
+pub async fn initialize_search_service() -> Result<(), Box<dyn std::error::Error>> {
+    let mut service = SEARCH_SERVICE.write().await;
+    service.load_configs().await?;
+    println!("Symbol search service initialized");
+    Ok(())
+}

--- a/server/test_symbol_search.sh
+++ b/server/test_symbol_search.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Test script for the symbol search endpoint
+# This script demonstrates various search queries and expected behavior
+
+echo "Symbol Search Endpoint Test Cases"
+echo "================================="
+echo ""
+
+# Test cases for symbol search
+echo "Test 1: Search for 'btc' (should match Bitcoin pairs)"
+echo "Expected: BTC/USD from multiple exchanges"
+echo "curl -k 'https://localhost:8443/api/symbol-search?q=btc'"
+echo ""
+
+echo "Test 2: Search for 'bitcoin' (should match by display name)"
+echo "Expected: BTC/USD with Bitcoin in display name"
+echo "curl -k 'https://localhost:8443/api/symbol-search?q=bitcoin'"
+echo ""
+
+echo "Test 3: Search for 'eth' (should match Ethereum)"
+echo "Expected: ETH/USD from multiple exchanges"
+echo "curl -k 'https://localhost:8443/api/symbol-search?q=eth'"
+echo ""
+
+echo "Test 4: Search for 'usd' (should match USD pairs)"
+echo "Expected: Multiple pairs with USD as quote currency"
+echo "curl -k 'https://localhost:8443/api/symbol-search?q=usd'"
+echo ""
+
+echo "Test 5: Search for 'doge' (should match Dogecoin)"
+echo "Expected: DOGE/USD from multiple exchanges"
+echo "curl -k 'https://localhost:8443/api/symbol-search?q=doge'"
+echo ""
+
+echo "Test 6: Search for 'layer2' (should match by tag)"
+echo "Expected: ARB/USD and OP/USD (Layer 2 solutions)"
+echo "curl -k 'https://localhost:8443/api/symbol-search?q=layer2'"
+echo ""
+
+echo "Test 7: Search for 'defi' (should match DeFi tokens)"
+echo "Expected: UNI/USD (Uniswap)"
+echo "curl -k 'https://localhost:8443/api/symbol-search?q=defi'"
+echo ""
+
+echo "Test 8: Search for partial match 'sol'"
+echo "Expected: SOL/USD (Solana)"
+echo "curl -k 'https://localhost:8443/api/symbol-search?q=sol'"
+echo ""
+
+echo "Test 9: Empty search query"
+echo "Expected: Empty results array"
+echo "curl -k 'https://localhost:8443/api/symbol-search?q='"
+echo ""
+
+echo "Test 10: Case insensitive search 'BTC'"
+echo "Expected: Same results as lowercase 'btc'"
+echo "curl -k 'https://localhost:8443/api/symbol-search?q=BTC'"
+echo ""
+
+echo "================================="
+echo "To run these tests, start the server with:"
+echo "cd server && cargo run --target x86_64-unknown-linux-gnu"
+echo "Then execute the curl commands above"

--- a/web/.env.development
+++ b/web/.env.development
@@ -1,0 +1,2 @@
+# Development environment variables
+VITE_API_BASE_URL=https://localhost:8443

--- a/web/src/components/PresetSection.tsx
+++ b/web/src/components/PresetSection.tsx
@@ -108,26 +108,42 @@ export default function PresetSection({
         ))}
       </select>
 
-      {/* Chart type checkboxes when preset is active */}
+      {/* Chart type buttons when preset is active */}
       {preset && metrics.length > 0 && (
-        <div className="mt-3 space-y-2">
-          <div className="text-xs text-gray-400 mb-1">Chart Components:</div>
-          {metrics.map((metric) => (
-            <label
-              key={metric.label}
-              className="flex items-center space-x-2 cursor-pointer hover:bg-gray-700 p-1 rounded transition-colors"
-            >
-              <input
-                type="checkbox"
-                checked={metric.visible}
-                onChange={() => handleMetricToggle(metric.label)}
-                className="w-4 h-4 text-blue-600 bg-gray-700 border-gray-600 rounded focus:ring-blue-500 focus:ring-2"
-              />
-              <span className="text-sm text-gray-300 select-none">
-                {metric.label}
-              </span>
-            </label>
-          ))}
+        <div className="mt-4 space-y-2">
+          <label className="text-gray-300 text-sm font-medium">Metrics</label>
+          <div className="grid grid-cols-2 gap-2">
+            {metrics.map((metric) => {
+              const isActive = metric.visible;
+              return (
+                <button
+                  key={metric.label}
+                  onClick={() => handleMetricToggle(metric.label)}
+                  className={`
+                    relative px-3 py-2.5 text-sm font-medium rounded-lg
+                    transition-all duration-200 transform
+                    ${isActive 
+                      ? 'bg-gray-700 text-white shadow-lg scale-[1.02]' 
+                      : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-gray-200'
+                    }
+                    border ${isActive ? 'border-gray-500' : 'border-gray-700'}
+                    hover:scale-[1.02] active:scale-[0.98]
+                  `}
+                >
+                  <div className="flex items-center justify-center gap-2">
+                    {/* Indicator dot */}
+                    <div 
+                      className={`
+                        w-2 h-2 rounded-full transition-all duration-200
+                        ${isActive ? 'bg-green-400' : 'bg-gray-600'}
+                      `}
+                    />
+                    <span>{metric.label}</span>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
         </div>
       )}
     </div>

--- a/web/src/components/SymbolSearch.tsx
+++ b/web/src/components/SymbolSearch.tsx
@@ -221,9 +221,9 @@ export default function SymbolSearch({
           {!isLoading && !error && results.length === 0 && query && (
             <div className="p-4 text-center text-text-tertiary">
               <div>No results found for "{query}"</div>
-              {query.includes(' ') || query.includes('/') ? (
+              {query.includes(' ') && !query.includes('/') ? (
                 <div className="text-xs mt-1 text-text-quaternary">
-                  Searching for symbols containing all terms
+                  Tip: Searching for "{query.split(/\s+/).join('/')}" pairs
                 </div>
               ) : null}
             </div>
@@ -337,8 +337,8 @@ export default function SymbolSearch({
               <div className="flex items-center justify-between text-xs text-text-tertiary">
                 <span>
                   {results.length} result{results.length !== 1 ? 's' : ''} found
-                  {(query.includes(' ') || query.includes('/')) && (
-                    <span className="ml-1 text-accent-primary">(AND search)</span>
+                  {(query.includes(' ') || query.includes('/')) && query.split(/[\s\/]+/).length === 2 && (
+                    <span className="ml-1 text-accent-primary">(pair search)</span>
                   )}
                 </span>
                 <div className="flex items-center gap-3">

--- a/web/src/components/SymbolSearch.tsx
+++ b/web/src/components/SymbolSearch.tsx
@@ -1,0 +1,331 @@
+import { useState, useEffect, useRef, useCallback, KeyboardEvent } from 'react';
+import { Search, ChevronDown, TrendingUp, Layers, DollarSign, Hash, X } from 'lucide-react';
+import { useDebounce } from '../hooks/useDebounce';
+import { 
+  searchSymbols, 
+  SearchResult, 
+  formatExchangeName, 
+  getExchangeColor,
+  getRelevanceIndicator 
+} from '../services/symbolApi';
+import { useAppStore } from '../store/useAppStore';
+import clsx from 'clsx';
+
+interface SymbolSearchProps {
+  className?: string;
+  placeholder?: string;
+  onSymbolSelect?: (symbol: string) => void;
+}
+
+export default function SymbolSearch({ 
+  className, 
+  placeholder = "Search symbols...",
+  onSymbolSelect 
+}: SymbolSearchProps) {
+  const { currentSymbol, setCurrentSymbol } = useAppStore();
+  const [query, setQuery] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const resultsRef = useRef<HTMLDivElement>(null);
+  
+  const debouncedQuery = useDebounce(query, 300);
+
+  // Perform search when debounced query changes
+  useEffect(() => {
+    if (debouncedQuery.trim()) {
+      performSearch(debouncedQuery);
+    } else {
+      setResults([]);
+      setError(null);
+    }
+  }, [debouncedQuery]);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const performSearch = async (searchQuery: string) => {
+    setIsLoading(true);
+    setError(null);
+    
+    try {
+      const searchResults = await searchSymbols(searchQuery);
+      setResults(searchResults);
+      setSelectedIndex(-1);
+    } catch (err) {
+      setError('Failed to search symbols');
+      console.error('Search error:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSelectSymbol = useCallback((result: SearchResult) => {
+    // Find the first exchange's symbol to use
+    const firstExchange = result.exchanges[0];
+    if (firstExchange) {
+      const symbolToUse = firstExchange.symbol;
+      setCurrentSymbol(symbolToUse);
+      onSymbolSelect?.(symbolToUse);
+      setQuery('');
+      setIsOpen(false);
+      setResults([]);
+    }
+  }, [setCurrentSymbol, onSymbolSelect]);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (!isOpen && e.key === 'ArrowDown') {
+      setIsOpen(true);
+      return;
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setSelectedIndex(prev => 
+          prev < results.length - 1 ? prev + 1 : prev
+        );
+        break;
+        
+      case 'ArrowUp':
+        e.preventDefault();
+        setSelectedIndex(prev => prev > -1 ? prev - 1 : -1);
+        break;
+        
+      case 'Enter':
+        e.preventDefault();
+        if (selectedIndex >= 0 && selectedIndex < results.length) {
+          handleSelectSymbol(results[selectedIndex]);
+        }
+        break;
+        
+      case 'Escape':
+        e.preventDefault();
+        setIsOpen(false);
+        setQuery('');
+        break;
+    }
+  };
+
+  // Scroll selected item into view
+  useEffect(() => {
+    if (selectedIndex >= 0 && resultsRef.current) {
+      const items = resultsRef.current.querySelectorAll('[data-result-item]');
+      if (items[selectedIndex]) {
+        items[selectedIndex].scrollIntoView({
+          block: 'nearest',
+          behavior: 'smooth'
+        });
+      }
+    }
+  }, [selectedIndex]);
+
+  const getCategoryIcon = (category: string) => {
+    switch (category.toLowerCase()) {
+      case 'crypto':
+        return <Hash className="w-4 h-4" />;
+      case 'forex':
+        return <DollarSign className="w-4 h-4" />;
+      case 'commodity':
+        return <TrendingUp className="w-4 h-4" />;
+      default:
+        return <Layers className="w-4 h-4" />;
+    }
+  };
+
+  return (
+    <div ref={containerRef} className={clsx("relative", className)}>
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-text-tertiary" size={16} />
+        
+        <input
+          ref={inputRef}
+          type="text"
+          value={query || currentSymbol || ''}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setIsOpen(true);
+          }}
+          onFocus={() => {
+            if (query) setIsOpen(true);
+          }}
+          onKeyDown={handleKeyDown}
+          className={clsx(
+            "w-full pl-10 pr-10 py-2.5 bg-bg-secondary border border-border",
+            "text-text-primary placeholder-text-tertiary",
+            "focus:outline-none focus:border-accent-primary focus:ring-1 focus:ring-accent-primary",
+            "transition-all duration-200"
+          )}
+          placeholder={placeholder}
+        />
+        
+        {query ? (
+          <button
+            onClick={() => {
+              setQuery('');
+              setResults([]);
+              inputRef.current?.focus();
+            }}
+            className="absolute right-3 top-1/2 transform -translate-y-1/2 text-text-tertiary hover:text-text-primary transition-colors"
+          >
+            <X size={16} />
+          </button>
+        ) : (
+          <ChevronDown className="absolute right-3 top-1/2 transform -translate-y-1/2 text-text-tertiary" size={16} />
+        )}
+      </div>
+
+      {/* Search Results Dropdown */}
+      {isOpen && (query || results.length > 0) && (
+        <div 
+          ref={resultsRef}
+          className={clsx(
+            "absolute z-50 w-full mt-1 bg-bg-primary border border-border shadow-2xl",
+            "max-h-96 overflow-y-auto",
+            "animate-in fade-in slide-in-from-top-1 duration-200"
+          )}
+        >
+          {isLoading && (
+            <div className="p-4 text-center text-text-tertiary">
+              <div className="inline-block animate-spin rounded-full h-5 w-5 border-b-2 border-accent-primary"></div>
+              <span className="ml-2">Searching...</span>
+            </div>
+          )}
+
+          {error && (
+            <div className="p-4 text-center text-accent-red">
+              {error}
+            </div>
+          )}
+
+          {!isLoading && !error && results.length === 0 && query && (
+            <div className="p-4 text-center text-text-tertiary">
+              No results found for "{query}"
+            </div>
+          )}
+
+          {!isLoading && !error && results.length > 0 && (
+            <div className="py-2">
+              {results.map((result, index) => {
+                const relevance = getRelevanceIndicator(result.relevance_score);
+                const isSelected = index === selectedIndex;
+                
+                return (
+                  <div
+                    key={`${result.normalized_id}-${index}`}
+                    data-result-item
+                    onClick={() => handleSelectSymbol(result)}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                    className={clsx(
+                      "px-4 py-3 cursor-pointer transition-all duration-150",
+                      "border-b border-border/50 last:border-b-0",
+                      isSelected ? "bg-bg-secondary" : "hover:bg-bg-secondary/50"
+                    )}
+                  >
+                    {/* Main Row */}
+                    <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center gap-3">
+                        {/* Category Icon */}
+                        <div className="text-text-tertiary">
+                          {getCategoryIcon(result.category)}
+                        </div>
+                        
+                        {/* Symbol Info */}
+                        <div>
+                          <div className="flex items-center gap-2">
+                            <span className="text-text-primary font-semibold">
+                              {result.normalized_id}
+                            </span>
+                            <span className="text-text-secondary text-sm">
+                              {result.display_name}
+                            </span>
+                          </div>
+                          <div className="text-text-tertiary text-xs mt-0.5">
+                            {result.description}
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Relevance Score */}
+                      <div className="flex flex-col items-end gap-1">
+                        <span 
+                          className="text-xs font-medium px-2 py-0.5 rounded"
+                          style={{ 
+                            backgroundColor: `${relevance.color}20`,
+                            color: relevance.color 
+                          }}
+                        >
+                          {relevance.label}
+                        </span>
+                        <div className="w-20 h-1 bg-bg-tertiary rounded-full overflow-hidden">
+                          <div 
+                            className="h-full transition-all duration-300"
+                            style={{ 
+                              width: `${relevance.percentage}%`,
+                              backgroundColor: relevance.color 
+                            }}
+                          />
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Exchange Pills */}
+                    <div className="flex flex-wrap gap-1.5 mt-2">
+                      {result.exchanges.map((exchange, idx) => (
+                        <div
+                          key={`${exchange.exchange}-${idx}`}
+                          className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs"
+                          style={{
+                            backgroundColor: `${getExchangeColor(exchange.exchange)}15`,
+                            borderLeft: `2px solid ${getExchangeColor(exchange.exchange)}`
+                          }}
+                        >
+                          <span className="font-medium text-text-secondary">
+                            {formatExchangeName(exchange.exchange)}
+                          </span>
+                          <span className="text-text-tertiary">
+                            {exchange.symbol}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Quick Actions Footer */}
+          {!isLoading && results.length > 0 && (
+            <div className="p-2 border-t border-border bg-bg-secondary/30">
+              <div className="flex items-center justify-between text-xs text-text-tertiary">
+                <span>
+                  {results.length} result{results.length !== 1 ? 's' : ''} found
+                </span>
+                <div className="flex items-center gap-3">
+                  <span>↑↓ Navigate</span>
+                  <span>↵ Select</span>
+                  <span>ESC Close</span>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/chart/ChartControls.tsx
+++ b/web/src/components/chart/ChartControls.tsx
@@ -229,9 +229,14 @@ export default function ChartControls({
                     toggleExchange(exchange.id);
                   } else {
                     // In single mode, switch to this exchange
-                    const newSymbol = `${exchange.id}:${storeBaseSymbol || baseSymbol || 'BTC-USD'}`;
+                    // Use the baseSymbol from parsing current symbol, or storeBaseSymbol, or default
+                    const symbolToUse = baseSymbol || storeBaseSymbol || 'BTC-USD';
+                    const newSymbol = `${exchange.id}:${symbolToUse}`;
                     setCurrentSymbol(newSymbol);
-                    setBaseSymbol(storeBaseSymbol || baseSymbol || 'BTC-USD');
+                    setBaseSymbol(symbolToUse);
+                    
+                    // Update selected exchanges to just this one
+                    toggleExchange(exchange.id);
                     
                     // Update URL
                     const urlParams = new URLSearchParams(window.location.search);

--- a/web/src/components/chart/ChartControls.tsx
+++ b/web/src/components/chart/ChartControls.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAppStore, useChartSubscription } from '../../store/useAppStore';
 import PresetSection from '../PresetSection';
 import { Chart } from '@pkg/wasm_bridge.js';
+import { formatExchangeName, getExchangeColor, parseSymbol } from '../../services/symbolApi';
 
 /**
  * Chart Controls Component
@@ -53,6 +54,21 @@ export default function ChartControls({
 
   // Available options (memoized to prevent dependency issues)
   const symbols = useMemo(() => ['BTC-USD', 'ETH-USD', 'ADA-USD', 'DOT-USD', 'LINK-USD', 'AVAX-USD'], []);
+  
+  // Parse exchange and base symbol from current symbol
+  const { exchange: currentExchange, baseSymbol } = useMemo(() => {
+    if (!symbol) return { exchange: 'coinbase', baseSymbol: 'BTC-USD' };
+    return parseSymbol(symbol);
+  }, [symbol]);
+  
+  // Available exchanges
+  const exchanges = useMemo(() => [
+    { id: 'coinbase', name: 'Coinbase' },
+    { id: 'binance', name: 'Binance' },
+    { id: 'kraken', name: 'Kraken' },
+    { id: 'bitfinex', name: 'Bitfinex' },
+    { id: 'okx', name: 'OKX' },
+  ], []);
 
   // Set up chart subscription for change tracking
   const chartSubscription = useChartSubscription({
@@ -114,9 +130,21 @@ export default function ChartControls({
         <label className="text-gray-300 text-sm font-medium">Current Symbol</label>
         <div
           data-testid="current-symbol"
-          className="w-full bg-gray-700 border border-gray-600 text-white rounded px-3 py-2 text-sm font-mono"
+          className="w-full bg-gray-700 border border-gray-600 text-white rounded px-3 py-2 text-sm"
         >
-          {symbol}
+          <div className="flex items-center justify-between">
+            <span className="font-mono">{baseSymbol}</span>
+            <span 
+              className="text-xs px-2 py-1 rounded"
+              style={{
+                backgroundColor: `${getExchangeColor(currentExchange)}20`,
+                color: getExchangeColor(currentExchange),
+                border: `1px solid ${getExchangeColor(currentExchange)}40`
+              }}
+            >
+              {formatExchangeName(currentExchange)}
+            </span>
+          </div>
         </div>
       </div>
 
@@ -144,19 +172,96 @@ export default function ChartControls({
       )}
 
 
+      {/* Exchange Selection */}
+      <div className="space-y-2">
+        <label className="text-gray-300 text-sm font-medium">Exchange</label>
+        <div className="grid grid-cols-2 gap-2">
+          {exchanges.map(exchange => {
+            const isActive = currentExchange === exchange.id;
+            const color = getExchangeColor(exchange.id);
+            return (
+              <button
+                key={exchange.id}
+                onClick={() => {
+                  const newSymbol = `${exchange.id}:${baseSymbol || 'BTC-USD'}`;
+                  setCurrentSymbol(newSymbol);
+                  
+                  // Update URL
+                  const urlParams = new URLSearchParams(window.location.search);
+                  urlParams.set('topic', newSymbol);
+                  const newUrl = `${window.location.pathname}?${urlParams.toString()}`;
+                  window.history.pushState({}, '', newUrl);
+                }}
+                className={`
+                  relative px-3 py-2.5 text-sm font-medium rounded-lg
+                  transition-all duration-200 transform
+                  ${isActive 
+                    ? 'bg-gray-700 text-white shadow-lg scale-[1.02]' 
+                    : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-gray-200'
+                  }
+                  border ${isActive ? 'border-gray-500' : 'border-gray-700'}
+                  hover:scale-[1.02] active:scale-[0.98]
+                `}
+                style={{
+                  borderLeftWidth: '3px',
+                  borderLeftColor: isActive ? color : 'transparent',
+                }}
+              >
+                <span className="relative z-10">{exchange.name}</span>
+                {isActive && (
+                  <div 
+                    className="absolute inset-0 rounded-lg opacity-10"
+                    style={{ backgroundColor: color }}
+                  />
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
       {/* Time Range Presets */}
       <div className="space-y-2">
         <label className="text-gray-300 text-sm font-medium">Time Range</label>
         <div className="grid grid-cols-2 gap-2">
-          {['1h', '4h', '1d', '1w'].map(preset => (
-            <button
-              key={preset}
-              onClick={() => handleTimeRangePreset(preset)}
-              className="px-3 py-2 text-sm bg-gray-700 text-gray-300 rounded hover:bg-gray-600 transition-colors"
-            >
-              Last {preset}
-            </button>
-          ))}
+          {[
+            { id: '1h', label: '1 Hour' },
+            { id: '4h', label: '4 Hours' },
+            { id: '1d', label: '1 Day' },
+            { id: '1w', label: '1 Week' }
+          ].map(preset => {
+            // Check if this preset is currently active
+            const now = Math.floor(Date.now() / 1000);
+            let presetStart: number;
+            switch (preset.id) {
+              case '1h': presetStart = now - 3600; break;
+              case '4h': presetStart = now - 14400; break;
+              case '1d': presetStart = now - 86400; break;
+              case '1w': presetStart = now - 604800; break;
+              default: presetStart = now - 86400;
+            }
+            // Simple check if current range matches (within 60 seconds tolerance)
+            const isActive = Math.abs(useAppStore.getState().startTime - presetStart) < 60;
+            
+            return (
+              <button
+                key={preset.id}
+                onClick={() => handleTimeRangePreset(preset.id)}
+                className={`
+                  relative px-3 py-2.5 text-sm font-medium rounded-lg
+                  transition-all duration-200 transform
+                  ${isActive 
+                    ? 'bg-gray-700 text-white shadow-lg scale-[1.02]' 
+                    : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-gray-200'
+                  }
+                  border ${isActive ? 'border-gray-500' : 'border-gray-700'}
+                  hover:scale-[1.02] active:scale-[0.98]
+                `}
+              >
+                {preset.label}
+              </button>
+            );
+          })}
         </div>
       </div>
 

--- a/web/src/components/chart/ChartLegend.tsx
+++ b/web/src/components/chart/ChartLegend.tsx
@@ -1,0 +1,165 @@
+import { useState, useEffect } from 'react';
+import { useAppStore } from '../../store/useAppStore';
+import { formatExchangeName, getExchangeColor } from '../../services/symbolApi';
+import { Eye, EyeOff } from 'lucide-react';
+import clsx from 'clsx';
+
+interface ExchangeData {
+  exchange: string;
+  symbol: string;
+  currentPrice?: number;
+  change24h?: number;
+  visible: boolean;
+}
+
+interface ChartLegendProps {
+  className?: string;
+}
+
+export default function ChartLegend({ className }: ChartLegendProps) {
+  const { comparisonMode, selectedExchanges, baseSymbol } = useAppStore();
+  const [exchangeData, setExchangeData] = useState<ExchangeData[]>([]);
+  
+  // Initialize exchange data when selections change
+  useEffect(() => {
+    if (comparisonMode && selectedExchanges && baseSymbol) {
+      const newData = selectedExchanges.map(exchange => ({
+        exchange,
+        symbol: `${exchange}:${baseSymbol}`,
+        visible: true,
+        // These will be populated when we fetch real data
+        currentPrice: undefined,
+        change24h: undefined,
+      }));
+      setExchangeData(newData);
+    } else {
+      setExchangeData([]);
+    }
+  }, [comparisonMode, selectedExchanges, baseSymbol]);
+  
+  // Only show legend in comparison mode with multiple exchanges
+  if (!comparisonMode || !selectedExchanges || selectedExchanges.length < 2) {
+    return null;
+  }
+  
+  const toggleVisibility = (exchange: string) => {
+    setExchangeData(prev => 
+      prev.map(data => 
+        data.exchange === exchange 
+          ? { ...data, visible: !data.visible }
+          : data
+      )
+    );
+  };
+  
+  const formatPrice = (price?: number) => {
+    if (!price) return '---';
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(price);
+  };
+  
+  const formatChange = (change?: number) => {
+    if (!change) return '0.00%';
+    const sign = change >= 0 ? '+' : '';
+    return `${sign}${change.toFixed(2)}%`;
+  };
+  
+  return (
+    <div className={clsx(
+      "bg-gray-800 border border-gray-600 rounded-lg p-3",
+      className
+    )}>
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-white text-sm font-semibold">Exchange Comparison</h3>
+        <span className="text-xs text-gray-400">{baseSymbol}</span>
+      </div>
+      
+      <div className="space-y-2">
+        {exchangeData.map((data) => {
+          const color = getExchangeColor(data.exchange);
+          const isVisible = data.visible;
+          
+          return (
+            <div
+              key={data.exchange}
+              className={clsx(
+                "flex items-center justify-between p-2 rounded transition-all",
+                isVisible ? "bg-gray-700" : "bg-gray-900 opacity-60"
+              )}
+            >
+              <div className="flex items-center gap-3">
+                {/* Color indicator */}
+                <div
+                  className="w-3 h-3 rounded-full"
+                  style={{ backgroundColor: isVisible ? color : '#4B5563' }}
+                />
+                
+                {/* Exchange name */}
+                <div className="flex flex-col">
+                  <span className={clsx(
+                    "text-sm font-medium",
+                    isVisible ? "text-white" : "text-gray-400"
+                  )}>
+                    {formatExchangeName(data.exchange)}
+                  </span>
+                  {data.currentPrice && (
+                    <span className="text-xs text-gray-400">
+                      {formatPrice(data.currentPrice)}
+                    </span>
+                  )}
+                </div>
+              </div>
+              
+              <div className="flex items-center gap-2">
+                {/* Price change */}
+                {data.change24h !== undefined && (
+                  <span className={clsx(
+                    "text-xs font-medium",
+                    data.change24h >= 0 ? "text-green-400" : "text-red-400"
+                  )}>
+                    {formatChange(data.change24h)}
+                  </span>
+                )}
+                
+                {/* Visibility toggle */}
+                <button
+                  onClick={() => toggleVisibility(data.exchange)}
+                  className="p-1 hover:bg-gray-600 rounded transition-colors"
+                  title={isVisible ? "Hide" : "Show"}
+                >
+                  {isVisible ? (
+                    <Eye className="w-4 h-4 text-gray-400" />
+                  ) : (
+                    <EyeOff className="w-4 h-4 text-gray-500" />
+                  )}
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      
+      {/* Price spread indicator */}
+      {exchangeData.length === 2 && 
+       exchangeData[0].currentPrice && 
+       exchangeData[1].currentPrice && (
+        <div className="mt-3 pt-3 border-t border-gray-700">
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-gray-400">Spread</span>
+            <span className="text-white font-medium">
+              {formatPrice(Math.abs(exchangeData[0].currentPrice - exchangeData[1].currentPrice))}
+              <span className="text-gray-400 ml-1">
+                ({((Math.abs(exchangeData[0].currentPrice - exchangeData[1].currentPrice) / 
+                   Math.min(exchangeData[0].currentPrice, exchangeData[1].currentPrice)) * 100).toFixed(3)}%)
+              </span>
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,8 +1,9 @@
-import { Search, ChevronDown, Settings, User } from 'lucide-react';
+import { ChevronDown, Settings, User } from 'lucide-react';
 import { useAppStore } from '../../store/useAppStore';
+import SymbolSearch from '../SymbolSearch';
 
 export default function Header() {
-  const { currentSymbol, setCurrentSymbol, isConnected } = useAppStore();
+  const { isConnected } = useAppStore();
 
   return (
     <header className="h-16 bg-bg-primary border-b border-border flex items-center px-6">
@@ -12,18 +13,10 @@ export default function Header() {
       </div>
 
       {/* Search / Symbol Selector */}
-      <div className="flex-1 max-w-md">
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-text-tertiary" size={16} />
-          <input
-            type="text"
-            value={currentSymbol}
-            onChange={(e) => setCurrentSymbol(e.target.value.toUpperCase())}
-            className="input-primary pl-10 pr-4 w-full"
-            placeholder="Search symbols..."
-          />
-          <ChevronDown className="absolute right-3 top-1/2 transform -translate-y-1/2 text-text-tertiary" size={16} />
-        </div>
+      <div className="flex-1 max-w-xl">
+        <SymbolSearch 
+          placeholder="Search symbols, coins, or markets..." 
+        />
       </div>
 
       {/* Watchlist */}

--- a/web/src/hooks/useDebounce.ts
+++ b/web/src/hooks/useDebounce.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Custom hook for debouncing a value
+ * @param value - The value to debounce
+ * @param delay - The delay in milliseconds
+ * @returns The debounced value
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    // Set up the timeout
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    // Clean up the timeout if value changes or component unmounts
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/web/src/pages/TradingApp.tsx
+++ b/web/src/pages/TradingApp.tsx
@@ -6,6 +6,7 @@ import Sidebar from '../components/layout/Sidebar';
 import StatusBar from '../components/layout/StatusBar';
 import WasmCanvas from '../components/chart/WasmCanvas';
 import ChartControls from '../components/chart/ChartControls';
+import ChartLegend from '../components/chart/ChartLegend';
 import { Chart } from '@pkg/wasm_bridge.js';
 // import DataFetchingMonitor from '../components/monitoring/DataFetchingMonitor'; // Disabled temporarily
 
@@ -14,7 +15,7 @@ function ChartView() {
   const [appliedPreset, setAppliedPreset] = useState<string | undefined>(undefined);
 
   // Get store state and actions
-  const { symbol, preset, startTime, endTime, setCurrentSymbol, setTimeRange, setPreset } = useAppStore();
+  const { symbol, preset, startTime, endTime, setCurrentSymbol, setTimeRange, setPreset, setBaseSymbol } = useAppStore();
   const [activePreset, setActivePreset] = useState<string | undefined>(preset);
 
 
@@ -46,6 +47,9 @@ function ChartView() {
     const topic = urlParams.get('topic');
     if (topic) {
       setCurrentSymbol(topic);
+      // Extract base symbol from the topic (e.g., "coinbase:BTC-USD" -> "BTC-USD")
+      const baseSymbol = topic.includes(':') ? topic.split(':')[1] : topic;
+      setBaseSymbol(baseSymbol);
     }
 
     // Parse start and end timestamps
@@ -63,7 +67,7 @@ function ChartView() {
       } else {
       }
     }
-  }, [setCurrentSymbol, setTimeRange]); // Include dependencies
+  }, [setCurrentSymbol, setTimeRange, setBaseSymbol]); // Include dependencies
   
   // Note: Time range updates are now handled in WasmCanvas component
   // which watches for startTime/endTime changes and calls update_time_range
@@ -105,9 +109,15 @@ function ChartView() {
 
               {/* Main Chart Area */}
               <div className="flex-1 flex flex-col">
-                <WasmCanvas
-                  onChartReady={setChartInstance}
-                />
+                {/* Chart Legend - positioned over the chart */}
+                <div className="relative">
+                  <WasmCanvas
+                    onChartReady={setChartInstance}
+                  />
+                  <div className="absolute top-4 right-4 z-10">
+                    <ChartLegend />
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/web/src/services/multiExchangeApi.ts
+++ b/web/src/services/multiExchangeApi.ts
@@ -1,0 +1,288 @@
+// Multi-Exchange Data API Service
+
+import { parseSymbol } from './symbolApi';
+
+// Get API base URL from environment or use default
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 
+  (window.location.hostname === 'localhost' ? 'https://localhost:8443' : 'https://api.rednax.io');
+
+export interface ExchangeDataResponse {
+  exchange: string;
+  symbol: string;
+  columns: Array<{
+    name: string;
+    record_size: number;
+    num_records: number;
+    data_length: number;
+  }>;
+  data?: ArrayBuffer;
+  error?: string;
+}
+
+export interface MultiExchangeData {
+  baseSymbol: string;
+  startTime: number;
+  endTime: number;
+  exchanges: ExchangeDataResponse[];
+}
+
+/**
+ * Fetch data for a single exchange
+ */
+async function fetchExchangeData(
+  exchange: string,
+  baseSymbol: string,
+  startTime: number,
+  endTime: number,
+  columns: string[] = ['time', 'best_bid', 'best_ask', 'price', 'volume']
+): Promise<ExchangeDataResponse> {
+  const symbol = `${exchange}:${baseSymbol}`;
+  
+  try {
+    const params = new URLSearchParams({
+      symbol: baseSymbol,  // Some APIs expect just the base symbol
+      type: 'MD',
+      start: startTime.toString(),
+      end: endTime.toString(),
+      columns: columns.join(','),
+    });
+    
+    const response = await fetch(`${API_BASE_URL}/api/data?${params}`, {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/octet-stream, application/json',
+      },
+    });
+    
+    if (!response.ok) {
+      throw new Error(`Failed to fetch data for ${exchange}: ${response.statusText}`);
+    }
+    
+    // Parse the response
+    const contentType = response.headers.get('content-type');
+    if (contentType?.includes('application/json')) {
+      // JSON response with metadata
+      const metadata = await response.json();
+      return {
+        exchange,
+        symbol,
+        columns: metadata.columns || [],
+        error: metadata.error,
+      };
+    } else {
+      // Binary response - read header first
+      const blob = await response.blob();
+      const arrayBuffer = await blob.arrayBuffer();
+      
+      // Try to parse JSON header from the beginning of the response
+      // The server typically sends JSON metadata followed by binary data
+      const decoder = new TextDecoder();
+      const view = new Uint8Array(arrayBuffer);
+      
+      // Find the end of JSON (look for closing brace)
+      let jsonEnd = -1;
+      for (let i = 0; i < Math.min(view.length, 10000); i++) {
+        if (view[i] === 125) { // '}' character
+          jsonEnd = i + 1;
+          break;
+        }
+      }
+      
+      if (jsonEnd > 0) {
+        const jsonStr = decoder.decode(view.slice(0, jsonEnd));
+        const metadata = JSON.parse(jsonStr);
+        const binaryData = arrayBuffer.slice(jsonEnd);
+        
+        return {
+          exchange,
+          symbol,
+          columns: metadata.columns || [],
+          data: binaryData,
+        };
+      }
+      
+      // Fallback if no JSON header found
+      return {
+        exchange,
+        symbol,
+        columns: columns.map(name => ({
+          name,
+          record_size: 4,
+          num_records: arrayBuffer.byteLength / (4 * columns.length),
+          data_length: arrayBuffer.byteLength / columns.length,
+        })),
+        data: arrayBuffer,
+      };
+    }
+  } catch (error) {
+    console.error(`Error fetching data for ${exchange}:`, error);
+    return {
+      exchange,
+      symbol,
+      columns: [],
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+/**
+ * Fetch data from multiple exchanges in parallel
+ */
+export async function fetchMultiExchangeData(
+  exchanges: string[],
+  baseSymbol: string,
+  startTime: number,
+  endTime: number,
+  columns?: string[]
+): Promise<MultiExchangeData> {
+  console.log(`Fetching data for ${exchanges.join(', ')} - ${baseSymbol}`);
+  
+  // Fetch data from all exchanges in parallel
+  const promises = exchanges.map(exchange =>
+    fetchExchangeData(exchange, baseSymbol, startTime, endTime, columns)
+  );
+  
+  const results = await Promise.allSettled(promises);
+  
+  // Process results, including both successful and failed fetches
+  const exchangeData: ExchangeDataResponse[] = results.map((result, index) => {
+    if (result.status === 'fulfilled') {
+      return result.value;
+    } else {
+      // Failed fetch
+      return {
+        exchange: exchanges[index],
+        symbol: `${exchanges[index]}:${baseSymbol}`,
+        columns: [],
+        error: result.reason?.message || 'Failed to fetch data',
+      };
+    }
+  });
+  
+  return {
+    baseSymbol,
+    startTime,
+    endTime,
+    exchanges: exchangeData,
+  };
+}
+
+/**
+ * Parse binary data from the server response
+ */
+export function parseBinaryData(
+  data: ArrayBuffer,
+  columns: string[]
+): Map<string, Float32Array> {
+  const result = new Map<string, Float32Array>();
+  const view = new DataView(data);
+  
+  const recordSize = columns.length * 4; // 4 bytes per value
+  const numRecords = data.byteLength / recordSize;
+  
+  // Initialize arrays for each column
+  columns.forEach(column => {
+    result.set(column, new Float32Array(numRecords));
+  });
+  
+  // Parse the data
+  for (let record = 0; record < numRecords; record++) {
+    for (let col = 0; col < columns.length; col++) {
+      const offset = record * recordSize + col * 4;
+      const value = view.getFloat32(offset, true); // little-endian
+      result.get(columns[col])![record] = value;
+    }
+  }
+  
+  return result;
+}
+
+/**
+ * Align time series data from multiple exchanges
+ * Interpolates missing values to create aligned datasets
+ */
+export function alignTimeSeriesData(
+  exchangeDataMap: Map<string, Map<string, Float32Array>>
+): Map<string, Map<string, Float32Array>> {
+  // Find the common time range across all exchanges
+  let minTime = Infinity;
+  let maxTime = -Infinity;
+  
+  exchangeDataMap.forEach(data => {
+    const timeData = data.get('time');
+    if (timeData && timeData.length > 0) {
+      minTime = Math.min(minTime, timeData[0]);
+      maxTime = Math.max(maxTime, timeData[timeData.length - 1]);
+    }
+  });
+  
+  if (minTime === Infinity || maxTime === -Infinity) {
+    return exchangeDataMap; // No data to align
+  }
+  
+  // Create a common time grid (1-second intervals for now)
+  const timeStep = 1; // 1 second
+  const numPoints = Math.floor((maxTime - minTime) / timeStep) + 1;
+  const commonTime = new Float32Array(numPoints);
+  
+  for (let i = 0; i < numPoints; i++) {
+    commonTime[i] = minTime + i * timeStep;
+  }
+  
+  // Interpolate each exchange's data to the common time grid
+  const alignedData = new Map<string, Map<string, Float32Array>>();
+  
+  exchangeDataMap.forEach((data, exchange) => {
+    const alignedExchangeData = new Map<string, Float32Array>();
+    const originalTime = data.get('time');
+    
+    if (!originalTime || originalTime.length === 0) {
+      alignedData.set(exchange, alignedExchangeData);
+      return;
+    }
+    
+    // For each column, interpolate to common time grid
+    data.forEach((values, column) => {
+      if (column === 'time') {
+        alignedExchangeData.set('time', commonTime);
+      } else {
+        const interpolated = new Float32Array(numPoints);
+        
+        // Simple linear interpolation
+        let originalIndex = 0;
+        for (let i = 0; i < numPoints; i++) {
+          const targetTime = commonTime[i];
+          
+          // Find the surrounding points in the original data
+          while (originalIndex < originalTime.length - 1 && 
+                 originalTime[originalIndex + 1] < targetTime) {
+            originalIndex++;
+          }
+          
+          if (originalIndex >= originalTime.length - 1) {
+            // Use last value
+            interpolated[i] = values[originalTime.length - 1];
+          } else if (originalTime[originalIndex] > targetTime) {
+            // Use first value
+            interpolated[i] = values[0];
+          } else {
+            // Linear interpolation
+            const t1 = originalTime[originalIndex];
+            const t2 = originalTime[originalIndex + 1];
+            const v1 = values[originalIndex];
+            const v2 = values[originalIndex + 1];
+            
+            const ratio = (targetTime - t1) / (t2 - t1);
+            interpolated[i] = v1 + (v2 - v1) * ratio;
+          }
+        }
+        
+        alignedExchangeData.set(column, interpolated);
+      }
+    });
+    
+    alignedData.set(exchange, alignedExchangeData);
+  });
+  
+  return alignedData;
+}

--- a/web/src/services/multiExchangeApi.ts
+++ b/web/src/services/multiExchangeApi.ts
@@ -40,7 +40,8 @@ async function fetchExchangeData(
   
   try {
     const params = new URLSearchParams({
-      symbol: baseSymbol,  // Some APIs expect just the base symbol
+      symbol: baseSymbol,  // Just the base symbol without exchange prefix
+      exchange: exchange,  // Exchange as separate parameter
       type: 'MD',
       start: startTime.toString(),
       end: endTime.toString(),

--- a/web/src/services/symbolApi.ts
+++ b/web/src/services/symbolApi.ts
@@ -1,0 +1,176 @@
+// Symbol API Service for interacting with the symbol search endpoint
+
+export interface ExchangeSymbol {
+  exchange: string;
+  symbol: string;
+}
+
+export interface SearchResult {
+  normalized_id: string;
+  display_name: string;
+  description: string;
+  base: string;
+  quote: string;
+  category: string;
+  exchanges: ExchangeSymbol[];
+  relevance_score: number;
+}
+
+export interface SymbolSearchResponse {
+  results: SearchResult[];
+}
+
+// Get API base URL from environment or use default
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 
+  (window.location.hostname === 'localhost' ? 'https://localhost:8443' : 'https://api.rednax.io');
+
+// Cache for search results
+const searchCache = new Map<string, { data: SearchResult[]; timestamp: number }>();
+const CACHE_TTL = 60000; // 1 minute cache
+
+/**
+ * Search for symbols using the new symbol-search endpoint
+ * @param query - The search query string
+ * @returns Array of search results sorted by relevance
+ */
+export async function searchSymbols(query: string): Promise<SearchResult[]> {
+  if (!query || query.trim().length === 0) {
+    return [];
+  }
+
+  // Check cache first
+  const cacheKey = query.toLowerCase();
+  const cached = searchCache.get(cacheKey);
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+    return cached.data;
+  }
+
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/api/symbol-search?q=${encodeURIComponent(query)}`,
+      {
+        method: 'GET',
+        headers: {
+          'Accept': 'application/json',
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Search failed: ${response.statusText}`);
+    }
+
+    const data: SymbolSearchResponse = await response.json();
+    
+    // Cache the results
+    searchCache.set(cacheKey, {
+      data: data.results,
+      timestamp: Date.now(),
+    });
+
+    return data.results;
+  } catch (error) {
+    console.error('Symbol search error:', error);
+    // Return empty array on error to allow graceful degradation
+    return [];
+  }
+}
+
+/**
+ * Get all available symbols (no search query)
+ * @returns Array of all symbols from all exchanges
+ */
+export async function getAllSymbols(): Promise<string[]> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/symbols`, {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch symbols: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return data.symbols || [];
+  } catch (error) {
+    console.error('Failed to fetch all symbols:', error);
+    return [];
+  }
+}
+
+/**
+ * Clear the search cache
+ */
+export function clearSearchCache(): void {
+  searchCache.clear();
+}
+
+/**
+ * Format exchange name for display
+ */
+export function formatExchangeName(exchange: string): string {
+  const exchangeMap: Record<string, string> = {
+    coinbase: 'Coinbase',
+    binance: 'Binance',
+    bitfinex: 'Bitfinex',
+    kraken: 'Kraken',
+    okx: 'OKX',
+  };
+  return exchangeMap[exchange.toLowerCase()] || exchange;
+}
+
+/**
+ * Get exchange color for visual indicators
+ */
+export function getExchangeColor(exchange: string): string {
+  const colorMap: Record<string, string> = {
+    coinbase: '#0052FF',  // Coinbase blue
+    binance: '#F3BA2F',   // Binance yellow
+    bitfinex: '#5CDB95',  // Bitfinex green
+    kraken: '#5741D9',    // Kraken purple
+    okx: '#000000',       // OKX black
+  };
+  return colorMap[exchange.toLowerCase()] || '#6B7280';
+}
+
+/**
+ * Group search results by category
+ */
+export function groupResultsByCategory(results: SearchResult[]): Record<string, SearchResult[]> {
+  const grouped: Record<string, SearchResult[]> = {};
+  
+  results.forEach(result => {
+    const category = result.category || 'Other';
+    if (!grouped[category]) {
+      grouped[category] = [];
+    }
+    grouped[category].push(result);
+  });
+
+  return grouped;
+}
+
+/**
+ * Get a relevance indicator based on score
+ */
+export function getRelevanceIndicator(score: number): {
+  label: string;
+  color: string;
+  percentage: number;
+} {
+  const maxScore = 150; // Maximum possible score
+  const percentage = Math.min(100, (score / maxScore) * 100);
+  
+  if (score >= 120) {
+    return { label: 'Exact Match', color: '#10B981', percentage }; // Green
+  } else if (score >= 80) {
+    return { label: 'High Match', color: '#3B82F6', percentage }; // Blue
+  } else if (score >= 50) {
+    return { label: 'Good Match', color: '#F59E0B', percentage }; // Yellow
+  } else {
+    return { label: 'Partial Match', color: '#6B7280', percentage }; // Gray
+  }
+}

--- a/web/src/store/useAppStore.ts
+++ b/web/src/store/useAppStore.ts
@@ -48,7 +48,7 @@ interface AppStore extends StoreState {
 
 // Default configuration values
 const DEFAULT_CONFIG: StoreState = {
-  symbol: 'BTC-USD',
+  symbol: 'coinbase:BTC-USD',
   startTime: Math.floor(Date.now() / 1000) - 24 * 60 * 60, // 24 hours ago
   endTime: Math.floor(Date.now() / 1000), // Now
   preset: 'Market Data',

--- a/web/src/store/useAppStore.ts
+++ b/web/src/store/useAppStore.ts
@@ -6,6 +6,7 @@ export interface StoreState {
   symbol?: string;
   startTime: number;
   endTime: number;
+  isConnected?: boolean;
 }
 
 // // WASM integration types
@@ -30,6 +31,7 @@ interface AppStore extends StoreState {
   // Core actions
   setCurrentSymbol: (symbol: string) => void;
   setPreset: (preset?: string) => void;
+  setIsConnected: (connected: boolean) => void;
   // Enhanced actions with time range management
   setTimeRange: (startTime: number, endTime: number) => void;
   // Batch operations
@@ -50,6 +52,7 @@ const DEFAULT_CONFIG: StoreState = {
   startTime: Math.floor(Date.now() / 1000) - 24 * 60 * 60, // 24 hours ago
   endTime: Math.floor(Date.now() / 1000), // Now
   preset: 'Market Data',
+  isConnected: false,
 };
 
 export const useAppStore = create<AppStore>((set, get) => ({
@@ -61,6 +64,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   preset: DEFAULT_CONFIG.preset,
   startTime: DEFAULT_CONFIG.startTime,
   endTime: DEFAULT_CONFIG.endTime,
+  isConnected: DEFAULT_CONFIG.isConnected,
 
   // Subscription management
   _subscriptions: new Map(),
@@ -77,6 +81,13 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setPreset: (preset) => {
     const oldState = get();
     set({ preset });
+    const newState = get();
+    newState._triggerSubscriptions(newState, oldState);
+  },
+
+  setIsConnected: (isConnected) => {
+    const oldState = get();
+    set({ isConnected });
     const newState = get();
     newState._triggerSubscriptions(newState, oldState);
   },

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -61,6 +61,38 @@
   .animation-delay-400 {
     animation-delay: 400ms;
   }
+  
+  /* Dropdown animations */
+  .animate-in {
+    animation-duration: 200ms;
+    animation-fill-mode: both;
+  }
+  
+  .fade-in {
+    animation-name: fadeIn;
+  }
+  
+  .slide-in-from-top-1 {
+    animation-name: slideInFromTop;
+  }
+  
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  
+  @keyframes slideInFromTop {
+    from {
+      transform: translateY(-4px);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
 }
 
 /* Price animations */

--- a/web/symbol-search-demo.html
+++ b/web/symbol-search-demo.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Symbol Search Demo - GPU Charts</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: #0A0B0D;
+            color: #E5E5E5;
+            padding: 20px;
+        }
+        
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+        
+        h1 {
+            color: #10B981;
+            margin-bottom: 10px;
+            font-size: 2.5rem;
+        }
+        
+        .subtitle {
+            color: #6B7280;
+            margin-bottom: 40px;
+            font-size: 1.1rem;
+        }
+        
+        .demo-section {
+            background: #16181C;
+            border: 1px solid #2D3748;
+            border-radius: 8px;
+            padding: 30px;
+            margin-bottom: 30px;
+        }
+        
+        h2 {
+            color: #3B82F6;
+            margin-bottom: 20px;
+            font-size: 1.5rem;
+        }
+        
+        .feature-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+        
+        .feature-card {
+            background: #1F2937;
+            border: 1px solid #374151;
+            border-radius: 6px;
+            padding: 20px;
+        }
+        
+        .feature-card h3 {
+            color: #10B981;
+            margin-bottom: 10px;
+            font-size: 1.1rem;
+        }
+        
+        .feature-card p {
+            color: #9CA3AF;
+            line-height: 1.6;
+        }
+        
+        .search-preview {
+            background: #1F2937;
+            border: 1px solid #374151;
+            border-radius: 6px;
+            padding: 20px;
+            margin: 20px 0;
+        }
+        
+        .mock-search {
+            position: relative;
+            max-width: 600px;
+            margin: 0 auto;
+        }
+        
+        .mock-input {
+            width: 100%;
+            padding: 12px 40px;
+            background: #111827;
+            border: 1px solid #374151;
+            border-radius: 4px;
+            color: #E5E5E5;
+            font-size: 16px;
+        }
+        
+        .mock-dropdown {
+            position: absolute;
+            top: 100%;
+            left: 0;
+            right: 0;
+            margin-top: 4px;
+            background: #111827;
+            border: 1px solid #374151;
+            border-radius: 4px;
+            overflow: hidden;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.5);
+        }
+        
+        .result-item {
+            padding: 12px 16px;
+            border-bottom: 1px solid #1F2937;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+        
+        .result-item:hover {
+            background: #1F2937;
+        }
+        
+        .result-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 8px;
+        }
+        
+        .symbol-info {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        
+        .symbol-id {
+            font-weight: 600;
+            color: #E5E5E5;
+        }
+        
+        .symbol-name {
+            color: #9CA3AF;
+            font-size: 14px;
+        }
+        
+        .relevance-badge {
+            padding: 2px 8px;
+            border-radius: 3px;
+            font-size: 12px;
+            font-weight: 500;
+        }
+        
+        .exact-match {
+            background: rgba(16, 185, 129, 0.2);
+            color: #10B981;
+        }
+        
+        .high-match {
+            background: rgba(59, 130, 246, 0.2);
+            color: #3B82F6;
+        }
+        
+        .exchange-pills {
+            display: flex;
+            gap: 6px;
+            flex-wrap: wrap;
+        }
+        
+        .exchange-pill {
+            padding: 2px 8px;
+            border-radius: 3px;
+            font-size: 12px;
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+        
+        .coinbase {
+            background: rgba(0, 82, 255, 0.15);
+            border-left: 2px solid #0052FF;
+        }
+        
+        .binance {
+            background: rgba(243, 186, 47, 0.15);
+            border-left: 2px solid #F3BA2F;
+        }
+        
+        .kraken {
+            background: rgba(87, 65, 217, 0.15);
+            border-left: 2px solid #5741D9;
+        }
+        
+        .code-block {
+            background: #111827;
+            border: 1px solid #374151;
+            border-radius: 4px;
+            padding: 16px;
+            margin: 16px 0;
+            font-family: 'Monaco', 'Menlo', monospace;
+            font-size: 14px;
+            overflow-x: auto;
+        }
+        
+        .highlight {
+            color: #10B981;
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Symbol Search Integration</h1>
+        <p class="subtitle">Professional-grade trading symbol selector with intelligent search</p>
+        
+        <div class="demo-section">
+            <h2>✨ Key Features</h2>
+            <div class="feature-grid">
+                <div class="feature-card">
+                    <h3>🔍 Smart Search</h3>
+                    <p>Fuzzy matching across symbol codes, names, descriptions, and tags with relevance scoring</p>
+                </div>
+                <div class="feature-card">
+                    <h3>🏢 Cross-Exchange</h3>
+                    <p>Shows symbol availability across Coinbase, Binance, Kraken, Bitfinex, and OKX</p>
+                </div>
+                <div class="feature-card">
+                    <h3>⚡ Real-time</h3>
+                    <p>300ms debounced search with caching for instant results</p>
+                </div>
+                <div class="feature-card">
+                    <h3>⌨️ Keyboard Nav</h3>
+                    <p>Full keyboard support with arrow keys, Enter to select, Escape to close</p>
+                </div>
+                <div class="feature-card">
+                    <h3>🎨 Beautiful UI</h3>
+                    <p>Professional dark theme with smooth animations and visual indicators</p>
+                </div>
+                <div class="feature-card">
+                    <h3>📊 Rich Data</h3>
+                    <p>Display names, descriptions, categories, and exchange-specific symbols</p>
+                </div>
+            </div>
+        </div>
+        
+        <div class="demo-section">
+            <h2>🎯 Visual Preview</h2>
+            <div class="search-preview">
+                <div class="mock-search">
+                    <input type="text" class="mock-input" value="btc" placeholder="Search symbols..." />
+                    <div class="mock-dropdown">
+                        <div class="result-item">
+                            <div class="result-header">
+                                <div class="symbol-info">
+                                    <span class="symbol-id">BTC/USD</span>
+                                    <span class="symbol-name">Bitcoin / US Dollar</span>
+                                </div>
+                                <span class="relevance-badge exact-match">Exact Match</span>
+                            </div>
+                            <div class="exchange-pills">
+                                <span class="exchange-pill coinbase">Coinbase: BTC-USD</span>
+                                <span class="exchange-pill binance">Binance: BTCUSDT</span>
+                                <span class="exchange-pill kraken">Kraken: XBT/USD</span>
+                            </div>
+                        </div>
+                        <div class="result-item">
+                            <div class="result-header">
+                                <div class="symbol-info">
+                                    <span class="symbol-id">BTC/EUR</span>
+                                    <span class="symbol-name">Bitcoin / Euro</span>
+                                </div>
+                                <span class="relevance-badge high-match">High Match</span>
+                            </div>
+                            <div class="exchange-pills">
+                                <span class="exchange-pill kraken">Kraken: XBT/EUR</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+        <div class="demo-section">
+            <h2>🔌 API Integration</h2>
+            <div class="code-block">
+                <div>// New endpoint for symbol search</div>
+                <div><span class="highlight">GET</span> /api/symbol-search?q=<span class="highlight">{query}</span></div>
+                <div></div>
+                <div>// Returns normalized symbols with exchange mappings</div>
+                <div>{</div>
+                <div>  "results": [{</div>
+                <div>    "normalized_id": "BTC/USD",</div>
+                <div>    "display_name": "Bitcoin / US Dollar",</div>
+                <div>    "exchanges": [</div>
+                <div>      {"exchange": "coinbase", "symbol": "BTC-USD"},</div>
+                <div>      {"exchange": "binance", "symbol": "BTCUSDT"},</div>
+                <div>      {"exchange": "kraken", "symbol": "XBT/USD"}</div>
+                <div>    ],</div>
+                <div>    "relevance_score": 150.0</div>
+                <div>  }]</div>
+                <div>}</div>
+            </div>
+        </div>
+        
+        <div class="demo-section">
+            <h2>🚀 Quick Start</h2>
+            <div class="code-block">
+                <div># Start the development stack</div>
+                <div>npm run dev:server    <span class="highlight"># Start data server</span></div>
+                <div>npm run dev:web       <span class="highlight"># Start React app</span></div>
+                <div></div>
+                <div># Access the application</div>
+                <div>http://localhost:3000/app</div>
+            </div>
+        </div>
+        
+        <div class="demo-section">
+            <h2>📝 Example Searches</h2>
+            <div class="feature-grid">
+                <div class="feature-card">
+                    <h3>Symbol Codes</h3>
+                    <p>Try: <code>btc</code>, <code>eth</code>, <code>sol</code></p>
+                </div>
+                <div class="feature-card">
+                    <h3>Names</h3>
+                    <p>Try: <code>bitcoin</code>, <code>ethereum</code>, <code>dogecoin</code></p>
+                </div>
+                <div class="feature-card">
+                    <h3>Categories</h3>
+                    <p>Try: <code>layer2</code>, <code>defi</code>, <code>meme</code></p>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/web/test-symbol-search.md
+++ b/web/test-symbol-search.md
@@ -1,0 +1,174 @@
+# Symbol Search Integration Test Guide
+
+## Overview
+The new symbol search feature provides a powerful, professional-grade trading symbol selector with intelligent search, cross-exchange support, and beautiful UI.
+
+## Features Implemented
+
+### 1. Smart Autocomplete
+- Real-time search with 300ms debouncing
+- Fuzzy matching on multiple fields
+- Relevance scoring with visual indicators
+
+### 2. Rich Information Display
+- **Symbol Details**: Normalized ID, display name, description
+- **Exchange Support**: Shows all exchanges where the symbol trades
+- **Category Icons**: Visual indicators for crypto, forex, commodities
+- **Relevance Scores**: Color-coded match quality (Exact, High, Good, Partial)
+
+### 3. Keyboard Navigation
+- `↑/↓` - Navigate through results
+- `Enter` - Select highlighted result
+- `Escape` - Close dropdown
+- `Tab` - Standard focus navigation
+
+### 4. Exchange Indicators
+Each result shows colored pills for supported exchanges:
+- **Coinbase** (Blue): `BTC-USD`
+- **Binance** (Yellow): `BTCUSDT`
+- **Bitfinex** (Green): `tBTCUSD`
+- **Kraken** (Purple): `XBT/USD`
+- **OKX** (Black): `BTC-USDT`
+
+### 5. Search Capabilities
+Try these search queries:
+- `btc` - Find Bitcoin pairs
+- `bitcoin` - Search by display name
+- `eth` - Find Ethereum
+- `usd` - Find USD pairs
+- `layer2` - Find Layer 2 solutions (ARB, OP)
+- `defi` - Find DeFi tokens
+- `doge` - Find meme coins
+
+## Testing Instructions
+
+### 1. Start the Development Stack
+```bash
+# Terminal 1: Start the server
+npm run dev:server
+
+# Terminal 2: Start the web app with WASM
+npm run dev:web
+```
+
+### 2. Access the Application
+Open: http://localhost:3000/app
+
+### 3. Test Search Functionality
+
+#### Basic Search
+1. Click on the search box in the header
+2. Type "btc" - should show Bitcoin results
+3. Notice the relevance scores and exchange indicators
+
+#### Keyboard Navigation
+1. Type a search query
+2. Use arrow keys to navigate
+3. Press Enter to select
+4. Press Escape to close
+
+#### Exchange Information
+1. Search for "bitcoin"
+2. Observe the exchange pills showing where it trades
+3. Note the different symbol formats per exchange
+
+#### Category Filtering
+1. Search for "layer2" - should show Arbitrum and Optimism
+2. Search for "defi" - should show Uniswap
+3. Notice the category icons
+
+### 4. Performance Testing
+- Type rapidly to test debouncing
+- Search cache prevents redundant API calls
+- Results appear within 300-500ms
+
+## API Endpoints Used
+
+### Symbol Search
+```
+GET /api/symbol-search?q={query}
+```
+
+Returns:
+```json
+{
+  "results": [{
+    "normalized_id": "BTC/USD",
+    "display_name": "Bitcoin / US Dollar",
+    "description": "Bitcoin to US Dollar spot trading pair",
+    "base": "BTC",
+    "quote": "USD",
+    "category": "crypto",
+    "exchanges": [
+      {"exchange": "coinbase", "symbol": "BTC-USD"},
+      {"exchange": "binance", "symbol": "BTCUSDT"}
+    ],
+    "relevance_score": 150.0
+  }]
+}
+```
+
+## UI Components
+
+### SymbolSearch Component
+Location: `web/src/components/SymbolSearch.tsx`
+- Main search component with dropdown
+- Handles all interaction logic
+- Manages search state and results
+
+### API Service
+Location: `web/src/services/symbolApi.ts`
+- Handles API communication
+- Implements caching
+- Provides utility functions
+
+### Styling
+- Professional dark theme
+- Smooth animations
+- Responsive design
+- Accessibility features
+
+## Customization Options
+
+### Change Search Debounce
+In `SymbolSearch.tsx`:
+```typescript
+const debouncedQuery = useDebounce(query, 300); // Change 300 to desired ms
+```
+
+### Modify Cache TTL
+In `symbolApi.ts`:
+```typescript
+const CACHE_TTL = 60000; // Change to desired cache duration in ms
+```
+
+### Customize Exchange Colors
+In `symbolApi.ts`, modify `getExchangeColor()` function
+
+## Troubleshooting
+
+### No Results Appearing
+1. Check server is running: `npm run dev:server`
+2. Verify API endpoint: `curl -k https://localhost:8443/api/symbol-search?q=btc`
+3. Check browser console for errors
+
+### SSL Certificate Errors
+1. Regenerate certificates: `npm run setup:ssl`
+2. Accept self-signed cert in browser
+
+### Slow Performance
+1. Check network tab for API response times
+2. Verify debounce is working (300ms delay)
+3. Check cache is functioning
+
+## Next Steps
+
+Potential enhancements:
+1. Add favorite symbols with star icons
+2. Recent searches history
+3. Advanced filters (by exchange, category)
+4. Real-time price display in results
+5. Quick chart preview on hover
+6. Multi-symbol comparison
+7. Watchlist integration
+8. Hotkeys for quick symbol switching


### PR DESCRIPTION
## Summary
- Fixes tooltip showing 4 duplicate entries (8 data groups total) when in comparison mode
- Only creates data groups for visible chart types, reducing from 8 groups to 2
- Improves performance and reduces memory usage

## Problem
When enabling comparison mode with 2 exchanges (e.g., Coinbase and Binance), the system was creating 8 data groups total - 4 for each exchange (one for each data type in the preset: MD, TRADES, etc.), even though only 1 metric was visible. This caused the tooltip to show 4 duplicate entries for the same metric.

## Solution
Added a visibility check when processing chart types from the preset. Now we skip invisible chart types entirely when building data requirements, which prevents unnecessary data groups from being created.

## Test Plan
1. Select a symbol (e.g., BTC-USD)
2. Enable comparison mode
3. Select 2 exchanges (Coinbase and Binance)
4. Hover over the chart
5. Verify tooltip shows only 2 entries (one per exchange)
6. Verify no duplicate entries appear

🤖 Generated with [Claude Code](https://claude.ai/code)